### PR TITLE
Fix keywords for 🍡

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -1965,7 +1965,7 @@
     "category": "food_and_drink"
   },
   "dango": {
-    "keywords": ["food", "barbecue", "meat"],
+    "keywords": ["food", "dessert", "sweet", "japanese"],
     "char": "🍡",
     "category": "food_and_drink"
   },


### PR DESCRIPTION
🍡  is Japanese sweet, not 🍖  🍗 !