### PR TITLE
Change a keyword for 🍾 from "food" to "drink"

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -2055,7 +2055,7 @@
     "category": "food_and_drink"
   },
   "bottle": {
-    "keywords": ["food", "wine", "champagne"],
+    "keywords": ["drink", "wine", "champagne"],
     "char": "🍾",
     "category": "food_and_drink"
   },


### PR DESCRIPTION
I did this because 🍾 did't have keywords like "drink" or "beverage". 
With this change we can separate food and drink in the food and drink category 👌 