### PR TITLE
add more keywords to :cyclone:

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -4360,7 +4360,7 @@
     "category": "symbols"
   },
   "cyclone": {
-    "keywords": ["weather", "swirl", "blue", "cloud"],
+    "keywords": ["weather", "swirl", "blue", "cloud", "vortex", "spiral", "whirlpool", "spin"],
     "char": "🌀",
     "category": "symbols"
   },


### PR DESCRIPTION
I can never remember that :cyclone: is called `cyclone`. This patch will allow me to continue to not remember.