### PR TITLE
chore: add phantomjs to devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/muan/emojilib/issues"
   },
-  "homepage": "https://github.com/muan/emojilib#readme"
+  "homepage": "https://github.com/muan/emojilib#readme",
+  "devDependencies": {
+    "phantomjs": "^1.9.17"
+  }
 }


### PR DESCRIPTION
Now you can simply run `npm install` after you cloned the repo and it
will install phantomjs for you in `node_modules`. ✨ You don’t have to
install it globally to run the tests. 💥:ok_hand:

* add phantomjs to devDependencies
* introduce .gitignore and ignore `node_modules`