### PR TITLE
Add "kawaii" keyword for 😁

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -10,7 +10,7 @@
     "category": "people"
   },
   "grin": {
-    "keywords": ["face", "happy", "smile", "joy"],
+    "keywords": ["face", "happy", "smile", "joy", "kawaii"],
     "char": "😁",
     "category": "people"
   },


### PR DESCRIPTION
In Australia it is deemed acceptable to use the word "kawaii" for ^_^ and 😁