### PR TITLE
Fitzpatrick scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ npm install emojilib --save
   "grinning": {
     "keywords": ["face", "smile", "happy", "joy"],
     "char": "😀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "grin": {
     "keywords": ["face", "happy", "smile", "joy"],
     "char": "😁",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   ...
@@ -37,6 +39,18 @@ npm install emojilib --save
 
 > emoji.ordered
 [ 'grinning', 'grimacing', 'grin', 'joy', 'smiley', 'smile', 'sweat_smile', ...]
+
+> emoji.fitzpatrick_scale_modifiers
+[ '🏻', '🏼', '🏽', '🏾', '🏿' ]
+
+> emoji.lib.v.fitzpatrick_scale
+true
+
+> emoji.lib.turtle.fitzpatrick_scale
+false
+
+> emoji.lib.v.char + emoji.fitzpatrick_scale_modifiers[4]
+'✌🏿'
 ```
 
 ## :electric_plug: Powered by emojilib

--- a/emojis.json
+++ b/emojis.json
@@ -3326,37 +3326,37 @@
   "women_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♀️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "men_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♂️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_doing_cartwheel": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♀️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "man_doing_cartwheel": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♂️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♀️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "man_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♂️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "ice_skate": {
@@ -3416,13 +3416,13 @@
   "woman_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♀️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "man_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♂️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_surfing": {
@@ -3590,13 +3590,13 @@
   "woman_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♀️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "man_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♂️",
-    "fitzpatrick_scale": false,
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "microphone": {

--- a/emojis.json
+++ b/emojis.json
@@ -8594,86 +8594,103 @@
   "octocat": {
     "keywords": ["animal", "octopus", "github", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "shipit": {
     "keywords": ["squirrel", "detective", "animal", "sherlock", "inspector", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "bowtie": {
     "keywords": ["face", "formal", "fashion", "suit", "classy", "magic", "circus"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "neckbeard": {
     "keywords": ["nerdy", "face", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "metal": {
     "keywords": ["fingers", "rocknroll", "concert", "band", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "fu": {
     "keywords": ["fuck", "finger", "dislike", "thumbsdown", "disapprove", "no", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "trollface": {
     "keywords": ["internet", "meme", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "godmode": {
     "keywords": ["doom", "oldschool"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "goberserk": {
     "keywords": ["doom", "rage", "bloody", "hurt"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "finnadie": {
     "keywords": ["doom", "oldschool"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "feelsgood": {
     "keywords": ["doom", "oldschool"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "rage1": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "rage2": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "rage3": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "rage4": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "suspect": {
     "keywords": ["mad", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   },
   "hurtrealbad": {
     "keywords": ["mad", "injured", "doom", "oldschool", "custom_"],
     "char": null,
+    "fitzpatrick_scale": false,
     "category": "_custom"
   }
 }

--- a/emojis.json
+++ b/emojis.json
@@ -2,7161 +2,8593 @@
   "grinning": {
     "keywords": ["face", "smile", "happy", "joy", ":D", "grin"],
     "char": "😀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "grimacing": {
     "keywords": ["face", "grimace", "teeth"],
     "char": "😬",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "grin": {
     "keywords": ["face", "happy", "smile", "joy", "kawaii"],
     "char": "😁",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "joy": {
     "keywords": ["face", "cry", "tears", "weep", "happy", "happytears", "haha"],
     "char": "😂",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "rofl": {
     "keywords": ["face", "rolling", "floor", "laughing", "lol", "haha"],
     "char": "🤣",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smiley": {
     "keywords": ["face", "happy", "joy", "haha", ":D", ":)", "smile", "funny"],
     "char": "😃",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smile": {
     "keywords": ["face", "happy", "joy", "funny", "haha", "laugh", "like", ":D", ":)"],
     "char": "😄",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sweat_smile": {
     "keywords": ["face", "hot", "happy", "laugh", "sweat", "smile", "relief"],
     "char": "😅",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "laughing": {
     "keywords": ["happy", "joy", "lol", "satisfied", "haha", "face", "glad", "XD", "laugh"],
     "char": "😆",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "innocent": {
     "keywords": ["face", "angel", "heaven", "halo"],
     "char": "😇",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "wink": {
     "keywords": ["face", "happy", "mischievous", "secret", ";)", "smile"],
     "char": "😉",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "blush": {
     "keywords": ["face", "smile", "happy", "flushed", "crush", "embarrassed", "shy", "joy"],
     "char": "😊",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "slightly_smiling": {
     "keywords": ["face", "smile"],
     "char": "🙂",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "upside_down": {
     "keywords": ["face", "flipped", "silly", "smile"],
     "char": "🙃",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "relaxed": {
     "keywords": ["face", "blush", "massage", "happiness"],
     "char": "☺️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "yum": {
     "keywords": ["happy", "joy", "tongue", "smile", "face", "silly", "yummy", "nom"],
     "char": "😋",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "relieved": {
     "keywords": ["face", "relaxed", "phew", "massage", "happiness"],
     "char": "😌",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "heart_eyes": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "crush", "heart"],
     "char": "😍",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kissing_heart": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "kiss"],
     "char": "😘",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kissing": {
     "keywords": ["love", "like", "face", "3", "valentines", "infatuation", "kiss"],
     "char": "😗",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kissing_smiling_eyes": {
     "keywords": ["face", "affection", "valentines", "infatuation", "kiss"],
     "char": "😙",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kissing_closed_eyes": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "kiss"],
     "char": "😚",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "stuck_out_tongue_winking_eye": {
     "keywords": ["face", "prank", "childish", "playful", "mischievous", "smile", "wink", "tongue"],
     "char": "😜",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "stuck_out_tongue_closed_eyes": {
     "keywords": ["face", "prank", "playful", "mischievous", "smile", "tongue"],
     "char": "😝",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "stuck_out_tongue": {
     "keywords": ["face", "prank", "childish", "playful", "mischievous", "smile", "tongue"],
     "char": "😛",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "money_mouth": {
     "keywords": ["face", "rich", "dollar", "money"],
     "char": "🤑",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "nerd": {
     "keywords": ["face", "nerdy", "geek", "dork"],
     "char": "🤓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sunglasses": {
     "keywords": ["face", "cool", "smile", "summer", "beach", "sunglass"],
     "char": "😎",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "clown": {
     "keywords": ["face"],
     "char": "🤡",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "cowboy": {
     "keywords": ["face", "cowgirl", "hat"],
     "char": "🤠",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "hugging": {
     "keywords": ["face", "smile", "hug"],
     "char": "🤗",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smirk": {
     "keywords": ["face", "smile", "mean", "prank", "smug", "sarcasm"],
     "char": "😏",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "no_mouth": {
     "keywords": ["face", "hellokitty"],
     "char": "😶",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "neutral_face": {
     "keywords": ["indifference", "meh", ":|", "neutral"],
     "char": "😐",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "expressionless": {
     "keywords": ["face", "indifferent", "-_-", "meh", "deadpan"],
     "char": "😑",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "unamused": {
     "keywords": ["indifference", "bored", "straight face", "serious", "sarcasm"],
     "char": "😒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "rolling_eyes": {
     "keywords": ["face", "eyeroll", "frustrated"],
     "char": "🙄",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "thinking": {
     "keywords": ["face", "hmmm", "think", "consider"],
     "char": "🤔",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "lying": {
     "keywords": ["face", "lie", "pinocchio"],
     "char": "🤥",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "flushed": {
     "keywords": ["face", "blush", "shy", "flattered"],
     "char": "😳",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "disappointed": {
     "keywords": ["face", "sad", "upset", "depressed", ":("],
     "char": "😞",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "worried": {
     "keywords": ["face", "concern", "nervous", ":("],
     "char": "😟",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "angry": {
     "keywords": ["mad", "face", "annoyed", "frustrated"],
     "char": "😠",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "rage": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": "😡",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "pensive": {
     "keywords": ["face", "sad", "depressed", "okay", "upset"],
     "char": "😔",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "confused": {
     "keywords": ["face", "indifference", "huh", "weird", "hmmm", ":/"],
     "char": "😕",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "slightly_sad": {
     "keywords": ["face", "frowning", "disappointed", "sad", "upset"],
     "char": "🙁",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "white_frowning": {
     "keywords": ["face", "sad", "upset", "frown"],
     "char": "☹",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "persevere": {
     "keywords": ["face", "sick", "no", "upset", "oops"],
     "char": "😣",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "confounded": {
     "keywords": ["face", "confused", "sick", "unwell", "oops", ":S"],
     "char": "😖",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "tired_face": {
     "keywords": ["sick", "whine", "upset", "frustrated"],
     "char": "😫",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "weary": {
     "keywords": ["face", "tired", "sleepy", "sad", "frustrated", "upset"],
     "char": "😩",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "triumph": {
     "keywords": ["face", "gas", "phew", "proud", "pride"],
     "char": "😤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "open_mouth": {
     "keywords": ["face", "surprise", "impressed", "wow", "whoa", ":O"],
     "char": "😮",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "scream": {
     "keywords": ["face", "munch", "scared", "omg"],
     "char": "😱",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "fearful": {
     "keywords": ["face", "scared", "terrified", "nervous", "oops", "huh"],
     "char": "😨",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "cold_sweat": {
     "keywords": ["face", "nervous", "sweat"],
     "char": "😰",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "hushed": {
     "keywords": ["face", "woo", "shh"],
     "char": "😯",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "frowning": {
     "keywords": ["face", "aw", "what"],
     "char": "😦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "anguished": {
     "keywords": ["face", "stunned", "nervous"],
     "char": "😧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "cry": {
     "keywords": ["face", "tears", "sad", "depressed", "upset", ":'("],
     "char": "😢",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "disappointed_relieved": {
     "keywords": ["face", "phew", "sweat", "nervous"],
     "char": "😥",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "drooling": {
     "keywords": ["face"],
     "char": "🤤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sleepy": {
     "keywords": ["face", "tired", "rest", "nap"],
     "char": "😪",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sweat": {
     "keywords": ["face", "hot", "sad", "tired", "exercise"],
     "char": "😓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sob": {
     "keywords": ["face", "cry", "tears", "sad", "upset", "depressed"],
     "char": "😭",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "dizzy_face": {
     "keywords": ["spent", "unconscious", "xox", "dizzy"],
     "char": "😵",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "astonished": {
     "keywords": ["face", "xox", "surprised", "poisoned"],
     "char": "😲",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "zipper_mouth": {
     "keywords": ["face", "sealed", "zipper", "secret"],
     "char": "🤐",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "nauseated": {
     "keywords": ["face", "vomit"],
     "char": "🤢",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sneezing": {
     "keywords": ["face", "gesundheit", "sneeze"],
     "char": "🤧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "mask": {
     "keywords": ["face", "sick", "ill", "disease"],
     "char": "😷",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "thermometer_face": {
     "keywords": ["sick", "temperature", "thermometer", "cold"],
     "char": "🤒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "bandage_face": {
     "keywords": ["injured", "clumsy", "bandage", "hurt"],
     "char": "🤕",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sleeping": {
     "keywords": ["face", "tired", "sleepy", "night", "zzz"],
     "char": "😴",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "zzz": {
     "keywords": ["sleepy", "tired"],
     "char": "💤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "hankey": {
     "keywords": ["poop", "shitface", "fail", "turd", "shit"],
     "char": "💩",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smiling_imp": {
     "keywords": ["devil", "horns"],
     "char": "😈",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "imp": {
     "keywords": ["devil", "angry", "horns"],
     "char": "👿",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "japanese_ogre": {
     "keywords": ["monster", "red", "mask", "halloween", "scary", "creepy", "devil", "demon", "japanese", "ogre"],
     "char": "👹",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "japanese_goblin": {
     "keywords": ["red", "evil", "mask", "monster", "scary", "creepy", "japanese", "goblin"],
     "char": "👺",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "skull": {
     "keywords": ["dead", "skeleton", "creepy"],
     "char": "💀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "ghost": {
     "keywords": ["halloween", "spooky", "scary"],
     "char": "👻",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "alien": {
     "keywords": ["UFO", "paul", "weird", "outer_space"],
     "char": "👽",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "robot": {
     "keywords": ["computer", "machine"],
     "char": "🤖",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smiley_cat": {
     "keywords": ["animal", "cats", "happy", "smile"],
     "char": "😺",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smile_cat": {
     "keywords": ["animal", "cats", "smile"],
     "char": "😸",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "joy_cat": {
     "keywords": ["animal", "cats", "haha", "happy", "tears"],
     "char": "😹",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "heart_eyes_cat": {
     "keywords": ["animal", "love", "like", "affection", "cats", "valentines", "heart"],
     "char": "😻",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "smirk_cat": {
     "keywords": ["animal", "cats", "smirk"],
     "char": "😼",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kissing_cat": {
     "keywords": ["animal", "cats", "kiss"],
     "char": "😽",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "scream_cat": {
     "keywords": ["animal", "cats", "munch", "scared", "scream"],
     "char": "🙀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "crying_cat_face": {
     "keywords": ["animal", "tears", "weep", "sad", "cats", "upset", "cry"],
     "char": "😿",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "pouting_cat": {
     "keywords": ["animal", "cats"],
     "char": "😾",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "raised_hands": {
     "keywords": ["gesture", "hooray", "yea", "celebration", "hands"],
     "char": "🙌",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "clap": {
     "keywords": ["hands", "praise", "applause", "congrats", "yay"],
     "char": "👏",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "wave": {
     "keywords": ["hands", "gesture", "goodbye", "solong", "farewell", "hello", "palm"],
     "char": "👋",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "call_me": {
     "keywords": ["hands", "gesture"],
     "char": "🤙",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "+1": {
     "keywords": ["thumbsup", "yes", "awesome", "good", "agree", "accept", "cool", "hand", "like"],
     "char": "👍",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "-1": {
     "keywords": ["thumbsdown", "no", "dislike", "hand"],
     "char": "👎",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "facepunch": {
     "keywords": ["angry", "violence", "fist", "hit", "attack", "hand"],
     "char": "👊",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "fist": {
     "keywords": ["fingers", "hand", "grasp"],
     "char": "✊",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "left_facing_fist": {
     "keywords": ["hand", "fistbump"],
     "char": "🤛",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "right_facing_fist": {
     "keywords": ["hand", "fistbump"],
     "char": "🤜",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "v": {
     "keywords": ["fingers", "ohyeah", "hand", "peace", "victory", "two"],
-    "char": "✌️",
+    "char": "✌",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "ok_hand": {
     "keywords": ["fingers", "limbs", "perfect", "ok"],
     "char": "👌",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "hand": {
     "keywords": ["fingers", "stop", "highfive", "palm", "ban", "raised_hand"],
     "char": "✋",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "back_of_hand": {
     "keywords": ["fingers", "raised", "backhand"],
     "char": "🤚",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "open_hands": {
     "keywords": ["fingers", "butterfly", "hands", "open"],
     "char": "👐",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "muscle": {
     "keywords": ["arm", "flex", "hand", "summer", "strong", "biceps"],
     "char": "💪",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "pray": {
     "keywords": ["please", "hope", "wish", "namaste", "highfive"],
     "char": "🙏",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "handshake": {
     "keywords": ["agreement", "shake"],
     "char": "🤝",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "point_up": {
     "keywords": ["hand", "fingers", "direction", "up"],
-    "char": "☝️",
+    "char": "☝",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "point_up_2": {
     "keywords": ["fingers", "hand", "direction", "up"],
     "char": "👆",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "point_down": {
     "keywords": ["fingers", "hand", "direction", "down"],
     "char": "👇",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "point_left": {
     "keywords": ["direction", "fingers", "hand", "left"],
     "char": "👈",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "point_right": {
     "keywords": ["fingers", "hand", "direction", "right"],
     "char": "👉",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "middle_finger": {
     "keywords": ["hand", "fingers", "rude"],
     "char": "🖕",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "splayed_fingers": {
     "keywords": ["hand", "fingers", "palm"],
     "char": "🖐",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "sign_of_horns": {
     "keywords": ["hand", "fingers", "evil_eye", "metal", "rock_on"],
     "char": "🤘",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "fingers_crossed": {
     "keywords": ["good", "lucky"],
     "char": "🤞",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "vulcan_salute": {
     "keywords": ["hand", "fingers", "spock", "star trek"],
     "char": "🖖",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "writing_hand": {
     "keywords": ["pen", "stationery", "write"],
     "char": "✍",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "selfie": {
     "keywords": ["camera", "phone"],
     "char": "🤳",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "nail_care": {
     "keywords": ["beauty", "manicure", "finger", "fashion", "nail"],
     "char": "💅",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "lips": {
     "keywords": ["mouth", "kiss"],
     "char": "👄",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "tongue": {
     "keywords": ["mouth", "playful"],
     "char": "👅",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "ear": {
     "keywords": ["face", "hear", "sound", "listen"],
     "char": "👂",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "nose": {
     "keywords": ["smell", "sniff"],
     "char": "👃",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "eye": {
     "keywords": ["face", "look", "see", "watch", "stare"],
     "char": "👁",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "eyes": {
     "keywords": ["look", "watch", "stalk", "peek", "see"],
     "char": "👀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "bust_in_silhouette": {
     "keywords": ["user", "person", "human"],
     "char": "👤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "busts_in_silhouette": {
     "keywords": ["user", "person", "human", "group", "team"],
     "char": "👥",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "speaking_head": {
     "keywords": ["user", "person", "human"],
     "char": "🗣",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "baby": {
     "keywords": ["child", "boy", "girl", "toddler"],
     "char": "👶",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "boy": {
     "keywords": ["man", "male", "guy", "teenager"],
     "char": "👦",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "girl": {
     "keywords": ["female", "woman", "teenager"],
     "char": "👧",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man": {
     "keywords": ["mustache", "father", "dad", "guy", "classy", "sir", "moustache"],
     "char": "👨",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman": {
     "keywords": ["female", "girls", "lady"],
     "char": "👩",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "blonde_woman": {
     "keywords": ["woman", "female", "girl", "blonde", "person"],
     "char": "👱‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "person_with_blond_hair": {
     "keywords": ["man", "male", "boy", "blonde", "guy", "person"],
     "char": "👱",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "older_man": {
     "keywords": ["human", "male", "men", "old", "elder", "senior"],
     "char": "👴",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "older_woman": {
     "keywords": ["human", "female", "women", "lady", "old", "elder", "senior"],
     "char": "👵",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_with_gua_pi_mao": {
     "keywords": ["male", "boy", "chinese"],
     "char": "👲",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_with_turban": {
     "keywords": ["female", "indian", "hinduism", "arabs", "woman"],
     "char": "👳‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "man_with_turban": {
     "keywords": ["male", "indian", "hinduism", "arabs"],
     "char": "👳",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_police_officer": {
     "keywords": ["woman", "police", "law", "legal", "enforcement", "arrest", "911", "female"],
     "char": "👮‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "cop": {
     "keywords": ["man", "police", "law", "legal", "enforcement", "arrest", "911"],
     "char": "👮",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_construction_worker": {
     "keywords": ["female", "human", "wip", "build", "construction", "worker", "labor", "woman"],
     "char": "👷‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "construction_worker": {
     "keywords": ["male", "human", "wip", "guy", "build", "construction", "worker", "labor"],
     "char": "👷",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_guard": {
     "keywords": ["uk", "gb", "british", "female", "royal", "woman"],
     "char": "💂‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "guardsman": {
     "keywords": ["uk", "gb", "british", "male", "guy", "royal"],
     "char": "💂",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_sleuth": {
     "keywords": ["human", "spy", "detective", "female", "woman"],
     "char": "🕵️‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sleuth": {
     "keywords": ["human", "spy", "detective"],
     "char": "🕵",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_health_worker": {
     "keywords": ["doctor", "nurse", "therapist", "healthcare", "woman", "human"],
     "char": "👩‍⚕️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_health_worker": {
     "keywords": ["doctor", "nurse", "therapist", "healthcare", "man", "human"],
     "char": "👨‍⚕️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_farmer": {
     "keywords": ["rancher", "gardener", "woman", "human"],
     "char": "👩‍🌾",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_farmer": {
     "keywords": ["rancher", "gardener", "man", "human"],
     "char": "👨‍🌾",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_cook": {
     "keywords": ["chef", "woman", "human"],
     "char": "👩‍🍳",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_cook": {
     "keywords": ["chef", "man", "human"],
     "char": "👨‍🍳",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_student": {
     "keywords": ["graduate", "woman", "human"],
     "char": "👩‍🎓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_student": {
     "keywords": ["graduate", "man", "human"],
     "char": "👨‍🎓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_singer": {
     "keywords": ["rockstar", "entertainer", "woman", "human"],
     "char": "👩‍🎤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_singer": {
     "keywords": ["rockstar", "entertainer", "man", "human"],
     "char": "👨‍🎤",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_teacher": {
     "keywords": ["instructor", "professor", "woman", "human"],
     "char": "👩‍🏫",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_teacher": {
     "keywords": ["instructor", "professor", "man", "human"],
     "char": "👨‍🏫",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_factory_worker": {
     "keywords": ["assembly", "industrial", "woman", "human"],
     "char": "👩‍🏭",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_factory_worker": {
     "keywords": ["assembly", "industrial", "man", "human"],
     "char": "👨‍🏭",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_technologist": {
     "keywords": ["coder", "developer", "engineer", "programmer", "software", "woman", "human"],
     "char": "👩‍💻",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_technologist": {
     "keywords": ["coder", "developer", "engineer", "programmer", "software", "man", "human"],
     "char": "👨‍💻",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_office_worker": {
     "keywords": ["business", "manager", "woman", "human"],
     "char": "👩‍💼",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_office_worker": {
     "keywords": ["business", "manager", "man", "human"],
     "char": "👨‍💼",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_mechanic": {
     "keywords": ["plumber", "woman", "human"],
     "char": "👩‍🔧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_mechanic": {
     "keywords": ["plumber", "man", "human"],
     "char": "👨‍🔧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_scientist": {
     "keywords": ["biologist", "chemist", "engineer", "physicist", "woman", "human"],
     "char": "👩‍🔬",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_scientist": {
     "keywords": ["biologist", "chemist", "engineer", "physicist", "man", "human"],
     "char": "👨‍🔬",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_artist": {
     "keywords": ["painter", "woman", "human"],
     "char": "👩‍🎨",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_artist": {
     "keywords": ["painter", "man", "human"],
     "char": "👨‍🎨",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_firefighter": {
     "keywords": ["fireman", "woman", "human"],
     "char": "👩‍🚒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_firefighter": {
     "keywords": ["fireman", "man", "human"],
     "char": "👨‍🚒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_pilot": {
     "keywords": ["aviator", "plane", "woman", "human"],
     "char": "👩‍✈️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_pilot": {
     "keywords": ["aviator", "plane", "man", "human"],
     "char": "👨‍✈️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_astronaut": {
     "keywords": ["space", "rocket", "woman", "human"],
     "char": "👩‍🚀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_astronaut": {
     "keywords": ["space", "rocket", "man", "human"],
     "char": "👨‍🚀",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "female_judge": {
     "keywords": ["justice", "court", "woman", "human"],
     "char": "👩‍⚖️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_judge": {
     "keywords": ["justice", "court", "man", "human"],
     "char": "👨‍⚖️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "mrs_claus": {
     "keywords": ["woman", "female", "xmas", "mother christmas"],
     "char": "🤶",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "santa": {
     "keywords": ["festival", "man", "male", "xmas", "father christmas"],
     "char": "🎅",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "angel": {
     "keywords": ["heaven", "wings", "halo"],
     "char": "👼",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "pregnant_woman": {
     "keywords": ["baby"],
     "char": "🤰",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "princess": {
     "keywords": ["girl", "woman", "female", "blond", "crown", "royal", "queen"],
     "char": "👸",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "prince": {
     "keywords": ["boy", "man", "male", "crown", "royal", "king"],
     "char": "🤴",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "bride_with_veil": {
     "keywords": ["couple", "marriage", "wedding", "woman", "bride"],
     "char": "👰",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_in_tuxedo": {
     "keywords": ["couple", "marriage", "wedding", "groom"],
     "char": "🤵",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_running": {
     "keywords": ["woman", "walking", "exercise", "race", "running", "female"],
     "char": "🏃‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "runner": {
     "keywords": ["man", "walking", "exercise", "race", "running"],
     "char": "🏃",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_walking": {
     "keywords": ["human", "feet", "steps", "woman", "female"],
     "char": "🚶‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "walking": {
     "keywords": ["human", "feet", "steps"],
     "char": "🚶",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "dancer": {
     "keywords": ["female", "girl", "woman", "fun"],
     "char": "💃",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_dancing": {
     "keywords": ["male", "boy", "fun", "dancer"],
     "char": "🕺",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "dancers": {
     "keywords": ["female", "bunny", "women", "girls"],
     "char": "👯",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "men_with_bunny_ears": {
     "keywords": ["male", "bunny", "men", "boys"],
     "char": "👯‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "couple": {
     "keywords": ["pair", "people", "human", "love", "date", "dating", "like", "affection", "valentines", "marriage"],
     "char": "👫",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "two_men_holding_hands": {
     "keywords": ["pair", "couple", "love", "like", "bromance", "friendship", "people", "human"],
     "char": "👬",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "two_women_holding_hands": {
     "keywords": ["pair", "friendship", "couple", "love", "like", "female", "people", "human"],
     "char": "👭",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_bowing_deeply": {
     "keywords": ["woman", "female", "girl"],
     "char": "🙇‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "bow": {
     "keywords": ["man", "male", "boy"],
     "char": "🙇",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "person_facepalming": {
     "keywords": ["man", "male", "boy", "disbelief"],
     "char": "🤦",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "woman_facepalming": {
     "keywords": ["woman", "female", "girl", "disbelief"],
     "char": "🤦‍♀️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "person_shrugging": {
     "keywords": ["woman", "female", "girl", "confused", "indifferent", "doubt"],
     "char": "🤷",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_shrugging": {
     "keywords": ["man", "male", "boy", "confused", "indifferent", "doubt"],
     "char": "🤷‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "information_desk_person": {
     "keywords": ["female", "girl", "woman", "human", "information"],
     "char": "💁",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_tipping_hand": {
     "keywords": ["male", "boy", "man", "human", "information"],
     "char": "💁‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "no_good": {
     "keywords": ["female", "girl", "woman", "nope"],
     "char": "🙅",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_gesturing_not_ok": {
     "keywords": ["male", "boy", "man", "nope"],
     "char": "🙅‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "ok_woman": {
     "keywords": ["women", "girl", "female", "pink", "human", "woman"],
     "char": "🙆",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_gesturing_ok": {
     "keywords": ["men", "boy", "male", "blue", "human", "man"],
     "char": "🙆‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "raising_hand": {
     "keywords": ["female", "girl", "woman"],
     "char": "🙋",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_raising_hand": {
     "keywords": ["male", "boy", "man"],
     "char": "🙋‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "person_with_pouting_face": {
     "keywords": ["female", "girl", "woman"],
     "char": "🙎",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
    "man_pouting": {
     "keywords": ["male", "boy", "man"],
     "char": "🙎‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "person_frowning": {
     "keywords": ["female", "girl", "woman", "sad", "depressed", "discouraged", "unhappy"],
     "char": "🙍",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_frowning": {
     "keywords": ["male", "boy", "man", "sad", "depressed", "discouraged", "unhappy"],
     "char": "🙍‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "haircut": {
     "keywords": ["female", "girl", "woman"],
     "char": "💇",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "man_getting_haircut": {
     "keywords": ["male", "boy", "man"],
     "char": "💇‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "massage": {
     "keywords": ["female", "girl", "woman", "head"],
     "char": "💆",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
    "man_getting_face_massage": {
     "keywords": ["male", "boy", "man", "head"],
     "char": "💆‍♂️",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "couple_with_heart": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "💑",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_couple_with_heart": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "👩‍❤️‍👩",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_couple_with_heart": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "👨‍❤️‍👨",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "couplekiss": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "💏",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "female_couplekiss": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "👩‍❤️‍💋‍👩",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "male_couplekiss": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "👨‍❤️‍💋‍👨",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family": {
     "keywords": ["home", "parents", "child", "mom", "dad", "father", "mother", "people", "human"],
     "char": "👪",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "family_man_woman_girl": {
     "keywords": ["home", "parents", "people", "human", "child"],
     "char": "👨‍👩‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_woman_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👧‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_woman_boys": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👦‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_woman_girls": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👧‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_women_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_women_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_women_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_women_boys": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👦‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_women_girls": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_men_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_men_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_men_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_men_boys": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👦‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_men_girls": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_woman_boy": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👩‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_woman_girl": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👩‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_woman_girl_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👧‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_woman_boy_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👦‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_woman_girl_girl": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👧‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_boy": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👨‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_girl": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👨‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_girl_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👧‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_boy_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👦‍👦",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "family_man_girl_girl": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👧‍👧",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "womans_clothes": {
     "keywords": ["fashion", "shopping", "female"],
     "char": "👚",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "shirt": {
     "keywords": ["fashion", "cloth", "casual", "tshirt", "tee"],
     "char": "👕",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "jeans": {
     "keywords": ["fashion", "shopping"],
     "char": "👖",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "necktie": {
     "keywords": ["shirt", "suitup", "formal", "fashion", "cloth", "business"],
     "char": "👔",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "dress": {
     "keywords": ["clothes", "fashion", "shopping"],
     "char": "👗",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "bikini": {
     "keywords": ["swimming", "female", "woman", "girl", "fashion", "beach", "summer"],
     "char": "👙",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kimono": {
     "keywords": ["dress", "fashion", "women", "female", "japanese"],
     "char": "👘",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "lipstick": {
     "keywords": ["female", "girl", "fashion", "woman"],
     "char": "💄",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "kiss": {
     "keywords": ["face", "lips", "love", "like", "affection", "valentines"],
     "char": "💋",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "footprints": {
     "keywords": ["feet", "tracking", "walking", "beach"],
     "char": "👣",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "high_heel": {
     "keywords": ["fashion", "shoes", "female", "pumps", "stiletto"],
     "char": "👠",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "sandal": {
     "keywords": ["shoes", "fashion", "flip flops"],
     "char": "👡",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "boot": {
     "keywords": ["shoes", "fashion"],
     "char": "👢",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "mans_shoe": {
     "keywords": ["fashion", "male"],
     "char": "👞",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "athletic_shoe": {
     "keywords": ["shoes", "sports", "sneakers"],
     "char": "👟",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "womans_hat": {
     "keywords": ["fashion", "accessories", "female", "lady", "spring"],
     "char": "👒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "tophat": {
     "keywords": ["magic", "gentleman", "classy", "circus"],
     "char": "🎩",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "helmet": {
     "keywords": ["construction", "build"],
     "char": "⛑",
+    "fitzpatrick_scale": true,
     "category": "people"
   },
   "mortar_board": {
     "keywords": ["school", "college", "degree", "university", "graduation", "cap", "hat", "legal", "learn", "education"],
     "char": "🎓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "crown": {
     "keywords": ["king", "kod", "leader", "royalty", "lord"],
     "char": "👑",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "school_satchel": {
     "keywords": ["student", "education", "bag", "backpack"],
     "char": "🎒",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "pouch": {
     "keywords": ["bag", "accessories", "shopping"],
     "char": "👝",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "purse": {
     "keywords": ["fashion", "accessories", "money", "sales", "shopping"],
     "char": "👛",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "handbag": {
     "keywords": ["fashion", "accessory", "accessories", "shopping"],
     "char": "👜",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "briefcase": {
     "keywords": ["business", "documents", "work", "law", "legal"],
     "char": "💼",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "eyeglasses": {
     "keywords": ["fashion", "accessories", "eyesight", "nerdy", "dork", "geek"],
     "char": "👓",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "dark_sunglasses": {
     "keywords": ["face", "cool", "accessories"],
     "char": "🕶",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "ring": {
     "keywords": ["wedding", "propose", "marriage", "valentines", "diamond", "fashion", "jewelry", "gem", "engagement"],
     "char": "💍",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "closed_umbrella": {
     "keywords": ["weather", "rain", "drizzle"],
     "char": "🌂",
+    "fitzpatrick_scale": false,
     "category": "people"
   },
   "dog": {
     "keywords": ["animal", "friend", "nature", "woof", "puppy", "pet", "faithful"],
     "char": "🐶",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cat": {
     "keywords": ["animal", "meow", "nature", "pet", "kitten"],
     "char": "🐱",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "mouse": {
     "keywords": ["animal", "nature", "cheese", "rodent"],
     "char": "🐭",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "hamster": {
     "keywords": ["animal", "nature"],
     "char": "🐹",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rabbit": {
     "keywords": ["animal", "nature", "pet", "spring", "magic", "bunny"],
     "char": "🐰",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "fox": {
     "keywords": ["animal", "nature", "face"],
     "char": "🦊",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bear": {
     "keywords": ["animal", "nature", "wild"],
     "char": "🐻",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "panda_face": {
     "keywords": ["animal", "nature", "panda"],
     "char": "🐼",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "koala": {
     "keywords": ["animal", "nature"],
     "char": "🐨",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "tiger": {
     "keywords": ["animal", "cat", "danger", "wild", "nature", "roar"],
     "char": "🐯",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "lion_face": {
     "keywords": ["animal", "nature"],
     "char": "🦁",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cow": {
     "keywords": ["beef", "ox", "animal", "nature", "moo", "milk"],
     "char": "🐮",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "pig": {
     "keywords": ["animal", "oink", "nature"],
     "char": "🐷",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "pig_nose": {
     "keywords": ["animal", "oink"],
     "char": "🐽",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "frog": {
     "keywords": ["animal", "nature", "croak", "toad"],
     "char": "🐸",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "squid": {
     "keywords": ["animal", "nature", "ocean", "sea"],
     "char": "🦑",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "octopus": {
     "keywords": ["animal", "creature", "ocean", "sea", "nature", "beach"],
     "char": "🐙",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "shrimp": {
     "keywords": ["animal", "ocean", "nature", "seafood"],
     "char": "🦐",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "monkey_face": {
     "keywords": ["animal", "nature", "circus"],
     "char": "🐵",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "gorilla": {
     "keywords": ["animal", "nature", "circus"],
     "char": "🦍",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "see_no_evil": {
     "keywords": ["monkey", "animal", "nature", "haha"],
     "char": "🙈",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "hear_no_evil": {
     "keywords": ["animal", "monkey", "nature"],
     "char": "🙉",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "speak_no_evil": {
     "keywords": ["monkey", "animal", "nature", "omg"],
     "char": "🙊",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "monkey": {
     "keywords": ["animal", "nature", "banana", "circus"],
     "char": "🐒",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "chicken": {
     "keywords": ["animal", "cluck", "nature", "bird"],
     "char": "🐔",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "penguin": {
     "keywords": ["animal", "nature"],
     "char": "🐧",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bird": {
     "keywords": ["animal", "nature", "fly", "tweet", "spring"],
     "char": "🐦",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "baby_chick": {
     "keywords": ["animal", "chicken", "bird"],
     "char": "🐤",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "hatching_chick": {
     "keywords": ["animal", "chicken", "egg", "born", "baby", "bird"],
     "char": "🐣",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "hatched_chick": {
     "keywords": ["animal", "chicken", "baby", "bird"],
     "char": "🐥",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "duck": {
     "keywords": ["animal", "nature", "bird", "mallard"],
     "char": "🦆",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "eagle": {
     "keywords": ["animal", "nature", "bird"],
     "char": "🦅",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "owl": {
     "keywords": ["animal", "nature", "bird", "hoot"],
     "char": "🦉",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bat": {
     "keywords": ["animal", "nature", "blind", "vampire"],
     "char": "🦇",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "wolf": {
     "keywords": ["animal", "nature", "wild"],
     "char": "🐺",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "boar": {
     "keywords": ["animal", "nature"],
     "char": "🐗",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "horse": {
     "keywords": ["animal", "brown", "nature"],
     "char": "🐴",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "unicorn_face": {
     "keywords": ["animal", "nature", "mystical"],
     "char": "🦄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bee": {
     "keywords": ["animal", "insect", "nature", "bug", "spring", "honey"],
     "char": "🐝",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bug": {
     "keywords": ["animal", "insect", "nature", "worm"],
     "char": "🐛",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "butterfly": {
     "keywords": ["animal", "insect", "nature", "caterpillar"],
     "char": "🦋",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "snail": {
     "keywords": ["slow", "animal", "shell"],
     "char": "🐌",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "beetle": {
     "keywords": ["animal", "insect", "nature", "ladybug"],
     "char": "🐞",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "ant": {
     "keywords": ["animal", "insect", "nature", "bug"],
     "char": "🐜",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "spider": {
     "keywords": ["animal", "arachnid"],
     "char": "🕷",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "scorpion": {
     "keywords": ["animal", "arachnid"],
     "char": "🦂",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "crab": {
     "keywords": ["animal", "crustacean"],
     "char": "🦀",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "snake": {
     "keywords": ["animal", "evil", "nature", "hiss", "python"],
     "char": "🐍",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "lizard": {
     "keywords": ["animal", "nature", "reptile"],
     "char": "🦎",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "turtle": {
     "keywords": ["animal", "slow", "nature", "tortoise"],
     "char": "🐢",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "tropical_fish": {
     "keywords": ["animal", "swim", "ocean", "beach", "nemo"],
     "char": "🐠",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "fish": {
     "keywords": ["animal", "food", "nature"],
     "char": "🐟",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "blowfish": {
     "keywords": ["animal", "nature", "food", "sea", "ocean"],
     "char": "🐡",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dolphin": {
     "keywords": ["animal", "nature", "fish", "sea", "ocean", "flipper", "fins", "beach"],
     "char": "🐬",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "shark": {
     "keywords": ["animal", "nature", "fish", "sea", "ocean", "jaws", "fins", "beach"],
     "char": "🦈",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "whale": {
     "keywords": ["animal", "nature", "sea", "ocean"],
     "char": "🐳",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "whale2": {
     "keywords": ["animal", "nature", "sea", "ocean"],
     "char": "🐋",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "crocodile": {
     "keywords": ["animal", "nature", "reptile", "lizard", "alligator"],
     "char": "🐊",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "leopard": {
     "keywords": ["animal", "nature"],
     "char": "🐆",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "tiger2": {
     "keywords": ["animal", "nature", "roar"],
     "char": "🐅",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "water_buffalo": {
     "keywords": ["animal", "nature", "ox", "cow"],
     "char": "🐃",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "ox": {
     "keywords": ["animal", "cow", "beef"],
     "char": "🐂",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cow2": {
     "keywords": ["beef", "ox", "animal", "nature", "moo", "milk"],
     "char": "🐄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "deer": {
     "keywords": ["animal", "nature", "horns", "venison"],
     "char": "🦌",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dromedary_camel": {
     "keywords": ["animal", "hot", "desert", "hump"],
     "char": "🐪",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "camel": {
     "keywords": ["animal", "nature", "hot", "desert", "hump"],
     "char": "🐫",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "elephant": {
     "keywords": ["animal", "nature", "nose", "thailand", "circus"],
     "char": "🐘",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rhinoceros": {
     "keywords": ["animal", "nature", "horn"],
     "char": "🦏",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "goat": {
     "keywords": ["animal", "nature"],
     "char": "🐐",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "ram": {
     "keywords": ["animal", "sheep", "nature"],
     "char": "🐏",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sheep": {
     "keywords": ["animal", "nature", "wool", "shipit"],
     "char": "🐑",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "racehorse": {
     "keywords": ["animal", "gamble", "luck"],
     "char": "🐎",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "pig2": {
     "keywords": ["animal", "nature"],
     "char": "🐖",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rat": {
     "keywords": ["animal", "mouse", "rodent"],
     "char": "🐀",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "mouse2": {
     "keywords": ["animal", "nature", "rodent"],
     "char": "🐁",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rooster": {
     "keywords": ["animal", "nature", "chicken"],
     "char": "🐓",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "turkey": {
     "keywords": ["animal", "bird"],
     "char": "🦃",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dove_of_peace": {
     "keywords": ["animal", "bird"],
     "char": "🕊",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dog2": {
     "keywords": ["animal", "nature", "friend", "doge", "pet", "faithful"],
     "char": "🐕",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "poodle": {
     "keywords": ["dog", "animal", "101", "nature", "pet"],
     "char": "🐩",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cat2": {
     "keywords": ["animal", "meow", "pet", "cats"],
     "char": "🐈",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rabbit2": {
     "keywords": ["animal", "nature", "pet", "magic", "spring"],
     "char": "🐇",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "chipmunk": {
     "keywords": ["animal", "nature", "rodent", "squirrel"],
     "char": "🐿",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "feet": {
     "keywords": ["animal", "tracking", "footprints", "dog", "cat", "pet", "paw_prints"],
     "char": "🐾",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dragon": {
     "keywords": ["animal", "myth", "nature", "chinese", "green"],
     "char": "🐉",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dragon_face": {
     "keywords": ["animal", "myth", "nature", "chinese", "green"],
     "char": "🐲",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cactus": {
     "keywords": ["vegetable", "plant", "nature"],
     "char": "🌵",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "christmas_tree": {
     "keywords": ["festival", "vacation", "december", "xmas", "celebration"],
     "char": "🎄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "evergreen_tree": {
     "keywords": ["plant", "nature"],
     "char": "🌲",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "deciduous_tree": {
     "keywords": ["plant", "nature"],
     "char": "🌳",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "palm_tree": {
     "keywords": ["plant", "vegetable", "nature", "summer", "beach", "mojito", "tropical"],
     "char": "🌴",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "seedling": {
     "keywords": ["plant", "nature", "grass", "lawn", "spring"],
     "char": "🌱",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "herb": {
     "keywords": ["vegetable", "plant", "medicine", "weed", "grass", "lawn"],
     "char": "🌿",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "shamrock": {
     "keywords": ["vegetable", "plant", "nature", "irish", "clover"],
     "char": "☘",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "four_leaf_clover": {
     "keywords": ["vegetable", "plant", "nature", "lucky", "irish"],
     "char": "🍀",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bamboo": {
     "keywords": ["plant", "nature", "vegetable", "panda", "pine_decoration"],
     "char": "🎍",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "tanabata_tree": {
     "keywords": ["plant", "nature", "branch", "summer"],
     "char": "🎋",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "leaves": {
     "keywords": ["nature", "plant", "tree", "vegetable", "grass", "lawn", "spring"],
     "char": "🍃",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "fallen_leaf": {
     "keywords": ["nature", "plant", "vegetable", "leaves"],
     "char": "🍂",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "maple_leaf": {
     "keywords": ["nature", "plant", "vegetable", "canada", "fall"],
     "char": "🍁",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "ear_of_rice": {
     "keywords": ["nature", "plant"],
     "char": "🌾",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "hibiscus": {
     "keywords": ["plant", "vegetable", "flowers", "beach"],
     "char": "🌺",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sunflower": {
     "keywords": ["nature", "plant", "fall"],
     "char": "🌻",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "rose": {
     "keywords": ["flowers", "valentines", "love", "spring"],
     "char": "🌹",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "wilted_rose": {
     "keywords": ["plant", "nature", "flower"],
     "char": "🥀",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "tulip": {
     "keywords": ["flowers", "plant", "nature", "summer", "spring"],
     "char": "🌷",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "blossom": {
     "keywords": ["nature", "flowers", "yellow"],
     "char": "🌼",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cherry_blossom": {
     "keywords": ["nature", "plant", "spring", "flower"],
     "char": "🌸",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "bouquet": {
     "keywords": ["flowers", "nature", "spring"],
     "char": "💐",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "mushroom": {
     "keywords": ["plant", "vegetable"],
     "char": "🍄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "chestnut": {
     "keywords": ["food", "squirrel"],
     "char": "🌰",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "jack_o_lantern": {
     "keywords": ["halloween", "light", "pumpkin", "creepy", "fall"],
     "char": "🎃",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "shell": {
     "keywords": ["nature", "sea", "beach"],
     "char": "🐚",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "spider_web": {
     "keywords": ["animal", "insect", "arachnid", "silk"],
     "char": "🕸",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "earth_americas": {
     "keywords": ["globe", "world", "USA", "international"],
     "char": "🌎",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "earth_africa": {
     "keywords": ["globe", "world", "international"],
     "char": "🌍",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "earth_asia": {
     "keywords": ["globe", "world", "east", "international"],
     "char": "🌏",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "full_moon": {
     "keywords": ["nature", "yellow", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌕",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "waning_gibbous_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep", "waxing_gibbous_moon"],
     "char": "🌖",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "last_quarter_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌗",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "waning_crescent_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌘",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "new_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌑",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "waxing_crescent_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌒",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "first_quarter_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌓",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "moon": {
     "keywords": ["nature", "night", "sky", "gray", "twilight", "planet", "space", "evening", "sleep"],
     "char": "🌔",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "new_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌚",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "full_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌝",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "first_quarter_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌛",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "last_quarter_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌜",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sun_with_face": {
     "keywords": ["nature", "morning", "sky"],
     "char": "🌞",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "crescent_moon": {
     "keywords": ["night", "sleep", "sky", "evening", "magic"],
     "char": "🌙",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "star": {
     "keywords": ["night", "yellow"],
     "char": "⭐",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "star2": {
     "keywords": ["night", "sparkle", "awesome", "good", "magic"],
     "char": "🌟",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dizzy": {
     "keywords": ["star", "sparkle", "shoot", "magic"],
     "char": "💫",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sparkles": {
     "keywords": ["stars", "shine", "shiny", "cool", "awesome", "good", "magic"],
     "char": "✨",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "comet": {
     "keywords": ["space"],
     "char": "☄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sunny": {
     "keywords": ["weather", "nature", "brightness", "summer", "beach", "spring"],
     "char": "☀️",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "white_sun_with_small_cloud": {
     "keywords": ["weather"],
     "char": "🌤",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "partly_sunny": {
     "keywords": ["weather", "nature", "cloudy", "morning", "fall", "spring"],
     "char": "⛅",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "white_sun_behind_cloud": {
     "keywords": ["weather"],
     "char": "🌥",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "white_sun_behind_cloud_with_rain": {
     "keywords": ["weather"],
     "char": "🌦",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cloud": {
     "keywords": ["weather", "sky"],
     "char": "☁️",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cloud_with_rain": {
     "keywords": ["weather"],
     "char": "🌧",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "thunder_cloud_and_rain": {
     "keywords": ["weather", "lightning"],
     "char": "⛈",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cloud_with_lightning": {
     "keywords": ["weather", "thunder"],
     "char": "🌩",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "zap": {
     "keywords": ["thunder", "weather", "lightning bolt", "fast"],
     "char": "⚡",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "fire": {
     "keywords": ["hot", "cook", "flame"],
     "char": "🔥",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "boom": {
     "keywords": ["bomb", "explode", "explosion", "collision", "blown"],
     "char": "💥",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "snowflake": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas"],
     "char": "❄️",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cloud_with_snow": {
     "keywords": ["weather"],
     "char": "🌨",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "snowman": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas", "frozen", "without_snow"],
     "char": "⛄",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "snowman_with_snow": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas", "frozen"],
     "char": "☃",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "wind_blowing_face": {
     "keywords": ["gust", "air"],
     "char": "🌬",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "dash": {
     "keywords": ["wind", "air", "fast", "shoo", "fart", "smoke", "puff"],
     "char": "💨",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "cloud_with_tornado": {
     "keywords": ["weather", "cyclone", "twister"],
     "char": "🌪",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "fog": {
     "keywords": ["weather"],
     "char": "🌫",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "umbrella_without_rain": {
     "keywords": ["weather", "spring"],
     "char": "☂",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "umbrella": {
     "keywords": ["rainy", "weather", "spring"],
     "char": "☔",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "droplet": {
     "keywords": ["water", "drip", "faucet", "spring"],
     "char": "💧",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "sweat_drops": {
     "keywords": ["water", "drip", "oops"],
     "char": "💦",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "ocean": {
     "keywords": ["sea", "water", "wave", "nature", "tsunami", "disaster"],
     "char": "🌊",
+    "fitzpatrick_scale": false,
     "category": "animals_and_nature"
   },
   "green_apple": {
     "keywords": ["fruit", "nature"],
     "char": "🍏",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "apple": {
     "keywords": ["fruit", "mac", "school"],
     "char": "🍎",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pear": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍐",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "tangerine": {
     "keywords": ["food", "fruit", "nature", "orange"],
     "char": "🍊",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "lemon": {
     "keywords": ["fruit", "nature"],
     "char": "🍋",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "banana": {
     "keywords": ["fruit", "food", "monkey"],
     "char": "🍌",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "watermelon": {
     "keywords": ["fruit", "food", "picnic", "summer"],
     "char": "🍉",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "grapes": {
     "keywords": ["fruit", "food", "wine"],
     "char": "🍇",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "strawberry": {
     "keywords": ["fruit", "food", "nature"],
     "char": "🍓",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "melon": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍈",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cherries": {
     "keywords": ["food", "fruit"],
     "char": "🍒",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "peach": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍑",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pineapple": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍍",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "kiwi": {
     "keywords": ["fruit", "food"],
     "char": "🥝",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "avocado": {
     "keywords": ["fruit", "food"],
     "char": "🥑",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "tomato": {
     "keywords": ["fruit", "vegetable", "nature", "food"],
     "char": "🍅",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "eggplant": {
     "keywords": ["vegetable", "nature", "food", "aubergine"],
     "char": "🍆",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cucumber": {
     "keywords": ["fruit", "food", "pickle"],
     "char": "🥒",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "carrot": {
     "keywords": ["vegetable", "food", "orange"],
     "char": "🥕",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "hot_pepper": {
     "keywords": ["food", "spicy", "chilli", "chili"],
     "char": "🌶",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "potato": {
     "keywords": ["food", "tuber", "vegatable", "starch"],
     "char": "🥔",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "corn": {
     "keywords": ["food", "vegetable", "plant"],
     "char": "🌽",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "sweet_potato": {
     "keywords": ["food", "nature"],
     "char": "🍠",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "peanuts": {
     "keywords": ["food", "nut"],
     "char": "🥜",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "honey_pot": {
     "keywords": ["bees", "sweet", "kitchen"],
     "char": "🍯",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "croissant": {
     "keywords": ["food", "bread", "french"],
     "char": "🥐",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "bread": {
     "keywords": ["food", "wheat", "breakfast", "toast"],
     "char": "🍞",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "baguette": {
     "keywords": ["food", "bread", "french"],
     "char": "🥖",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cheese_wedge": {
     "keywords": ["food", "chadder"],
     "char": "🧀",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "egg": {
     "keywords": ["food", "chicken", "breakfast"],
     "char": "🥚",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "bacon": {
     "keywords": ["food", "breakfast", "pork", "pig", "meat"],
     "char": "🥓",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pancakes": {
     "keywords": ["food", "breakfast", "flapjacks", "hotcakes"],
     "char": "🥞",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "poultry_leg": {
     "keywords": ["food", "meat", "drumstick", "bird", "chicken", "turkey"],
     "char": "🍗",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "meat_on_bone": {
     "keywords": ["good", "food", "drumstick"],
     "char": "🍖",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "fried_shrimp": {
     "keywords": ["food", "animal", "appetizer", "summer"],
     "char": "🍤",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cooking": {
     "keywords": ["food", "breakfast", "kitchen", "egg"],
     "char": "🍳",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "hamburger": {
     "keywords": ["meat", "fast food", "beef", "cheeseburger", "mcdonalds", "burger king"],
     "char": "🍔",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "fries": {
     "keywords": ["chips", "snack", "fast food"],
     "char": "🍟",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pita_sandwich": {
     "keywords": ["food", "flatbread", "stuffed", "gyro"],
     "char": "🥙",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "hot_dog": {
     "keywords": ["food", "frankfurter", "hotdog"],
     "char": "🌭",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pizza": {
     "keywords": ["food", "party"],
     "char": "🍕",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "spaghetti": {
     "keywords": ["food", "italian", "noodle"],
     "char": "🍝",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "taco": {
     "keywords": ["food", "mexican"],
     "char": "🌮",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "burrito": {
     "keywords": ["food", "mexican"],
     "char": "🌯",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "green_salad": {
     "keywords": ["food", "healthy", "lettuce"],
     "char": "🥗",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "pan_of_food": {
     "keywords": ["food", "cooking", "casserole", "paella"],
     "char": "🥘",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "ramen": {
     "keywords": ["food", "japanese", "noodle", "chopsticks"],
     "char": "🍜",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "stew": {
     "keywords": ["food", "meat", "soup"],
     "char": "🍲",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "fish_cake": {
     "keywords": ["food", "japan", "sea", "beach"],
     "char": "🍥",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "sushi": {
     "keywords": ["food", "fish", "japanese", "rice"],
     "char": "🍣",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "bento": {
     "keywords": ["food", "japanese", "box"],
     "char": "🍱",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "curry": {
     "keywords": ["food", "spicy", "hot", "indian"],
     "char": "🍛",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "rice_ball": {
     "keywords": ["food", "japanese"],
     "char": "🍙",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "rice": {
     "keywords": ["food", "china", "asian"],
     "char": "🍚",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "rice_cracker": {
     "keywords": ["food", "japanese"],
     "char": "🍘",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "oden": {
     "keywords": ["food", "japanese"],
     "char": "🍢",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "dango": {
     "keywords": ["food", "dessert", "sweet", "japanese", "barbecue", "meat"],
     "char": "🍡",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "shaved_ice": {
     "keywords": ["hot", "dessert", "summer"],
     "char": "🍧",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "ice_cream": {
     "keywords": ["food", "hot", "dessert"],
     "char": "🍨",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "icecream": {
     "keywords": ["food", "hot", "dessert", "summer"],
     "char": "🍦",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cake": {
     "keywords": ["food", "dessert"],
     "char": "🍰",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "birthday": {
     "keywords": ["food", "dessert", "cake"],
     "char": "🎂",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "custard": {
     "keywords": ["dessert", "food"],
     "char": "🍮",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "candy": {
     "keywords": ["snack", "dessert", "sweet", "lolly"],
     "char": "🍬",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "lollipop": {
     "keywords": ["food", "snack", "candy", "sweet"],
     "char": "🍭",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "chocolate_bar": {
     "keywords": ["food", "snack", "dessert", "sweet"],
     "char": "🍫",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "popcorn": {
     "keywords": ["food", "movie theater", "films", "snack"],
     "char": "🍿",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "doughnut": {
     "keywords": ["food", "dessert", "snack", "sweet", "donut"],
     "char": "🍩",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cookie": {
     "keywords": ["food", "snack", "oreo", "chocolate", "sweet", "dessert"],
     "char": "🍪",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "glass_of_milk": {
     "keywords": ["beverage", "drink", "cow"],
     "char": "🥛",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "beer": {
     "keywords": ["relax", "beverage", "drink", "drunk", "party", "pub", "summer", "alcohol", "booze"],
     "char": "🍺",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "beers": {
     "keywords": ["relax", "beverage", "drink", "drunk", "party", "pub", "summer", "alcohol", "booze"],
     "char": "🍻",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "clinking_glasses": {
     "keywords": ["beverage", "drink", "party", "alcohol", "celebrate", "cheers"],
     "char": "🥂",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "wine_glass": {
     "keywords": ["drink", "beverage", "drunk", "alcohol", "booze"],
     "char": "🍷",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "tumbler_glass": {
     "keywords": ["drink", "beverage", "drunk", "alcohol", "liquor", "booze", "bourbon", "scotch", "whisky", "glass", "shot"],
     "char": "🥃",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "cocktail": {
     "keywords": ["drink", "drunk", "alcohol", "beverage", "booze", "mojito"],
     "char": "🍸",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "tropical_drink": {
     "keywords": ["beverage", "cocktail", "summer", "beach", "alcohol", "booze", "mojito"],
     "char": "🍹",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "bottle": {
     "keywords": ["drink", "wine", "champagne"],
     "char": "🍾",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "sake": {
     "keywords": ["wine", "drink", "drunk", "beverage", "japanese", "alcohol", "booze"],
     "char": "🍶",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "tea": {
     "keywords": ["drink", "bowl", "breakfast", "green", "british"],
     "char": "🍵",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "coffee": {
     "keywords": ["beverage", "caffeine", "latte", "espresso"],
     "char": "☕",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "baby_bottle": {
     "keywords": ["food", "container", "milk"],
     "char": "🍼",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "spoon": {
     "keywords": ["cutlery", "kitchen", "tableware"],
     "char": "🥄",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "fork_and_knife": {
     "keywords": ["cutlery", "kitchen"],
     "char": "🍴",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "fork_and_knife_with_plate": {
     "keywords": ["food", "eat", "meal", "lunch", "dinner", "restaurant"],
     "char": "🍽",
+    "fitzpatrick_scale": false,
     "category": "food_and_drink"
   },
   "soccer": {
     "keywords": ["sports", "football"],
     "char": "⚽",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "basketball": {
     "keywords": ["sports", "balls", "NBA"],
     "char": "🏀",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "football": {
     "keywords": ["sports", "balls", "NFL"],
     "char": "🏈",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "baseball": {
     "keywords": ["sports", "balls"],
     "char": "⚾",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "tennis": {
     "keywords": ["sports", "balls", "green"],
     "char": "🎾",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "volleyball": {
     "keywords": ["sports", "balls"],
     "char": "🏐",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "rugby_football": {
     "keywords": ["sports", "team"],
     "char": "🏉",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "8ball": {
     "keywords": ["pool", "hobby", "game", "luck", "magic"],
     "char": "🎱",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "golf": {
     "keywords": ["sports", "business", "flag", "hole", "summer"],
     "char": "⛳",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_golfing": {
     "keywords": ["sports", "business", "woman", "female"],
     "char": "🏌️‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "golfer": {
     "keywords": ["sports", "business"],
     "char": "🏌",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "table_tennis": {
     "keywords": ["sports", "pingpong"],
     "char": "🏓",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "badminton": {
     "keywords": ["sports"],
     "char": "🏸",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "goal_net": {
     "keywords": ["sports"],
     "char": "🥅",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "ice_hockey": {
     "keywords": ["sports"],
     "char": "🏒",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "field_hockey": {
     "keywords": ["sports"],
     "char": "🏑",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "cricket": {
     "keywords": ["sports"],
     "char": "🏏",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "ski": {
     "keywords": ["sports", "winter", "cold", "snow"],
     "char": "🎿",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "skier": {
     "keywords": ["sports", "winter", "snow"],
     "char": "⛷",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "snowboarder": {
     "keywords": ["sports", "winter"],
     "char": "🏂",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "fencer": {
     "keywords": ["sports", "fencing", "sword"],
     "char": "🤺",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "women_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "men_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♂️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_doing_cartwheel": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "man_doing_cartwheel": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♂️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "man_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♂️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "ice_skate": {
     "keywords": ["sports"],
     "char": "⛸",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "bow_and_arrow": {
     "keywords": ["sports"],
     "char": "🏹",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "fishing_pole_and_fish": {
     "keywords": ["food", "hobby", "summer"],
     "char": "🎣",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "boxing_glove": {
     "keywords": ["sports", "fighting"],
     "char": "🥊",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "martial_arts_uniform": {
     "keywords": ["judo", "karate", "taekwondo"],
     "char": "🥋",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_rowing_boat": {
     "keywords": ["sports", "hobby", "water", "ship", "woman", "female"],
     "char": "🚣‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "rowboat": {
     "keywords": ["sports", "hobby", "water", "ship"],
     "char": "🚣",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_swimming": {
     "keywords": ["sports", "exercise", "human", "athlete", "water", "summer", "woman", "female"],
     "char": "🏊‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "swimmer": {
     "keywords": ["sports", "exercise", "human", "athlete", "water", "summer"],
     "char": "🏊",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "man_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♂️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_surfing": {
     "keywords": ["sports", "ocean", "sea", "summer", "beach", "woman", "female"],
     "char": "🏄‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "surfer": {
     "keywords": ["sports", "ocean", "sea", "summer", "beach"],
     "char": "🏄",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "bath": {
     "keywords": ["clean", "shower", "bathroom"],
     "char": "🛀",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_with_ball": {
     "keywords": ["sports", "human", "woman", "female"],
     "char": "⛹️‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "person_with_ball": {
     "keywords": ["sports", "human"],
     "char": "⛹",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_weight_lifting": {
     "keywords": ["sports", "training", "exercise", "woman", "female"],
     "char": "🏋️‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "weight_lifter": {
     "keywords": ["sports", "training", "exercise"],
     "char": "🏋",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_biking": {
     "keywords": ["sports", "bike", "exercise", "hipster", "woman", "female"],
     "char": "🚴‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "bicyclist": {
     "keywords": ["sports", "bike", "exercise", "hipster"],
     "char": "🚴",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "woman_mountain_biking": {
     "keywords": ["transportation", "sports", "human", "race", "bike", "woman", "female"],
     "char": "🚵‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "mountain_bicyclist": {
     "keywords": ["transportation", "sports", "human", "race", "bike"],
     "char": "🚵",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "horse_racing": {
     "keywords": ["animal", "betting", "competition", "gambling", "luck"],
     "char": "🏇",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "man_levitating": {
     "keywords": ["suit", "business", "levitate", "hover", "jump"],
     "char": "🕴",
+    "fitzpatrick_scale": true,
     "category": "activity"
   },
   "trophy": {
     "keywords": ["win", "award", "contest", "place", "ftw", "ceremony"],
     "char": "🏆",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "running_shirt_with_sash": {
     "keywords": ["play", "pageant"],
     "char": "🎽",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "sports_medal": {
     "keywords": ["award", "winning"],
     "char": "🏅",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "military_medal": {
     "keywords": ["award", "winning", "army"],
     "char": "🎖",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "gold_medal": {
     "keywords": ["award", "winning", "first"],
     "char": "🥇",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "silver_medal": {
     "keywords": ["award", "second"],
     "char": "🥈",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "bronze_medal": {
     "keywords": ["award", "third"],
     "char": "🥉",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "reminder_ribbon": {
     "keywords": ["sports", "cause", "support", "awareness"],
     "char": "🎗",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "rosette": {
     "keywords": ["flower", "decoration", "military"],
     "char": "🏵",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "ticket": {
     "keywords": ["event", "concert", "pass"],
     "char": "🎫",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "admission_ticket": {
     "keywords": ["sports", "concert", "entrance"],
     "char": "🎟",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "performing_arts": {
     "keywords": ["acting", "theater", "drama"],
     "char": "🎭",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "art": {
     "keywords": ["design", "paint", "draw", "colors"],
     "char": "🎨",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "circus_tent": {
     "keywords": ["festival", "carnival", "party"],
     "char": "🎪",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "woman_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♀️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "man_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♂️",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "microphone": {
     "keywords": ["sound", "music", "PA"],
     "char": "🎤",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "headphones": {
     "keywords": ["music", "score", "gadgets"],
     "char": "🎧",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "musical_score": {
     "keywords": ["treble", "clef"],
     "char": "🎼",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "musical_keyboard": {
     "keywords": ["piano", "instrument"],
     "char": "🎹",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "drum": {
     "keywords": ["music", "instrument", "drumsticks"],
     "char": "🥁",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "saxophone": {
     "keywords": ["music", "instrument", "jazz", "blues"],
     "char": "🎷",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "trumpet": {
     "keywords": ["music", "brass"],
     "char": "🎺",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "guitar": {
     "keywords": ["music", "instrument"],
     "char": "🎸",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "violin": {
     "keywords": ["music", "instrument", "orchestra", "symphony"],
     "char": "🎻",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "clapper": {
     "keywords": ["movie", "film", "record"],
     "char": "🎬",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "video_game": {
     "keywords": ["play", "console", "PS4", "controller"],
     "char": "🎮",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "space_invader": {
     "keywords": ["game", "arcade", "play"],
     "char": "👾",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "dart": {
     "keywords": ["game", "play", "bar"],
     "char": "🎯",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "game_die": {
     "keywords": ["dice", "random", "tabletop", "play", "luck"],
     "char": "🎲",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "slot_machine": {
     "keywords": ["bet", "gamble", "vegas", "fruit machine", "luck", "casino"],
     "char": "🎰",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "bowling": {
     "keywords": ["sports", "fun", "play"],
     "char": "🎳",
+    "fitzpatrick_scale": false,
     "category": "activity"
   },
   "car": {
     "keywords": ["red", "transportation", "vehicle"],
     "char": "🚗",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "taxi": {
     "keywords": ["uber", "vehicle", "cars", "transportation"],
     "char": "🚕",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "blue_car": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚙",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bus": {
     "keywords": ["car", "vehicle", "transportation"],
     "char": "🚌",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "trolleybus": {
     "keywords": ["bart", "transportation", "vehicle"],
     "char": "🚎",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "racing_car": {
     "keywords": ["sports", "race", "fast", "formula", "f1"],
     "char": "🏎",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "police_car": {
     "keywords": ["vehicle", "cars", "transportation", "law", "legal", "enforcement"],
     "char": "🚓",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "ambulance": {
     "keywords": ["health", "911", "hospital"],
     "char": "🚑",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "fire_engine": {
     "keywords": ["transportation", "cars", "vehicle"],
     "char": "🚒",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "minibus": {
     "keywords": ["vehicle", "car", "transportation"],
     "char": "🚐",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "truck": {
     "keywords": ["cars", "transportation"],
     "char": "🚚",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "articulated_lorry": {
     "keywords": ["vehicle", "cars", "transportation", "express"],
     "char": "🚛",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "tractor": {
     "keywords": ["vehicle", "car", "farming", "agriculture"],
     "char": "🚜",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "scooter": {
     "keywords": ["vehicle", "kick", "razor"],
     "char": "🛴",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "racing_motorcycle": {
     "keywords": ["race", "sports", "fast"],
     "char": "🏍",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bike": {
     "keywords": ["sports", "bicycle", "exercise", "hipster"],
     "char": "🚲",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "motor_scooter": {
     "keywords": ["vehicle", "vespa", "sasha"],
     "char": "🛵",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "rotating_light": {
     "keywords": ["police", "ambulance", "911", "emergency", "alert", "error", "pinged", "law", "legal"],
     "char": "🚨",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "oncoming_police_car": {
     "keywords": ["vehicle", "law", "legal", "enforcement", "911"],
     "char": "🚔",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "oncoming_bus": {
     "keywords": ["vehicle", "transportation"],
     "char": "🚍",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "oncoming_automobile": {
     "keywords": ["car", "vehicle", "transportation"],
     "char": "🚘",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "oncoming_taxi": {
     "keywords": ["vehicle", "cars", "uber"],
     "char": "🚖",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "aerial_tramway": {
     "keywords": ["transportation", "vehicle", "ski"],
     "char": "🚡",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "mountain_cableway": {
     "keywords": ["transportation", "vehicle", "ski"],
     "char": "🚠",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "suspension_railway": {
     "keywords": ["vehicle", "transportation"],
     "char": "🚟",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "railway_car": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚃",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "train": {
     "keywords": ["transportation", "vehicle", "carriage", "public", "travel"],
     "char": "🚋",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "monorail": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚝",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bullettrain_side": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚄",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bullettrain_front": {
     "keywords": ["transportation", "vehicle", "speed", "fast", "public", "travel"],
     "char": "🚅",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "light_rail": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚈",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "mountain_railway": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚞",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "steam_locomotive": {
     "keywords": ["transportation", "vehicle", "train"],
     "char": "🚂",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "train2": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚆",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "metro": {
     "keywords": ["transportation", "blue-square", "mrt", "underground", "tube"],
     "char": "🚇",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "tram": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚊",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "station": {
     "keywords": ["transportation", "vehicle", "public"],
     "char": "🚉",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "helicopter": {
     "keywords": ["transportation", "vehicle", "fly"],
     "char": "🚁",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "small_airplane": {
     "keywords": ["flight", "transportation", "fly", "vehicle"],
     "char": "🛩",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "airplane": {
     "keywords": ["vehicle", "transportation", "flight", "fly"],
     "char": "✈️",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "airplane_departure": {
     "keywords": ["airport", "flight", "landing"],
     "char": "🛫",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "airplane_arrival": {
     "keywords": ["airport", "flight", "boarding"],
     "char": "🛬",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "boat": {
     "keywords": ["ship", "summer", "transportation", "water", "sailing", "sailboat"],
     "char": "⛵",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "motor_boat": {
     "keywords": ["ship"],
     "char": "🛥",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "speedboat": {
     "keywords": ["ship", "transportation", "vehicle", "summer"],
     "char": "🚤",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "ferry": {
     "keywords": ["boat", "ship", "yacht"],
     "char": "⛴",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "passenger_ship": {
     "keywords": ["yacht", "cruise", "ferry"],
     "char": "🛳",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "rocket": {
     "keywords": ["launch", "ship", "staffmode", "NASA", "outer space", "outer_space", "fly"],
     "char": "🚀",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "artificial_satellite": {
     "keywords": ["communication", "gps", "orbit", "spaceflight", "NASA", "ISS"],
     "char": "🛰",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "seat": {
     "keywords": ["sit", "airplane", "transport", "bus", "flight", "fly"],
     "char": "💺",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "canoe": {
     "keywords": ["boat", "paddle", "water", "ship"],
     "char": "🛶",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "anchor": {
     "keywords": ["ship", "ferry", "sea", "boat"],
     "char": "⚓",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "construction": {
     "keywords": ["wip", "progress", "caution", "warning"],
     "char": "🚧",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "fuelpump": {
     "keywords": ["gas station", "petroleum"],
     "char": "⛽",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "busstop": {
     "keywords": ["transportation", "wait"],
     "char": "🚏",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "vertical_traffic_light": {
     "keywords": ["transportation", "driving"],
     "char": "🚦",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "traffic_light": {
     "keywords": ["transportation", "signal"],
     "char": "🚥",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "checkered_flag": {
     "keywords": ["contest", "finishline", "race", "gokart"],
     "char": "🏁",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "ship": {
     "keywords": ["transportation", "titanic", "deploy"],
     "char": "🚢",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "ferris_wheel": {
     "keywords": ["photo", "carnival", "londoneye"],
     "char": "🎡",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "roller_coaster": {
     "keywords": ["carnival", "playground", "photo", "fun"],
     "char": "🎢",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "carousel_horse": {
     "keywords": ["photo", "carnival"],
     "char": "🎠",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "building_construction": {
     "keywords": ["wip", "working", "progress"],
     "char": "🏗",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "foggy": {
     "keywords": ["photo", "mountain"],
     "char": "🌁",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "tokyo_tower": {
     "keywords": ["photo", "japanese"],
     "char": "🗼",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "factory": {
     "keywords": ["building", "industry", "pollution", "smoke"],
     "char": "🏭",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "fountain": {
     "keywords": ["photo", "summer", "water", "fresh"],
     "char": "⛲",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "rice_scene": {
     "keywords": ["photo", "japan", "asia", "tsukimi"],
     "char": "🎑",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "mountain": {
     "keywords": ["photo", "nature", "environment"],
     "char": "⛰",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "snow_capped_mountain": {
     "keywords": ["photo", "nature", "environment", "winter", "cold"],
     "char": "🏔",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "mount_fuji": {
     "keywords": ["photo", "mountain", "nature", "japanese"],
     "char": "🗻",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "volcano": {
     "keywords": ["photo", "nature", "disaster"],
     "char": "🌋",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "japan": {
     "keywords": ["nation", "country", "japanese", "asia"],
     "char": "🗾",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "camping": {
     "keywords": ["photo", "outdoors", "tent"],
     "char": "🏕",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "tent": {
     "keywords": ["photo", "camping", "outdoors"],
     "char": "⛺",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "national_park": {
     "keywords": ["photo", "environment", "nature"],
     "char": "🏞",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "motorway": {
     "keywords": ["road", "cupertino", "interstate", "highway"],
     "char": "🛣",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "railway_track": {
     "keywords": ["train", "transportation"],
     "char": "🛤",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "sunrise": {
     "keywords": ["morning", "view", "vacation", "photo"],
     "char": "🌅",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "sunrise_over_mountains": {
     "keywords": ["view", "vacation", "photo"],
     "char": "🌄",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "desert": {
     "keywords": ["photo", "warm", "saharah"],
     "char": "🏜",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "beach_with_umbrella": {
     "keywords": ["weather", "summer", "sunny", "sand", "mojito"],
     "char": "🏖",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "desert_island": {
     "keywords": ["photo", "tropical", "mojito"],
     "char": "🏝",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "city_sunrise": {
     "keywords": ["photo", "good morning", "dawn"],
     "char": "🌇",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "city_sunset": {
     "keywords": ["photo", "evening", "sky", "buildings"],
     "char": "🌆",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "cityscape": {
     "keywords": ["photo", "night life", "urban"],
     "char": "🏙",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "night_with_stars": {
     "keywords": ["evening", "city", "downtown"],
     "char": "🌃",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bridge_at_night": {
     "keywords": ["photo", "sanfrancisco"],
     "char": "🌉",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "milky_way": {
     "keywords": ["photo", "space", "stars"],
     "char": "🌌",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "stars": {
     "keywords": ["night", "photo"],
     "char": "🌠",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "sparkler": {
     "keywords": ["stars", "night", "shine"],
     "char": "🎇",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "fireworks": {
     "keywords": ["photo", "festival", "carnival", "congratulations"],
     "char": "🎆",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "rainbow": {
     "keywords": ["nature", "happy", "unicorn", "photo", "sky", "spring"],
     "char": "🌈",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "buildings": {
     "keywords": ["houses", "photo"],
     "char": "🏘",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "european_castle": {
     "keywords": ["building", "royalty", "history"],
     "char": "🏰",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "japanese_castle": {
     "keywords": ["photo", "building"],
     "char": "🏯",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "stadium": {
     "keywords": ["photo", "place", "sports", "concert", "venue"],
     "char": "🏟",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "statue_of_liberty": {
     "keywords": ["american", "newyork"],
     "char": "🗽",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "house": {
     "keywords": ["building", "home"],
     "char": "🏠",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "house_with_garden": {
     "keywords": ["home", "plant", "nature"],
     "char": "🏡",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "derelict_house": {
     "keywords": ["abandon", "evict", "broken", "building"],
     "char": "🏚",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "office": {
     "keywords": ["building", "bureau", "work"],
     "char": "🏢",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "department_store": {
     "keywords": ["building", "shopping", "mall"],
     "char": "🏬",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "post_office": {
     "keywords": ["building", "email", "communication"],
     "char": "🏣",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "european_post_office": {
     "keywords": ["building", "email"],
     "char": "🏤",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "hospital": {
     "keywords": ["building", "health", "surgery", "doctor"],
     "char": "🏥",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "bank": {
     "keywords": ["building", "money", "sales", "cash", "business", "enterprise"],
     "char": "🏦",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "hotel": {
     "keywords": ["building", "accomodation", "checkin"],
     "char": "🏨",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "convenience_store": {
     "keywords": ["building", "shopping", "groceries"],
     "char": "🏪",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "school": {
     "keywords": ["building", "student", "education", "learn", "teach"],
     "char": "🏫",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "love_hotel": {
     "keywords": ["like", "affection", "dating"],
     "char": "🏩",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "wedding": {
     "keywords": ["love", "like", "affection", "couple", "marriage", "bride", "groom"],
     "char": "💒",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "museum": {
     "keywords": ["art", "culture", "history"],
     "char": "🏛",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "church": {
     "keywords": ["building", "religion", "christ"],
     "char": "⛪",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "mosque": {
     "keywords": ["islam", "worship", "minaret"],
     "char": "🕌",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "synagogue": {
     "keywords": ["judaism", "worship", "temple", "jewish"],
     "char": "🕍",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "kaaba": {
     "keywords": ["mecca", "mosque", "islam"],
     "char": "🕋",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "shinto_shrine": {
     "keywords": ["temple", "japan", "kyoto"],
     "char": "⛩",
+    "fitzpatrick_scale": false,
     "category": "travel_and_places"
   },
   "watch": {
     "keywords": ["time", "accessories"],
     "char": "⌚",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "iphone": {
     "keywords": ["technology", "apple", "gadgets", "dial"],
     "char": "📱",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "calling": {
     "keywords": ["iphone", "incoming"],
     "char": "📲",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "computer": {
     "keywords": ["technology", "laptop", "screen", "display", "monitor"],
     "char": "💻",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "keyboard": {
     "keywords": ["technology", "computer", "type", "input", "text"],
     "char": "⌨",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "desktop_computer": {
     "keywords": ["technology", "computing", "screen"],
     "char": "🖥",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "printer": {
     "keywords": ["paper", "ink"],
     "char": "🖨",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "three_button_mouse": {
     "keywords": ["click"],
     "char": "🖱",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "trackball": {
     "keywords": ["technology", "trackpad"],
     "char": "🖲",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "joystick": {
     "keywords": ["game", "play"],
     "char": "🕹",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "compression": {
     "keywords": ["tool"],
     "char": "🗜",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "minidisc": {
     "keywords": ["technology", "record", "data", "disk", "90s"],
     "char": "💽",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "floppy_disk": {
     "keywords": ["oldschool", "technology", "save", "90s", "80s"],
     "char": "💾",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "cd": {
     "keywords": ["technology", "dvd", "disk", "disc", "90s"],
     "char": "💿",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "dvd": {
     "keywords": ["cd", "disk", "disc"],
     "char": "📀",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "vhs": {
     "keywords": ["record", "video", "oldschool", "90s", "80s"],
     "char": "📼",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "camera": {
     "keywords": ["gadgets", "photography"],
     "char": "📷",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "camera_with_flash": {
     "keywords": ["photography", "gadgets"],
     "char": "📸",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "video_camera": {
     "keywords": ["film", "record"],
     "char": "📹",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "movie_camera": {
     "keywords": ["film", "record"],
     "char": "🎥",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "film_projector": {
     "keywords": ["video", "tape", "record", "movie"],
     "char": "📽",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "film_frames": {
     "keywords": ["movie"],
     "char": "🎞",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "telephone_receiver": {
     "keywords": ["technology", "communication", "dial"],
     "char": "📞",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "phone": {
     "keywords": ["technology", "communication", "dial", "telephone"],
     "char": "☎️",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pager": {
     "keywords": ["bbcall", "oldschool", "90s"],
     "char": "📟",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "fax": {
     "keywords": ["communication", "technology"],
     "char": "📠",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "tv": {
     "keywords": ["technology", "program", "oldschool", "show", "television"],
     "char": "📺",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "radio": {
     "keywords": ["communication", "music", "podcast", "program"],
     "char": "📻",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "studio_microphone": {
     "keywords": ["singer", "recording", "artist"],
     "char": "🎙",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "level_slider": {
     "keywords": ["scale"],
     "char": "🎚",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "control_knobs": {
     "keywords": ["dial"],
     "char": "🎛",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "stopwatch": {
     "keywords": ["time", "deadline"],
     "char": "⏱",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "timer_clock": {
     "keywords": ["alarm"],
     "char": "⏲",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "alarm_clock": {
     "keywords": ["time", "wake"],
     "char": "⏰",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mantelpiece_clock": {
     "keywords": ["time"],
     "char": "🕰",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hourglass_flowing_sand": {
     "keywords": ["oldschool", "time", "countdown"],
     "char": "⏳",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hourglass": {
     "keywords": ["time", "clock", "oldschool", "limit", "exam", "quiz", "test"],
     "char": "⌛",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "satellite": {
     "keywords": ["communication", "future", "radio", "space"],
     "char": "📡",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "battery": {
     "keywords": ["power", "energy", "sustain"],
     "char": "🔋",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "electric_plug": {
     "keywords": ["charger", "power"],
     "char": "🔌",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bulb": {
     "keywords": ["light", "electricity", "idea"],
     "char": "💡",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "flashlight": {
     "keywords": ["dark", "camping", "sight", "night"],
     "char": "🔦",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "candle": {
     "keywords": ["fire", "wax"],
     "char": "🕯",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "wastebasket": {
     "keywords": ["bin", "trash", "rubbish", "garbage", "toss"],
     "char": "🗑",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "oil_drum": {
     "keywords": ["barrell"],
     "char": "🛢",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "money_with_wings": {
     "keywords": ["dollar", "bills", "payment", "sale"],
     "char": "💸",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "dollar": {
     "keywords": ["money", "sales", "bill", "currency"],
     "char": "💵",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "yen": {
     "keywords": ["money", "sales", "japanese", "dollar", "currency"],
     "char": "💴",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "euro": {
     "keywords": ["money", "sales", "dollar", "currency"],
     "char": "💶",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pound": {
     "keywords": ["british", "sterling", "money", "sales", "bills", "uk", "england", "currency"],
     "char": "💷",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "moneybag": {
     "keywords": ["dollar", "payment", "coins", "sale"],
     "char": "💰",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "credit_card": {
     "keywords": ["money", "sales", "dollar", "bill", "payment", "shopping"],
     "char": "💳",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "gem": {
     "keywords": ["blue", "ruby", "diamond", "jewelry"],
     "char": "💎",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "scales": {
     "keywords": ["law", "fairness", "weight"],
     "char": "⚖",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "wrench": {
     "keywords": ["tools", "diy", "ikea", "fix", "maintainer"],
     "char": "🔧",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hammer": {
     "keywords": ["tools", "build", "create"],
     "char": "🔨",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hammer_and_pick": {
     "keywords": ["tools", "build", "create"],
     "char": "⚒",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hammer_and_wrench": {
     "keywords": ["tools", "build", "create"],
     "char": "🛠",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pick": {
     "keywords": ["tools", "dig"],
     "char": "⛏",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "nut_and_bolt": {
     "keywords": ["handy", "tools", "fix"],
     "char": "🔩",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "gear": {
     "keywords": ["cog"],
     "char": "⚙",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "chains": {
     "keywords": ["lock", "arrest"],
     "char": "⛓",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "gun": {
     "keywords": ["violence", "weapon", "pistol", "revolver"],
     "char": "🔫",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bomb": {
     "keywords": ["boom", "explode", "explosion", "terrorism"],
     "char": "💣",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hocho": {
     "keywords": ["knife", "blade", "cutlery", "kitchen", "weapon"],
     "char": "🔪",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "dagger_knife": {
     "keywords": ["weapon"],
     "char": "🗡",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "crossed_swords": {
     "keywords": ["weapon"],
     "char": "⚔",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "shield": {
     "keywords": ["protection", "security"],
     "char": "🛡",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "smoking": {
     "keywords": ["kills", "tobacco", "cigarette", "joint", "smoke"],
     "char": "🚬",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "skull_and_crossbones": {
     "keywords": ["poison", "danger", "deadly", "scary"],
     "char": "☠",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "coffin": {
     "keywords": ["vampire", "dead", "die", "death", "rip", "graveyard", "cemetery"],
     "char": "⚰",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "funeral_urn": {
     "keywords": ["dead", "die", "death", "rip", "ashes"],
     "char": "⚱",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "amphora": {
     "keywords": ["vase", "jar"],
     "char": "🏺",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "crystal_ball": {
     "keywords": ["disco", "party", "magic", "circus", "fortune_teller"],
     "char": "🔮",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "prayer_beads": {
     "keywords": ["dhikr", "religious"],
     "char": "📿",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "barber": {
     "keywords": ["hair", "salon", "style"],
     "char": "💈",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "alembic": {
     "keywords": ["distilling", "science", "experiment"],
     "char": "⚗",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "telescope": {
     "keywords": ["stars", "space", "zoom"],
     "char": "🔭",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "microscope": {
     "keywords": ["laboratory", "experiment", "zoomin", "science", "study"],
     "char": "🔬",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "hole": {
     "keywords": ["embarrassing"],
     "char": "🕳",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pill": {
     "keywords": ["health", "medicine", "doctor", "pharmacy", "drug"],
     "char": "💊",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "syringe": {
     "keywords": ["health", "hospital", "drugs", "blood", "medicine", "needle", "doctor", "nurse"],
     "char": "💉",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "thermometer": {
     "keywords": ["weather", "temperature", "hot", "cold"],
     "char": "🌡",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "label": {
     "keywords": ["sale", "tag"],
     "char": "🏷",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bookmark": {
     "keywords": ["favorite", "label", "save"],
     "char": "🔖",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "toilet": {
     "keywords": ["restroom", "wc", "washroom", "bathroom", "potty"],
     "char": "🚽",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "shower": {
     "keywords": ["clean", "water", "bathroom"],
     "char": "🚿",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bathtub": {
     "keywords": ["clean", "shower", "bathroom"],
     "char": "🛁",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "key": {
     "keywords": ["lock", "door", "password"],
     "char": "🔑",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "old_key": {
     "keywords": ["lock", "door", "password"],
     "char": "🗝",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "couch_and_lamp": {
     "keywords": ["read", "chill"],
     "char": "🛋",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "sleeping_accommodation": {
     "keywords": ["bed", "rest"],
     "char": "🛌",
+    "fitzpatrick_scale": true,
     "category": "objects"
   },
   "bed": {
     "keywords": ["sleep", "rest"],
     "char": "🛏",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "door": {
     "keywords": ["house", "entry", "exit"],
     "char": "🚪",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bellhop_bell": {
     "keywords": ["service"],
     "char": "🛎",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "frame_with_picture": {
     "keywords": ["photography"],
     "char": "🖼",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "world_map": {
     "keywords": ["location", "direction"],
     "char": "🗺",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "umbrella_on_ground": {
     "keywords": ["weather", "summer"],
     "char": "⛱",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "moyai": {
     "keywords": ["rock", "easter island", "moai"],
     "char": "🗿",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "shopping_bags": {
     "keywords": ["mall", "buy", "purchase"],
     "char": "🛍",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "shopping_cart": {
     "keywords": ["trolley"],
     "char": "🛒",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "balloon": {
     "keywords": ["party", "celebration", "birthday", "circus"],
     "char": "🎈",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "flags": {
     "keywords": ["fish", "japanese", "koinobori", "carp", "banner"],
     "char": "🎏",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "ribbon": {
     "keywords": ["decoration", "pink", "girl", "bowtie"],
     "char": "🎀",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "gift": {
     "keywords": ["present", "birthday", "christmas", "xmas"],
     "char": "🎁",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "confetti_ball": {
     "keywords": ["festival", "party", "birthday", "circus"],
     "char": "🎊",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "tada": {
     "keywords": ["party", "contulations", "birthday", "magic", "circus"],
     "char": "🎉",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "dolls": {
     "keywords": ["japanese", "toy", "kimono"],
     "char": "🎎",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "wind_chime": {
     "keywords": ["nature", "ding", "spring", "bell"],
     "char": "🎐",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "crossed_flags": {
     "keywords": ["japanese", "nation", "country", "border"],
     "char": "🎌",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "izakaya_lantern": {
     "keywords": ["light", "paper", "halloween", "spooky"],
     "char": "🏮",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "envelope": {
     "keywords": ["letter", "postal", "inbox", "communication"],
     "char": "✉️",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "envelope_with_arrow": {
     "keywords": ["email", "communication"],
     "char": "📩",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "incoming_envelope": {
     "keywords": ["email", "inbox"],
     "char": "📨",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "email": {
     "keywords": ["communication", "inbox"],
     "char": "📧",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "love_letter": {
     "keywords": ["email", "like", "affection", "envelope", "valentines"],
     "char": "💌",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "postbox": {
     "keywords": ["email", "letter", "envelope"],
     "char": "📮",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mailbox_closed": {
     "keywords": ["email", "communication", "inbox"],
     "char": "📪",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mailbox": {
     "keywords": ["email", "inbox", "communication"],
     "char": "📫",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mailbox_with_mail": {
     "keywords": ["email", "inbox", "communication"],
     "char": "📬",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mailbox_with_no_mail": {
     "keywords": ["email", "inbox"],
     "char": "📭",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "package": {
     "keywords": ["mail", "gift", "cardboard", "box", "moving"],
     "char": "📦",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "postal_horn": {
     "keywords": ["instrument", "music"],
     "char": "📯",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "inbox_tray": {
     "keywords": ["email", "documents"],
     "char": "📥",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "outbox_tray": {
     "keywords": ["inbox", "email"],
     "char": "📤",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "scroll": {
     "keywords": ["documents", "ancient", "history", "paper"],
     "char": "📜",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "page_with_curl": {
     "keywords": ["documents", "office", "paper"],
     "char": "📃",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bookmark_tabs": {
     "keywords": ["favorite", "save", "order", "tidy"],
     "char": "📑",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "bar_chart": {
     "keywords": ["graph", "presentation", "stats"],
     "char": "📊",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "chart_with_upwards_trend": {
     "keywords": ["graph", "presentation", "stats", "recovery", "business", "economics", "money", "sales", "good", "success"],
     "char": "📈",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "chart_with_downwards_trend": {
     "keywords": ["graph", "presentation", "stats", "recession", "business", "economics", "money", "sales", "bad", "failure"],
     "char": "📉",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "page_facing_up": {
     "keywords": ["documents", "office", "paper", "information"],
     "char": "📄",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "date": {
     "keywords": ["calendar", "schedule"],
     "char": "📅",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "calendar": {
     "keywords": ["schedule", "date", "planning"],
     "char": "📆",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "spiral_calendar_pad": {
     "keywords": ["date", "schedule", "planning"],
     "char": "🗓",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "card_index": {
     "keywords": ["business", "stationery"],
     "char": "📇",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "card_file_box": {
     "keywords": ["business", "stationery"],
     "char": "🗃",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "ballot_box_with_ballot": {
     "keywords": ["election", "vote"],
     "char": "🗳",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "file_cabinet": {
     "keywords": ["filing", "organizing"],
     "char": "🗄",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "clipboard": {
     "keywords": ["stationery", "documents"],
     "char": "📋",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "spiral_note_pad": {
     "keywords": ["memo", "stationery"],
     "char": "🗒",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "file_folder": {
     "keywords": ["documents", "business", "office"],
     "char": "📁",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "open_file_folder": {
     "keywords": ["documents", "load"],
     "char": "📂",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "card_index_dividers": {
     "keywords": ["organizing", "business", "stationery"],
     "char": "🗂",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "rolled_up_newspaper": {
     "keywords": ["press", "headline"],
     "char": "🗞",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "newspaper": {
     "keywords": ["press", "headline"],
     "char": "📰",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "notebook": {
     "keywords": ["stationery", "record", "notes", "paper", "study"],
     "char": "📓",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "closed_book": {
     "keywords": ["read", "library", "knowledge", "textbook", "learn"],
     "char": "📕",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "green_book": {
     "keywords": ["read", "library", "knowledge", "study"],
     "char": "📗",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "blue_book": {
     "keywords": ["read", "library", "knowledge", "learn", "study"],
     "char": "📘",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "orange_book": {
     "keywords": ["read", "library", "knowledge", "textbook", "study"],
     "char": "📙",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "notebook_with_decorative_cover": {
     "keywords": ["classroom", "notes", "record", "paper", "study"],
     "char": "📔",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "ledger": {
     "keywords": ["notes", "paper"],
     "char": "📒",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "books": {
     "keywords": ["literature", "library", "study"],
     "char": "📚",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "book": {
     "keywords": ["open_book", "read", "library", "knowledge", "literature", "learn", "study"],
     "char": "📖",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "link": {
     "keywords": ["rings", "url"],
     "char": "🔗",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "paperclip": {
     "keywords": ["documents", "stationery"],
     "char": "📎",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "linked_paperclips": {
     "keywords": ["documents", "stationery"],
     "char": "🖇",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "scissors": {
     "keywords": ["stationery", "cut"],
     "char": "✂️",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "triangular_ruler": {
     "keywords": ["stationery", "math", "architect", "sketch"],
     "char": "📐",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "straight_ruler": {
     "keywords": ["stationery", "calculate", "length", "math", "school", "drawing", "architect", "sketch"],
     "char": "📏",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pushpin": {
     "keywords": ["stationery", "mark", "here"],
     "char": "📌",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "round_pushpin": {
     "keywords": ["stationery", "location", "map", "here"],
     "char": "📍",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "triangular_flag_on_post": {
     "keywords": ["mark", "milestone", "place"],
     "char": "🚩",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "waving_white_flag": {
     "keywords": ["losing", "loser", "lost", "surrender", "give up", "fail"],
     "char": "🏳",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "waving_black_flag": {
     "keywords": ["pirate"],
     "char": "🏴",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "rainbow_flag": {
     "keywords": ["flag", "rainbow"],
     "char": "🏳️‍🌈",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "closed_lock_with_key": {
     "keywords": ["security", "privacy"],
     "char": "🔐",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lock": {
     "keywords": ["security", "password", "padlock"],
     "char": "🔒",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "unlock": {
     "keywords": ["privacy", "security"],
     "char": "🔓",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lock_with_ink_pen": {
     "keywords": ["security", "secret"],
     "char": "🔏",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lower_left_ballpoint_pen": {
     "keywords": ["stationery", "writing", "write"],
     "char": "🖊",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lower_left_fountain_pen": {
     "keywords": ["stationery", "writing", "write"],
     "char": "🖋",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "black_nib": {
     "keywords": ["pen", "stationery", "writing", "write"],
     "char": "✒️",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "memo": {
     "keywords": ["write", "documents", "stationery", "pencil", "paper", "writing", "legal", "exam", "quiz", "test", "study"],
     "char": "📝",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "pencil2": {
     "keywords": ["stationery", "write", "paper", "writing", "school", "study"],
     "char": "✏️",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lower_left_crayon": {
     "keywords": ["drawing", "creativity"],
     "char": "🖍",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "lower_left_paintbrush": {
     "keywords": ["drawing", "creativity", "art"],
     "char": "🖌",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mag": {
     "keywords": ["search", "zoom", "find", "detective"],
     "char": "🔍",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "mag_right": {
     "keywords": ["search", "zoom", "find", "detective"],
     "char": "🔎",
+    "fitzpatrick_scale": false,
     "category": "objects"
   },
   "heart": {
     "keywords": ["love", "like", "valentines"],
     "char": "❤️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "yellow_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "green_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💚",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "blue_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💙",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "purple_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💜",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_heart": {
     "keywords": ["evil"],
     "char": "🖤",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "broken_heart": {
     "keywords": ["sad", "sorry", "break", "heart", "heartbreak"],
     "char": "💔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_heart_exclamation_mark_ornament": {
     "keywords": ["decoration", "love"],
     "char": "❣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "two_hearts": {
     "keywords": ["love", "like", "affection", "valentines", "heart"],
     "char": "💕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "revolving_hearts": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💞",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heartbeat": {
     "keywords": ["love", "like", "affection", "valentines", "pink", "heart"],
     "char": "💓",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heartpulse": {
     "keywords": ["like", "love", "affection", "valentines", "pink"],
     "char": "💗",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sparkling_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💖",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cupid": {
     "keywords": ["love", "like", "heart", "affection", "valentines"],
     "char": "💘",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "gift_heart": {
     "keywords": ["love", "valentines"],
     "char": "💝",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heart_decoration": {
     "keywords": ["purple-square", "love", "like"],
     "char": "💟",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "peace_symbol": {
     "keywords": ["hippie"],
     "char": "☮",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "latin_cross": {
     "keywords": ["christianity"],
     "char": "✝",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "star_and_crescent": {
     "keywords": ["islam"],
     "char": "☪",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "om_symbol": {
     "keywords": ["hinduism", "buddhism", "sikhism", "jainism"],
     "char": "🕉",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "wheel_of_dharma": {
     "keywords": ["hinduism", "buddhism", "sikhism", "jainism"],
     "char": "☸",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "star_of_david": {
     "keywords": ["judaism"],
     "char": "✡",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "six_pointed_star": {
     "keywords": ["purple-square", "religion", "jewish", "hexagram"],
     "char": "🔯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "menorah_with_nine_branches": {
     "keywords": ["hanukkah", "candles", "jewish"],
     "char": "🕎",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "yin_yang": {
     "keywords": ["balance"],
     "char": "☯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "orthodox_cross": {
     "keywords": ["suppedaneum", "religion"],
     "char": "☦",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "place_of_worship": {
     "keywords": ["religion", "church", "temple", "prayer"],
     "char": "🛐",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ophiuchus": {
     "keywords": ["sign", "purple-square", "constellation", "astrology"],
     "char": "⛎",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "aries": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♈",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "taurus": {
     "keywords": ["purple-square", "sign", "zodiac", "astrology"],
     "char": "♉",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "gemini": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♊",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cancer": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♋",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "leo": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♌",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "virgo": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♍",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "libra": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♎",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "scorpius": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology", "scorpio"],
     "char": "♏",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sagittarius": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♐",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "capricorn": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♑",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "aquarius": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♒",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "pisces": {
     "keywords": ["purple-square", "sign", "zodiac", "astrology"],
     "char": "♓",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "id": {
     "keywords": ["purple-square", "words"],
     "char": "🆔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "atom_symbol": {
     "keywords": ["science"],
     "char": "⚛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u7a7a": {
     "keywords": ["kanji", "japanese", "chinese", "empty", "sky", "blue-square"],
     "char": "🈳",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u5272": {
     "keywords": ["cut", "divide", "chinese", "kanji", "pink-square"],
     "char": "🈹",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "radioactive_sign": {
     "keywords": ["nuclear", "danger"],
     "char": "☢",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "biohazard_sign": {
     "keywords": ["danger"],
     "char": "☣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "mobile_phone_off": {
     "keywords": ["mute", "orange-square", "silence", "quiet"],
     "char": "📴",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "vibration_mode": {
     "keywords": ["orange-square", "phone"],
     "char": "📳",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u6709": {
     "keywords": ["orange-square", "chinese", "have", "kanji"],
     "char": "🈶",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u7121": {
     "keywords": ["nothing", "chinese", "kanji", "japanese", "orange-square"],
     "char": "🈚",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u7533": {
     "keywords": ["chinese", "japanese", "kanji", "orange-square"],
     "char": "🈸",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u55b6": {
     "keywords": ["japanese", "opening hours", "orange-square"],
     "char": "🈺",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u6708": {
     "keywords": ["chinese", "month", "moon", "japanese", "orange-square", "kanji"],
     "char": "🈷️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "eight_pointed_black_star": {
     "keywords": ["orange-square", "shape", "polygon"],
     "char": "✴️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "vs": {
     "keywords": ["words", "orange-square"],
     "char": "🆚",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "accept": {
     "keywords": ["ok", "good", "chinese", "kanji", "agree", "yes", "orange-circle"],
     "char": "🉑",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_flower": {
     "keywords": ["japanese", "spring"],
     "char": "💮",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ideograph_advantage": {
     "keywords": ["chinese", "kanji", "obtain", "get", "circle"],
     "char": "🉐",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "secret": {
     "keywords": ["privacy", "chinese", "sshh", "kanji", "red-circle"],
     "char": "㊙️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "congratulations": {
     "keywords": ["chinese", "kanji", "japanese", "red-circle"],
     "char": "㊗️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u5408": {
     "keywords": ["japanese", "chinese", "join", "kanji", "red-square"],
     "char": "🈴",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u6e80": {
     "keywords": ["full", "chinese", "japanese", "red-square", "kanji"],
     "char": "🈵",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u7981": {
     "keywords": ["kanji", "japanese", "chinese", "forbidden", "limit", "restricted", "red-square"],
     "char": "🈲",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "a": {
     "keywords": ["red-square", "alphabet", "letter"],
     "char": "🅰️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "b": {
     "keywords": ["red-square", "alphabet", "letter"],
     "char": "🅱️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ab": {
     "keywords": ["red-square", "alphabet"],
     "char": "🆎",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cl": {
     "keywords": ["alphabet", "words", "red-square"],
     "char": "🆑",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "o2": {
     "keywords": ["alphabet", "red-square", "letter"],
     "char": "🅾️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sos": {
     "keywords": ["help", "red-square", "words", "emergency", "911"],
     "char": "🆘",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_entry": {
     "keywords": ["limit", "security", "privacy", "bad", "denied", "stop", "circle"],
     "char": "⛔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "name_badge": {
     "keywords": ["fire", "forbid"],
     "char": "📛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_entry_sign": {
     "keywords": ["forbid", "stop", "limit", "denied", "disallow", "circle"],
     "char": "🚫",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "x": {
     "keywords": ["no", "delete", "remove", "cancel"],
     "char": "❌",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "o": {
     "keywords": ["circle", "round"],
     "char": "⭕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "octagonal_sign": {
     "keywords": ["stop"],
     "char": "🛑",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "anger": {
     "keywords": ["angry", "mad"],
     "char": "💢",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "hotsprings": {
     "keywords": ["bath", "warm", "relax"],
     "char": "♨️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_pedestrians": {
     "keywords": ["rules", "crossing", "walking", "circle"],
     "char": "🚷",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "do_not_litter": {
     "keywords": ["trash", "bin", "garbage", "circle"],
     "char": "🚯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_bicycles": {
     "keywords": ["cyclist", "prohibited", "circle"],
     "char": "🚳",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "non-potable_water": {
     "keywords": ["drink", "faucet", "tap", "circle"],
     "char": "🚱",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "underage": {
     "keywords": ["18", "drink", "pub", "night", "minor", "circle"],
     "char": "🔞",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_mobile_phones": {
     "keywords": ["iphone", "mute", "circle"],
     "char": "📵",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "exclamation": {
     "keywords": ["heavy_exclamation_mark", "danger", "surprise", "punctuation", "wow", "warning"],
     "char": "❗",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "grey_exclamation": {
     "keywords": ["surprise", "punctuation", "gray", "wow", "warning"],
     "char": "❕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "question": {
     "keywords": ["doubt", "confused"],
     "char": "❓",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "grey_question": {
     "keywords": ["doubts", "gray", "huh", "confused"],
     "char": "❔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "bangbang": {
     "keywords": ["exclamation", "surprise"],
     "char": "‼️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "interrobang": {
     "keywords": ["wat", "punctuation", "surprise"],
     "char": "⁉️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
    "100": {
     "keywords": ["score", "perfect", "numbers", "century", "exam", "quiz", "test", "pass", "hundred"],
     "char": "💯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "low_brightness": {
     "keywords": ["sun", "afternoon", "warm", "summer"],
     "char": "🔅",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "high_brightness": {
     "keywords": ["sun", "light"],
     "char": "🔆",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "trident": {
     "keywords": ["weapon", "spear"],
     "char": "🔱",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "fleur_de_lis": {
     "keywords": ["decorative", "scout"],
     "char": "⚜",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "part_alternation_mark": {
     "keywords": ["graph", "presentation", "stats", "business", "economics", "bad"],
     "char": "〽️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "warning": {
     "keywords": ["exclamation", "wip", "alert", "error", "problem", "issue"],
     "char": "⚠️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "children_crossing": {
     "keywords": ["school", "warning", "danger", "sign", "driving", "yellow-diamond"],
     "char": "🚸",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "beginner": {
     "keywords": ["badge", "shield"],
     "char": "🔰",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "recycle": {
     "keywords": ["arrow", "environment", "garbage", "trash"],
     "char": "♻️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "u6307": {
     "keywords": ["chinese", "point", "green-square", "kanji"],
     "char": "🈯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "chart": {
     "keywords": ["green-square", "graph", "presentation", "stats"],
     "char": "💹",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sparkle": {
     "keywords": ["stars", "green-square", "awesome", "good", "fireworks"],
     "char": "❇️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "eight_spoked_asterisk": {
     "keywords": ["star", "sparkle", "green-square"],
     "char": "✳️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "negative_squared_cross_mark": {
     "keywords": ["x", "green-square", "no", "deny"],
     "char": "❎",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_check_mark": {
     "keywords": ["green-square", "ok", "agree", "vote", "election", "answer"],
     "char": "✅",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "diamond_shape_with_a_dot_inside": {
     "keywords": ["jewel", "blue", "gem", "crystal", "fancy"],
     "char": "💠",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cyclone": {
     "keywords": ["weather", "swirl", "blue", "cloud", "vortex", "spiral", "whirlpool", "spin"],
     "char": "🌀",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "loop": {
     "keywords": ["tape", "cassette"],
     "char": "➿",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "globe_with_meridians": {
     "keywords": ["earth", "international", "world", "internet", "interweb", "i18n"],
     "char": "🌐",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "m": {
     "keywords": ["alphabet", "blue-circle", "letter"],
     "char": "Ⓜ️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "atm": {
     "keywords": ["money", "sales", "cash", "blue-square", "payment", "bank"],
     "char": "🏧",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sa": {
     "keywords": ["japanese", "blue-square", "katakana"],
     "char": "🈂️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "passport_control": {
     "keywords": ["custom", "blue-square"],
     "char": "🛂",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "customs": {
     "keywords": ["passport", "border", "blue-square"],
     "char": "🛃",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "baggage_claim": {
     "keywords": ["blue-square", "airport", "transport"],
     "char": "🛄",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "left_luggage": {
     "keywords": ["blue-square", "travel"],
     "char": "🛅",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "wheelchair": {
     "keywords": ["blue-square", "disabled", "a11y", "accessibility"],
     "char": "♿",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_smoking": {
     "keywords": ["cigarette", "blue-square", "smell", "smoke"],
     "char": "🚭",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "wc": {
     "keywords": ["toilet", "restroom", "blue-square"],
     "char": "🚾",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "parking": {
     "keywords": ["cars", "blue-square", "alphabet", "letter"],
     "char": "🅿️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "potable_water": {
     "keywords": ["blue-square", "liquid", "restroom", "cleaning", "faucet"],
     "char": "🚰",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "mens": {
     "keywords": ["toilet", "restroom", "wc", "blue-square", "gender", "male"],
     "char": "🚹",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "womens": {
     "keywords": ["purple-square", "woman", "female", "toilet", "loo", "restroom", "gender"],
     "char": "🚺",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "baby_symbol": {
     "keywords": ["orange-square", "child"],
     "char": "🚼",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "restroom": {
     "keywords": ["blue-square", "toilet", "refresh", "wc", "gender"],
     "char": "🚻",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "put_litter_in_its_place": {
     "keywords": ["blue-square", "sign", "human", "info"],
     "char": "🚮",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cinema": {
     "keywords": ["blue-square", "record", "film", "movie", "curtain", "stage", "theater"],
     "char": "🎦",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "signal_strength": {
     "keywords": ["blue-square", "reception", "phone", "internet", "connection", "wifi", "bluetooth", "bars"],
     "char": "📶",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "koko": {
     "keywords": ["blue-square", "here", "katakana", "japanese", "destination"],
     "char": "🈁",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ng": {
     "keywords": ["blue-square", "words", "shape", "icon"],
     "char": "🆖",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ok": {
     "keywords": ["good", "agree", "yes", "blue-square"],
     "char": "🆗",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "up": {
     "keywords": ["blue-square", "above", "high"],
     "char": "🆙",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "cool": {
     "keywords": ["words", "blue-square"],
     "char": "🆒",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "new": {
     "keywords": ["blue-square", "words", "start"],
     "char": "🆕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "free": {
     "keywords": ["blue-square", "words"],
     "char": "🆓",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "zero": {
     "keywords": ["0", "numbers", "blue-square", "null"],
     "char": "0️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "one": {
     "keywords": ["blue-square", "numbers", "1"],
     "char": "1️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "two": {
     "keywords": ["numbers", "2", "prime", "blue-square"],
     "char": "2️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "three": {
     "keywords": ["3", "numbers", "prime", "blue-square"],
     "char": "3️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "four": {
     "keywords": ["4", "numbers", "blue-square"],
     "char": "4️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "five": {
     "keywords": ["5", "numbers", "blue-square", "prime"],
     "char": "5️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "six": {
     "keywords": ["6", "numbers", "blue-square"],
     "char": "6️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "seven": {
     "keywords": ["7", "numbers", "blue-square", "prime"],
     "char": "7️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "eight": {
     "keywords": ["8", "blue-square", "numbers"],
     "char": "8️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "nine": {
     "keywords": ["blue-square", "numbers", "9"],
     "char": "9️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "keycap_ten": {
     "keywords": ["numbers", "10", "blue-square"],
     "char": "🔟",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "keycap_star": {
     "keywords": ["asterisk"],
     "char": "*⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "1234": {
     "keywords": ["numbers", "blue-square"],
     "char": "🔢",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_forward": {
     "keywords": ["blue-square", "right", "direction", "play"],
     "char": "▶️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "double_vertical_bar": {
     "keywords": ["pause", "blue-square"],
     "char": "⏸",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_right_pointing_triangle_with_double_vertical_bar": {
     "keywords": ["forward", "next", "blue-square"],
     "char": "⏭",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_square_for_stop": {
     "keywords": ["blue-square"],
     "char": "⏹",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_circle_for_record": {
     "keywords": ["blue-square"],
     "char": "⏺",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_right_pointing_double_triangle_with_vertical_bar": {
     "keywords": ["blue-square", "play", "pause"],
     "char": "⏯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_left_pointing_double_triangle_with_vertical_bar": {
     "keywords": ["backward"],
     "char": "⏮",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "fast_forward": {
     "keywords": ["blue-square", "play", "speed", "continue"],
     "char": "⏩",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "rewind": {
     "keywords": ["play", "blue-square"],
     "char": "⏪",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "twisted_rightwards_arrows": {
     "keywords": ["blue-square", "shuffle", "music", "random"],
     "char": "🔀",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "repeat": {
     "keywords": ["loop", "record"],
     "char": "🔁",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "repeat_one": {
     "keywords": ["blue-square", "loop"],
     "char": "🔂",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_backward": {
     "keywords": ["blue-square", "left", "direction"],
     "char": "◀️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_up_small": {
     "keywords": ["blue-square", "triangle", "direction", "point", "forward", "top"],
     "char": "🔼",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_down_small": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "🔽",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_double_up": {
     "keywords": ["blue-square", "direction", "top"],
     "char": "⏫",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_double_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⏬",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_right": {
     "keywords": ["blue-square", "next"],
     "char": "➡️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_left": {
     "keywords": ["blue-square", "previous", "back"],
     "char": "⬅️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_up": {
     "keywords": ["blue-square", "continue", "top", "direction"],
     "char": "⬆️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⬇️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_upper_right": {
     "keywords": ["blue-square", "point", "direction", "diagonal", "northeast"],
     "char": "↗️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_lower_right": {
     "keywords": ["blue-square", "direction", "diagonal", "southeast"],
     "char": "↘️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_lower_left": {
     "keywords": ["blue-square", "direction", "diagonal", "southwest"],
     "char": "↙️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_upper_left": {
     "keywords": ["blue-square", "point", "direction", "diagonal", "northwest"],
     "char": "↖️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_up_down": {
     "keywords": ["blue-square", "direction", "way", "vertical"],
     "char": "↕️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "left_right_arrow": {
     "keywords": ["shape", "direction", "horizontal", "sideways"],
     "char": "↔️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrows_counterclockwise": {
     "keywords": ["blue-square", "sync", "cycle"],
     "char": "🔄",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_right_hook": {
     "keywords": ["blue-square", "return", "rotate", "direction"],
     "char": "↪️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "leftwards_arrow_with_hook": {
     "keywords": ["back", "return", "blue-square", "undo", "enter"],
     "char": "↩️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_heading_up": {
     "keywords": ["blue-square", "direction", "top"],
     "char": "⤴️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrow_heading_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⤵️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "hash": {
     "keywords": ["symbol", "blue-square", "twitter"],
     "char": "#️⃣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "information_source": {
     "keywords": ["blue-square", "alphabet", "letter"],
     "char": "ℹ️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "abc": {
     "keywords": ["blue-square", "alphabet"],
     "char": "🔤",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "abcd": {
     "keywords": ["blue-square", "alphabet"],
     "char": "🔡",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "capital_abcd": {
     "keywords": ["alphabet", "words", "blue-square"],
     "char": "🔠",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "symbols": {
     "keywords": ["blue-square", "music", "note", "ampersand", "percent", "glyphs", "characters"],
     "char": "🔣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "musical_note": {
     "keywords": ["score", "tone", "sound"],
     "char": "🎵",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "notes": {
     "keywords": ["music", "score"],
     "char": "🎶",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "wavy_dash": {
     "keywords": ["draw", "line", "moustache", "mustache", "squiggle", "scribble"],
     "char": "〰️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "curly_loop": {
     "keywords": ["scribble", "draw", "shape", "squiggle"],
     "char": "➰",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_check_mark": {
     "keywords": ["ok", "nike", "answer", "yes", "tick"],
     "char": "✔️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "arrows_clockwise": {
     "keywords": ["sync", "cycle", "round", "repeat"],
     "char": "🔃",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_plus_sign": {
     "keywords": ["math", "calculation", "addition", "more", "increase"],
     "char": "➕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_minus_sign": {
     "keywords": ["math", "calculation", "subtract", "less"],
     "char": "➖",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_division_sign": {
     "keywords": ["divide", "math", "calculation"],
     "char": "➗",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_multiplication_x": {
     "keywords": ["math", "calculation"],
     "char": "✖️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "heavy_dollar_sign": {
     "keywords": ["money", "sales", "payment", "currency", "buck"],
     "char": "💲",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "currency_exchange": {
     "keywords": ["money", "sales", "dollar", "travel"],
     "char": "💱",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "copyright": {
     "keywords": ["ip", "license", "circle", "law", "legal"],
     "char": "©️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "registered": {
     "keywords": ["alphabet", "circle"],
     "char": "®️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "tm": {
     "keywords": ["trademark", "brand", "law", "legal"],
     "char": "™️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "end": {
     "keywords": ["words", "arrow"],
     "char": "🔚",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "back": {
     "keywords": ["arrow", "words", "return"],
     "char": "🔙",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "on": {
     "keywords": ["arrow", "words"],
     "char": "🔛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "top": {
     "keywords": ["words", "blue-square"],
     "char": "🔝",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "soon": {
     "keywords": ["arrow", "words"],
     "char": "🔜",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "ballot_box_with_check": {
     "keywords": ["ok", "agree", "confirm", "black-square", "vote", "election", "yes"],
     "char": "☑️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "radio_button": {
     "keywords": ["input", "old", "music", "circle"],
     "char": "🔘",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_circle": {
     "keywords": ["shape", "round"],
     "char": "⚪",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_circle": {
     "keywords": ["shape", "button", "round"],
     "char": "⚫",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "red_circle": {
     "keywords": ["shape", "error", "danger"],
     "char": "🔴",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "large_blue_circle": {
     "keywords": ["shape", "icon", "button"],
     "char": "🔵",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "small_orange_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔸",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "small_blue_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔹",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "large_orange_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔶",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "large_blue_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔷",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "small_red_triangle": {
     "keywords": ["shape", "direction", "up", "top"],
     "char": "🔺",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_small_square": {
     "keywords": ["shape", "icon"],
     "char": "▪️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_small_square": {
     "keywords": ["shape", "icon"],
     "char": "▫️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_large_square": {
     "keywords": ["shape", "icon", "button"],
     "char": "⬛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_large_square": {
     "keywords": ["shape", "icon", "stone", "button"],
     "char": "⬜",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "small_red_triangle_down": {
     "keywords": ["shape", "direction", "bottom"],
     "char": "🔻",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_medium_square": {
     "keywords": ["shape", "button", "icon"],
     "char": "◼️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_medium_square": {
     "keywords": ["shape", "stone", "icon"],
     "char": "◻️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_medium_small_square": {
     "keywords": ["icon", "shape", "button"],
     "char": "◾",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_medium_small_square": {
     "keywords": ["shape", "stone", "icon", "button"],
     "char": "◽",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_square_button": {
     "keywords": ["shape", "input", "frame"],
     "char": "🔲",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "white_square_button": {
     "keywords": ["shape", "input"],
     "char": "🔳",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "speaker": {
     "keywords": ["sound", "volume", "silence", "broadcast"],
     "char": "🔈",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "sound": {
     "keywords": ["volume", "speaker", "broadcast"],
     "char": "🔉",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "loud_sound": {
     "keywords": ["volume", "noise", "noisy", "speaker", "broadcast"],
     "char": "🔊",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "mute": {
     "keywords": ["sound", "volume", "silence", "quiet"],
     "char": "🔇",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "mega": {
     "keywords": ["sound", "speaker", "volume"],
     "char": "📣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "loudspeaker": {
     "keywords": ["volume", "sound"],
     "char": "📢",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "bell": {
     "keywords": ["sound", "notification", "christmas", "xmas", "chime"],
     "char": "🔔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "no_bell": {
     "keywords": ["sound", "volume", "mute", "quiet", "silent"],
     "char": "🔕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "black_joker": {
     "keywords": ["poker", "cards", "game", "play", "magic"],
     "char": "🃏",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "mahjong": {
     "keywords": ["game", "play", "chinese", "kanji"],
     "char": "🀄",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "spades": {
     "keywords": ["poker", "cards", "suits", "magic"],
     "char": "♠️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clubs": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♣️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "hearts": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♥️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "diamonds": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♦️",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "flower_playing_cards": {
     "keywords": ["game", "sunset", "red"],
     "char": "🎴",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "thought_balloon": {
     "keywords": ["bubble", "cloud", "speech", "thinking"],
     "char": "💭",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "right_anger_bubble": {
     "keywords": ["caption", "speech", "thinking", "mad"],
     "char": "🗯",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "speech_balloon": {
     "keywords": ["bubble", "words", "message", "talk", "chatting"],
     "char": "💬",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "left_speech_bubble": {
     "keywords": ["words", "message", "talk", "chatting"],
     "char": "🗨",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock1": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕐",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock2": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕑",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock3": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕒",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock4": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕓",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock5": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕔",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock6": {
     "keywords": ["time", "late", "early", "schedule", "dawn", "dusk"],
     "char": "🕕",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock7": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕖",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock8": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕗",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock9": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕘",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock10": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕙",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock11": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕚",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock12": {
     "keywords": ["time", "noon", "midnight", "midday", "late", "early", "schedule"],
     "char": "🕛",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock130": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕜",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock230": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕝",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock330": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕞",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock430": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕟",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock530": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕠",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock630": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕡",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock730": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕢",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock830": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕣",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock930": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕤",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock1030": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕥",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock1130": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕦",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "clock1230": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕧",
+    "fitzpatrick_scale": false,
     "category": "symbols"
   },
   "af": {
     "keywords": ["afghanistan", "flag", "nation", "country", "banner"],
     "char": "🇦🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ax": {
     "keywords": ["Åland", "islands", "flag", "nation", "country", "banner"],
     "char": "🇦🇽",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "al": {
     "keywords": ["albania", "flag", "nation", "country", "banner"],
     "char": "🇦🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "dz": {
     "keywords": ["algeria", "flag", "nation", "country", "banner"],
     "char": "🇩🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "as": {
     "keywords": ["american", "samoa", "flag", "nation", "country", "banner"],
     "char": "🇦🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ad": {
     "keywords": ["andorra", "flag", "nation", "country", "banner"],
     "char": "🇦🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ao": {
     "keywords": ["angola", "flag", "nation", "country", "banner"],
     "char": "🇦🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ai": {
     "keywords": ["anguilla", "flag", "nation", "country", "banner"],
     "char": "🇦🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "aq": {
     "keywords": ["antarctica", "flag", "nation", "country", "banner"],
     "char": "🇦🇶",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ag": {
     "keywords": ["antigua", "barbuda", "flag", "nation", "country", "banner"],
     "char": "🇦🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ar": {
     "keywords": ["argentina", "flag", "nation", "country", "banner"],
     "char": "🇦🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "am": {
     "keywords": ["armenia", "flag", "nation", "country", "banner"],
     "char": "🇦🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "aw": {
     "keywords": ["aruba", "flag", "nation", "country", "banner"],
     "char": "🇦🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "au": {
     "keywords": ["australia", "flag", "nation", "country", "banner"],
     "char": "🇦🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "at": {
     "keywords": ["austria", "flag", "nation", "country", "banner"],
     "char": "🇦🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "az": {
     "keywords": ["azerbaijan", "flag", "nation", "country", "banner"],
     "char": "🇦🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bs": {
     "keywords": ["bahamas", "flag", "nation", "country", "banner"],
     "char": "🇧🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bh": {
     "keywords": ["bahrain", "flag", "nation", "country", "banner"],
     "char": "🇧🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bd": {
     "keywords": ["bangladesh", "flag", "nation", "country", "banner"],
     "char": "🇧🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bb": {
     "keywords": ["barbados", "flag", "nation", "country", "banner"],
     "char": "🇧🇧",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "by": {
     "keywords": ["belarus", "flag", "nation", "country", "banner"],
     "char": "🇧🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "be": {
     "keywords": ["belgium", "flag", "nation", "country", "banner"],
     "char": "🇧🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bz": {
     "keywords": ["belize", "flag", "nation", "country", "banner"],
     "char": "🇧🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bj": {
     "keywords": ["benin", "flag", "nation", "country", "banner"],
     "char": "🇧🇯",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bm": {
     "keywords": ["bermuda", "flag", "nation", "country", "banner"],
     "char": "🇧🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bt": {
     "keywords": ["bhutan", "flag", "nation", "country", "banner"],
     "char": "🇧🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bo": {
     "keywords": ["bolivia", "flag", "nation", "country", "banner"],
     "char": "🇧🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bq": {
     "keywords": ["bonaire", "flag", "nation", "country", "banner"],
     "char": "🇧🇶",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ba": {
     "keywords": ["bosnia", "herzegovina", "flag", "nation", "country", "banner"],
     "char": "🇧🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bw": {
     "keywords": ["botswana", "flag", "nation", "country", "banner"],
     "char": "🇧🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "br": {
     "keywords": ["brazil", "flag", "nation", "country", "banner"],
     "char": "🇧🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "io": {
     "keywords": ["british", "indian", "ocean", "territory", "flag", "nation", "country", "banner"],
     "char": "🇮🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "vg": {
     "keywords": ["british", "virgin", "islands", "bvi", "flag", "nation", "country", "banner"],
     "char": "🇻🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bn": {
     "keywords": ["brunei", "darussalam", "flag", "nation", "country", "banner"],
     "char": "🇧🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bg": {
     "keywords": ["bulgaria", "flag", "nation", "country", "banner"],
     "char": "🇧🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bf": {
     "keywords": ["burkina", "faso", "flag", "nation", "country", "banner"],
     "char": "🇧🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bi": {
     "keywords": ["burundi", "flag", "nation", "country", "banner"],
     "char": "🇧🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cv": {
     "keywords": ["cabo", "verde", "flag", "nation", "country", "banner"],
     "char": "🇨🇻",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kh": {
     "keywords": ["cambodia", "flag", "nation", "country", "banner"],
     "char": "🇰🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cm": {
     "keywords": ["cameroon", "flag", "nation", "country", "banner"],
     "char": "🇨🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ca": {
     "keywords": ["canada", "flag", "nation", "country", "banner"],
     "char": "🇨🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ic": {
     "keywords": ["canary", "islands", "flag", "nation", "country", "banner"],
     "char": "🇮🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ky": {
     "keywords": ["cayman", "islands", "flag", "nation", "country", "banner"],
     "char": "🇰🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cf": {
     "keywords": ["central", "african", "republic", "flag", "nation", "country", "banner"],
     "char": "🇨🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "td": {
     "keywords": ["chad", "flag", "nation", "country", "banner"],
     "char": "🇹🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "chile": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇨🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cn": {
     "keywords": ["china", "chinese", "prc", "flag", "country", "nation", "banner"],
     "char": "🇨🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cx": {
     "keywords": ["christmas", "island", "flag", "nation", "country", "banner"],
     "char": "🇨🇽",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cc": {
     "keywords": ["cocos", "keeling", "islands", "flag", "nation", "country", "banner"],
     "char": "🇨🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "co": {
     "keywords": ["colombia", "flag", "nation", "country", "banner"],
     "char": "🇨🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "km": {
     "keywords": ["comoros", "flag", "nation", "country", "banner"],
     "char": "🇰🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cg": {
     "keywords": ["congo", "flag", "nation", "country", "banner"],
     "char": "🇨🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "drc": {
     "keywords": ["congo", "democratic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇨🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ck": {
     "keywords": ["cook", "islands", "flag", "nation", "country", "banner"],
     "char": "🇨🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cr": {
     "keywords": ["costa", "rica", "flag", "nation", "country", "banner"],
     "char": "🇨🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "hr": {
     "keywords": ["croatia", "flag", "nation", "country", "banner"],
     "char": "🇭🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cu": {
     "keywords": ["cuba", "flag", "nation", "country", "banner"],
     "char": "🇨🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cw": {
     "keywords": ["curaçao", "flag", "nation", "country", "banner"],
     "char": "🇨🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cy": {
     "keywords": ["cyprus", "flag", "nation", "country", "banner"],
     "char": "🇨🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "cz": {
     "keywords": ["czech_republic", "flag", "nation", "country", "banner"],
     "char": "🇨🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "dk": {
     "keywords": ["denmark", "flag", "nation", "country", "banner"],
     "char": "🇩🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "dj": {
     "keywords": ["djibouti", "flag", "nation", "country", "banner"],
     "char": "🇩🇯",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "dm": {
     "keywords": ["dominica", "flag", "nation", "country", "banner"],
     "char": "🇩🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "do": {
     "keywords": ["dominican", "republic", "flag", "nation", "country", "banner"],
     "char": "🇩🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ec": {
     "keywords": ["ecuador", "flag", "nation", "country", "banner"],
     "char": "🇪🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "eg": {
     "keywords": ["egypt", "flag", "nation", "country", "banner"],
     "char": "🇪🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sv": {
     "keywords": ["el", "salvador", "flag", "nation", "country", "banner"],
     "char": "🇸🇻",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gq": {
     "keywords": ["equatorial", "guinea", "flag", "nation", "country", "banner"],
     "char": "🇬🇶",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "er": {
     "keywords": ["eritrea", "flag", "nation", "country", "banner"],
     "char": "🇪🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ee": {
     "keywords": ["estonia", "flag", "nation", "country", "banner"],
     "char": "🇪🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "et": {
     "keywords": ["ethiopia", "flag", "nation", "country", "banner"],
     "char": "🇪🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "eu": {
     "keywords": ["european", "union", "flag", "banner"],
     "char": "🇪🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fk": {
     "keywords": ["falkland", "islands", "malvinas", "flag", "nation", "country", "banner"],
     "char": "🇫🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fo": {
     "keywords": ["faroe", "islands", "flag", "nation", "country", "banner"],
     "char": "🇫🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fj": {
     "keywords": ["fiji", "flag", "nation", "country", "banner"],
     "char": "🇫🇯",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fi": {
     "keywords": ["finland", "flag", "nation", "country", "banner"],
     "char": "🇫🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fr": {
     "keywords": ["banner", "flag", "nation", "france", "french", "country"],
     "char": "🇫🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gf": {
     "keywords": ["french", "guiana", "flag", "nation", "country", "banner"],
     "char": "🇬🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pf": {
     "keywords": ["french", "polynesia", "flag", "nation", "country", "banner"],
     "char": "🇵🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tf": {
     "keywords": ["french", "southern", "territories", "flag", "nation", "country", "banner"],
     "char": "🇹🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ga": {
     "keywords": ["gabon", "flag", "nation", "country", "banner"],
     "char": "🇬🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gm": {
     "keywords": ["gambia", "flag", "nation", "country", "banner"],
     "char": "🇬🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ge": {
     "keywords": ["georgia", "flag", "nation", "country", "banner"],
     "char": "🇬🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "de": {
     "keywords": ["german", "nation", "flag", "country", "banner"],
     "char": "🇩🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gh": {
     "keywords": ["ghana", "flag", "nation", "country", "banner"],
     "char": "🇬🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gi": {
     "keywords": ["gibraltar", "flag", "nation", "country", "banner"],
     "char": "🇬🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gr": {
     "keywords": ["greece", "flag", "nation", "country", "banner"],
     "char": "🇬🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gl": {
     "keywords": ["greenland", "flag", "nation", "country", "banner"],
     "char": "🇬🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gd": {
     "keywords": ["grenada", "flag", "nation", "country", "banner"],
     "char": "🇬🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gp": {
     "keywords": ["guadeloupe", "flag", "nation", "country", "banner"],
     "char": "🇬🇵",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gu": {
     "keywords": ["guam", "flag", "nation", "country", "banner"],
     "char": "🇬🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gt": {
     "keywords": ["guatemala", "flag", "nation", "country", "banner"],
     "char": "🇬🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gg": {
     "keywords": ["guernsey", "flag", "nation", "country", "banner"],
     "char": "🇬🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gn": {
     "keywords": ["guinea", "flag", "nation", "country", "banner"],
     "char": "🇬🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gw": {
     "keywords": ["guinea", "bissau", "flag", "nation", "country", "banner"],
     "char": "🇬🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gy": {
     "keywords": ["guyana", "flag", "nation", "country", "banner"],
     "char": "🇬🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ht": {
     "keywords": ["haiti", "flag", "nation", "country", "banner"],
     "char": "🇭🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "hn": {
     "keywords": ["honduras", "flag", "nation", "country", "banner"],
     "char": "🇭🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "hk": {
     "keywords": ["hong", "kong", "flag", "nation", "country", "banner"],
     "char": "🇭🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "hu": {
     "keywords": ["hungary", "flag", "nation", "country", "banner"],
     "char": "🇭🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "is": {
     "keywords": ["iceland", "flag", "nation", "country", "banner"],
     "char": "🇮🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "in": {
     "keywords": ["india", "flag", "nation", "country", "banner"],
     "char": "🇮🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "indonesia": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇮🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ir": {
     "keywords": ["iran,", "islamic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇮🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "iq": {
     "keywords": ["iraq", "flag", "nation", "country", "banner"],
     "char": "🇮🇶",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ie": {
     "keywords": ["ireland", "flag", "nation", "country", "banner"],
     "char": "🇮🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "im": {
     "keywords": ["isle", "man", "flag", "nation", "country", "banner"],
     "char": "🇮🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "il": {
     "keywords": ["israel", "flag", "nation", "country", "banner"],
     "char": "🇮🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "it": {
     "keywords": ["italy", "flag", "nation", "country", "banner"],
     "char": "🇮🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ci": {
     "keywords": ["ivory", "coast", "flag", "nation", "country", "banner"],
     "char": "🇨🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "jm": {
     "keywords": ["jamaica", "flag", "nation", "country", "banner"],
     "char": "🇯🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "jp": {
     "keywords": ["japanese", "nation", "flag", "country", "banner"],
     "char": "🇯🇵",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "je": {
     "keywords": ["jersey", "flag", "nation", "country", "banner"],
     "char": "🇯🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "jo": {
     "keywords": ["jordan", "flag", "nation", "country", "banner"],
     "char": "🇯🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kz": {
     "keywords": ["kazakhstan", "flag", "nation", "country", "banner"],
     "char": "🇰🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ke": {
     "keywords": ["kenya", "flag", "nation", "country", "banner"],
     "char": "🇰🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ki": {
     "keywords": ["kiribati", "flag", "nation", "country", "banner"],
     "char": "🇰🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "xk": {
     "keywords": ["kosovo", "flag", "nation", "country", "banner"],
     "char": "🇽🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kw": {
     "keywords": ["kuwait", "flag", "nation", "country", "banner"],
     "char": "🇰🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kg": {
     "keywords": ["kyrgyzstan", "flag", "nation", "country", "banner"],
     "char": "🇰🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "la": {
     "keywords": ["lao", "democratic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇱🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lv": {
     "keywords": ["latvia", "flag", "nation", "country", "banner"],
     "char": "🇱🇻",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lb": {
     "keywords": ["lebanon", "flag", "nation", "country", "banner"],
     "char": "🇱🇧",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ls": {
     "keywords": ["lesotho", "flag", "nation", "country", "banner"],
     "char": "🇱🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lr": {
     "keywords": ["liberia", "flag", "nation", "country", "banner"],
     "char": "🇱🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ly": {
     "keywords": ["libya", "flag", "nation", "country", "banner"],
     "char": "🇱🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "li": {
     "keywords": ["liechtenstein", "flag", "nation", "country", "banner"],
     "char": "🇱🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lt": {
     "keywords": ["lithuania", "flag", "nation", "country", "banner"],
     "char": "🇱🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lu": {
     "keywords": ["luxembourg", "flag", "nation", "country", "banner"],
     "char": "🇱🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mo": {
     "keywords": ["macao", "flag", "nation", "country", "banner"],
     "char": "🇲🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mk": {
     "keywords": ["macedonia,", "flag", "nation", "country", "banner"],
     "char": "🇲🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mg": {
     "keywords": ["madagascar", "flag", "nation", "country", "banner"],
     "char": "🇲🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mw": {
     "keywords": ["malawi", "flag", "nation", "country", "banner"],
     "char": "🇲🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "my": {
     "keywords": ["malaysia", "flag", "nation", "country", "banner"],
     "char": "🇲🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mv": {
     "keywords": ["maldives", "flag", "nation", "country", "banner"],
     "char": "🇲🇻",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ml": {
     "keywords": ["mali", "flag", "nation", "country", "banner"],
     "char": "🇲🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mt": {
     "keywords": ["malta", "flag", "nation", "country", "banner"],
     "char": "🇲🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mh": {
     "keywords": ["marshall", "islands", "flag", "nation", "country", "banner"],
     "char": "🇲🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mq": {
     "keywords": ["martinique", "flag", "nation", "country", "banner"],
     "char": "🇲🇶",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mr": {
     "keywords": ["mauritania", "flag", "nation", "country", "banner"],
     "char": "🇲🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mu": {
     "keywords": ["mauritius", "flag", "nation", "country", "banner"],
     "char": "🇲🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "yt": {
     "keywords": ["mayotte", "flag", "nation", "country", "banner"],
     "char": "🇾🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mx": {
     "keywords": ["mexico", "flag", "nation", "country", "banner"],
     "char": "🇲🇽",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "fm": {
     "keywords": ["micronesia,", "federated", "states", "flag", "nation", "country", "banner"],
     "char": "🇫🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "md": {
     "keywords": ["moldova,", "republic", "flag", "nation", "country", "banner"],
     "char": "🇲🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mc": {
     "keywords": ["monaco", "flag", "nation", "country", "banner"],
     "char": "🇲🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mn": {
     "keywords": ["mongolia", "flag", "nation", "country", "banner"],
     "char": "🇲🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "me": {
     "keywords": ["montenegro", "flag", "nation", "country", "banner"],
     "char": "🇲🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ms": {
     "keywords": ["montserrat", "flag", "nation", "country", "banner"],
     "char": "🇲🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ma": {
     "keywords": ["morocco", "flag", "nation", "country", "banner"],
     "char": "🇲🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mz": {
     "keywords": ["mozambique", "flag", "nation", "country", "banner"],
     "char": "🇲🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mm": {
     "keywords": ["myanmar", "flag", "nation", "country", "banner"],
     "char": "🇲🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "na": {
     "keywords": ["namibia", "flag", "nation", "country", "banner"],
     "char": "🇳🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nr": {
     "keywords": ["nauru", "flag", "nation", "country", "banner"],
     "char": "🇳🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "np": {
     "keywords": ["nepal", "flag", "nation", "country", "banner"],
     "char": "🇳🇵",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nl": {
     "keywords": ["netherlands", "flag", "nation", "country", "banner"],
     "char": "🇳🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nc": {
     "keywords": ["new", "caledonia", "flag", "nation", "country", "banner"],
     "char": "🇳🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nz": {
     "keywords": ["new", "zealand", "flag", "nation", "country", "banner"],
     "char": "🇳🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ni": {
     "keywords": ["nicaragua", "flag", "nation", "country", "banner"],
     "char": "🇳🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ne": {
     "keywords": ["niger", "flag", "nation", "country", "banner"],
     "char": "🇳🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nigeria": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇳🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nu": {
     "keywords": ["niue", "flag", "nation", "country", "banner"],
     "char": "🇳🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "nf": {
     "keywords": ["norfolk", "island", "flag", "nation", "country", "banner"],
     "char": "🇳🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "mp": {
     "keywords": ["northern", "mariana", "islands", "flag", "nation", "country", "banner"],
     "char": "🇲🇵",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kp": {
     "keywords": ["north", "korea", "nation", "flag", "country", "banner"],
     "char": "🇰🇵",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "no": {
     "keywords": ["norway", "flag", "nation", "country", "banner"],
     "char": "🇳🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "om": {
     "keywords": ["oman", "flag", "nation", "country", "banner"],
     "char": "🇴🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pk": {
     "keywords": ["pakistan", "flag", "nation", "country", "banner"],
     "char": "🇵🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pw": {
     "keywords": ["palau", "flag", "nation", "country", "banner"],
     "char": "🇵🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ps": {
     "keywords": ["palestine", "palestinian", "territories", "flag", "nation", "country", "banner"],
     "char": "🇵🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pa": {
     "keywords": ["panama", "flag", "nation", "country", "banner"],
     "char": "🇵🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pg": {
     "keywords": ["papua", "new", "guinea", "flag", "nation", "country", "banner"],
     "char": "🇵🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "py": {
     "keywords": ["paraguay", "flag", "nation", "country", "banner"],
     "char": "🇵🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pe": {
     "keywords": ["peru", "flag", "nation", "country", "banner"],
     "char": "🇵🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ph": {
     "keywords": ["philippines", "flag", "nation", "country", "banner"],
     "char": "🇵🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pn": {
     "keywords": ["pitcairn", "flag", "nation", "country", "banner"],
     "char": "🇵🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pl": {
     "keywords": ["poland", "flag", "nation", "country", "banner"],
     "char": "🇵🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pt": {
     "keywords": ["portugal", "flag", "nation", "country", "banner"],
     "char": "🇵🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pr": {
     "keywords": ["puerto", "rico", "flag", "nation", "country", "banner"],
     "char": "🇵🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "qa": {
     "keywords": ["qatar", "flag", "nation", "country", "banner"],
     "char": "🇶🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "re": {
     "keywords": ["réunion", "flag", "nation", "country", "banner"],
     "char": "🇷🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ro": {
     "keywords": ["romania", "flag", "nation", "country", "banner"],
     "char": "🇷🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ru": {
     "keywords": ["russian", "federation", "flag", "nation", "country", "banner"],
     "char": "🇷🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "rw": {
     "keywords": ["rwanda", "flag", "nation", "country", "banner"],
     "char": "🇷🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "bl": {
     "keywords": ["saint", "barthélemy", "flag", "nation", "country", "banner"],
     "char": "🇧🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sh": {
     "keywords": ["saint", "helena", "ascension", "tristan", "cunha", "flag", "nation", "country", "banner"],
     "char": "🇸🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kn": {
     "keywords": ["saint", "kitts", "nevis", "flag", "nation", "country", "banner"],
     "char": "🇰🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lc": {
     "keywords": ["saint", "lucia", "flag", "nation", "country", "banner"],
     "char": "🇱🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "pm": {
     "keywords": ["saint", "pierre", "miquelon", "flag", "nation", "country", "banner"],
     "char": "🇵🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "vc": {
     "keywords": ["saint", "vincent", "grenadines", "flag", "nation", "country", "banner"],
     "char": "🇻🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ws": {
     "keywords": ["samoa", "flag", "nation", "country", "banner"],
     "char": "🇼🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sm": {
     "keywords": ["san", "marino", "flag", "nation", "country", "banner"],
     "char": "🇸🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "st": {
     "keywords": ["sao", "tome", "principe", "flag", "nation", "country", "banner"],
     "char": "🇸🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "saudi_arabia": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇸🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sn": {
     "keywords": ["senegal", "flag", "nation", "country", "banner"],
     "char": "🇸🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "rs": {
     "keywords": ["serbia", "flag", "nation", "country", "banner"],
     "char": "🇷🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sc": {
     "keywords": ["seychelles", "flag", "nation", "country", "banner"],
     "char": "🇸🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sl": {
     "keywords": ["sierra", "leone", "flag", "nation", "country", "banner"],
     "char": "🇸🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sg": {
     "keywords": ["singapore", "flag", "nation", "country", "banner"],
     "char": "🇸🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sx": {
     "keywords": ["sint", "maarten", "dutch", "flag", "nation", "country", "banner"],
     "char": "🇸🇽",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sk": {
     "keywords": ["slovakia", "flag", "nation", "country", "banner"],
     "char": "🇸🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "si": {
     "keywords": ["slovenia", "flag", "nation", "country", "banner"],
     "char": "🇸🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sb": {
     "keywords": ["solomon", "islands", "flag", "nation", "country", "banner"],
     "char": "🇸🇧",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "so": {
     "keywords": ["somalia", "flag", "nation", "country", "banner"],
     "char": "🇸🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "za": {
     "keywords": ["south", "africa", "flag", "nation", "country", "banner"],
     "char": "🇿🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gs": {
     "keywords": ["south", "georgia", "sandwich", "islands", "flag", "nation", "country", "banner"],
     "char": "🇬🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "kr": {
     "keywords": ["south", "korea", "nation", "flag", "country", "banner"],
     "char": "🇰🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ss": {
     "keywords": ["south", "sudan", "flag", "nation", "country", "banner"],
     "char": "🇸🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "es": {
     "keywords": ["spain", "flag", "nation", "country", "banner"],
     "char": "🇪🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "lk": {
     "keywords": ["sri", "lanka", "flag", "nation", "country", "banner"],
     "char": "🇱🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sd": {
     "keywords": ["sudan", "flag", "nation", "country", "banner"],
     "char": "🇸🇩",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sr": {
     "keywords": ["suriname", "flag", "nation", "country", "banner"],
     "char": "🇸🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sz": {
     "keywords": ["swaziland", "flag", "nation", "country", "banner"],
     "char": "🇸🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "se": {
     "keywords": ["sweden", "flag", "nation", "country", "banner"],
     "char": "🇸🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ch": {
     "keywords": ["switzerland", "flag", "nation", "country", "banner"],
     "char": "🇨🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "sy": {
     "keywords": ["syrian", "arab", "republic", "flag", "nation", "country", "banner"],
     "char": "🇸🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tw": {
     "keywords": ["taiwan", "flag", "nation", "country", "banner"],
     "char": "🇹🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tj": {
     "keywords": ["tajikistan", "flag", "nation", "country", "banner"],
     "char": "🇹🇯",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tz": {
     "keywords": ["tanzania,", "united", "republic", "flag", "nation", "country", "banner"],
     "char": "🇹🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "th": {
     "keywords": ["thailand", "flag", "nation", "country", "banner"],
     "char": "🇹🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tl": {
     "keywords": ["timor", "leste", "flag", "nation", "country", "banner"],
     "char": "🇹🇱",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tg": {
     "keywords": ["togo", "flag", "nation", "country", "banner"],
     "char": "🇹🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tk": {
     "keywords": ["tokelau", "flag", "nation", "country", "banner"],
     "char": "🇹🇰",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "to": {
     "keywords": ["tonga", "flag", "nation", "country", "banner"],
     "char": "🇹🇴",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tt": {
     "keywords": ["trinidad", "tobago", "flag", "nation", "country", "banner"],
     "char": "🇹🇹",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tn": {
     "keywords": ["tunisia", "flag", "nation", "country", "banner"],
     "char": "🇹🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tr": {
     "keywords": ["turkey", "flag", "nation", "country", "banner"],
     "char": "🇹🇷",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "turkmenistan": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇹🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tc": {
     "keywords": ["turks", "caicos", "islands", "flag", "nation", "country", "banner"],
     "char": "🇹🇨",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "tuvalu": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇹🇻",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ug": {
     "keywords": ["uganda", "flag", "nation", "country", "banner"],
     "char": "🇺🇬",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ua": {
     "keywords": ["ukraine", "flag", "nation", "country", "banner"],
     "char": "🇺🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ae": {
     "keywords": ["united", "arab", "emirates", "flag", "nation", "country", "banner"],
     "char": "🇦🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "gb": {
     "keywords": ["united", "kingdom", "great", "britain", "northern", "ireland", "flag", "nation", "country", "banner", "british", "UK", "english", "england", "union jack"],
     "char": "🇬🇧",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "us": {
     "keywords": ["united", "states", "america", "flag", "nation", "country", "banner"],
     "char": "🇺🇸",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "vi": {
     "keywords": ["virgin", "islands", "us", "flag", "nation", "country", "banner"],
     "char": "🇻🇮",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "uy": {
     "keywords": ["uruguay", "flag", "nation", "country", "banner"],
     "char": "🇺🇾",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "uz": {
     "keywords": ["uzbekistan", "flag", "nation", "country", "banner"],
     "char": "🇺🇿",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "vu": {
     "keywords": ["vanuatu", "flag", "nation", "country", "banner"],
     "char": "🇻🇺",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "va": {
     "keywords": ["vatican", "city", "flag", "nation", "country", "banner"],
     "char": "🇻🇦",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ve": {
     "keywords": ["venezuela", "bolivarian", "republic", "flag", "nation", "country", "banner"],
     "char": "🇻🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "vn": {
     "keywords": ["viet", "nam", "flag", "nation", "country", "banner"],
     "char": "🇻🇳",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "wf": {
     "keywords": ["wallis", "futuna", "flag", "nation", "country", "banner"],
     "char": "🇼🇫",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "eh": {
     "keywords": ["western", "sahara", "flag", "nation", "country", "banner"],
     "char": "🇪🇭",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "ye": {
     "keywords": ["yemen", "flag", "nation", "country", "banner"],
     "char": "🇾🇪",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "zm": {
     "keywords": ["zambia", "flag", "nation", "country", "banner"],
     "char": "🇿🇲",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "zw": {
     "keywords": ["zimbabwe", "flag", "nation", "country", "banner"],
     "char": "🇿🇼",
+    "fitzpatrick_scale": false,
     "category": "flags"
   },
   "octocat": {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   lib: require('./emojis'),
-  ordered: require('./ordered')
+  ordered: require('./ordered'),
+  fitzpatrick_scale_modifiers: ["🏻", "🏼", "🏽", "🏾", "🏾"]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
   lib: require('./emojis'),
   ordered: require('./ordered'),
-  fitzpatrick_scale_modifiers: ["🏻", "🏼", "🏽", "🏾", "🏾"]
+  fitzpatrick_scale_modifiers: ["🏻", "🏼", "🏽", "🏾", "🏿"]
 }

--- a/test.js
+++ b/test.js
@@ -176,4 +176,24 @@ if (offenses.length > 0) {
   passed()
 }
 
+//
+console.log('TEST: Properties')
+
+var properties = ["keywords", "char", "fitzpatrick_scale", "category"]
+var emojiWithWrongKeys = []
+keys.forEach(function (key) {
+  if (Object.keys(data[key]).join() !== properties.join()) {
+    emojiWithWrongKeys.push(key)
+  }
+})
+if (emojiWithWrongKeys.length > 0) {
+  emojiWithWrongKeys.forEach(function (emoji) {
+    console.log(emoji + ' has keys "' + Object.keys(data[emoji]).join(', ') + '", expect: "' + properties.join(', ') + '"')
+  })
+
+  failed()
+} else {
+  passed()
+}
+
 reveal()


### PR DESCRIPTION
Closes #63. 

This adds a property on every emoji, to indicate if it supports the fitzpatrick scale modifiers, and the actual modifiers can be found with `emoji.fitzpatrick_scale_modifiers`.

```javascript
"raised_hands": {
  "keywords": ["gesture", "hooray", "yea", "celebration", "hands"],
  "char": "🙌",
  "fitzpatrick_scale": true, // here
  "category": "people"
},
```

```javascript
> emoji.fitzpatrick_scale_modifiers
[ '🏻', '🏼', '🏽', '🏾', '🏿' ]
```

To test this out:

```javascript
emoji = require('./index.js')
for (var key of Object.keys(emoji.lib)) {
  if (emoji.lib[key].fitzpatrick_scale) {
    console.log(emoji.fitzpatrick_scale_modifiers.map(modifier => emoji.lib[key].char + modifier).join('  '))
  }
}
```

You should  see this:

![](https://cloud.githubusercontent.com/assets/1153134/22816097/cc0f8176-ef9a-11e6-8294-0c57791af397.png)

**Note: Support of modifiers for each emoji might be different depending on the OS.**

TODO:

- [x] Add a test
- [x] Update readme

cc @msikma @denistsoi