### PR TITLE
Fix incorrect country codes in flag names

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -5409,8 +5409,8 @@
     "char": "🇹🇩",
     "category": "flags"
   },
-  "chile": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "cl": {
+    "keywords": ["chile", "flag", "nation", "country", "banner"],
     "char": "🇨🇱",
     "category": "flags"
   },
@@ -5444,8 +5444,8 @@
     "char": "🇨🇬",
     "category": "flags"
   },
-  "drc": {
-    "keywords": ["congo", "democratic", "republic", "flag", "nation", "country", "banner"],
+  "cd": {
+    "keywords": ["congo", "democratic", "republic", "flag", "nation", "country", "banner", "drc"],
     "char": "🇨🇩",
     "category": "flags"
   },
@@ -5694,8 +5694,8 @@
     "char": "🇮🇳",
     "category": "flags"
   },
-  "indonesia": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "id": {
+    "keywords": ["indonesia", "flag", "nation", "country", "banner"],
     "char": "🇮🇩",
     "category": "flags"
   },
@@ -5984,8 +5984,8 @@
     "char": "🇳🇪",
     "category": "flags"
   },
-  "nigeria": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "ng": {
+    "keywords": ["nigeria", "flag", "nation", "country", "banner"],
     "char": "🇳🇬",
     "category": "flags"
   },
@@ -6149,8 +6149,8 @@
     "char": "🇸🇹",
     "category": "flags"
   },
-  "saudi_arabia": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "sa": {
+    "keywords": ["saudi", "arabia", "flag", "nation", "country", "banner"],
     "char": "🇸🇦",
     "category": "flags"
   },
@@ -6319,8 +6319,8 @@
     "char": "🇹🇷",
     "category": "flags"
   },
-  "turkmenistan": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "tm": {
+    "keywords": ["turkmenistan", "flag", "nation", "country", "banner"],
     "char": "🇹🇲",
     "category": "flags"
   },
@@ -6329,8 +6329,8 @@
     "char": "🇹🇨",
     "category": "flags"
   },
-  "tuvalu": {
-    "keywords": ["flag", "nation", "country", "banner"],
+  "tv": {
+    "keywords": ["tuvalu", "flag", "nation", "country", "banner"],
     "char": "🇹🇻",
     "category": "flags"
   },


### PR DESCRIPTION
I noticed that some of the flags didn't use the correct iso-3166 alpha-2 code name:

* Chile: https://www.iso.org/obp/ui/#iso:code:3166:CL
* Democratic Republic of the Congo: https://www.iso.org/obp/ui/#iso:code:3166:CD
* Indonesia: https://www.iso.org/obp/ui/#iso:code:3166:ID
* Nigeria: https://www.iso.org/obp/ui/#iso:code:3166:NG
* Saudi Arabia: https://www.iso.org/obp/ui/#iso:code:3166:SA
* Turkmenistan: https://www.iso.org/obp/ui/#iso:code:3166:TM
* Tuvalu: https://www.iso.org/obp/ui/#iso:code:3166:TV

For each country, I changed the key in the `emojis.json` file and added the country name in the `keywords` list if it wasn't there.

With this change, almost all the other flags have a valid 2-letter code (in the sense of iso3166), except two:

* `EU` (🇪🇺) for the European Union. It's not technically a country but it has a well-implemented flag support on most OS.
* `IC` (🇮🇨) for the Canary Islands. I'm not sure why this one has a flag but no iso code. Probably historical/political reasons.