### PR TITLE
Add unicode versions

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -3,8593 +3,10025 @@
     "keywords": ["face", "smile", "happy", "joy", ":D", "grin"],
     "char": "😀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "grimacing": {
     "keywords": ["face", "grimace", "teeth"],
     "char": "😬",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "grin": {
     "keywords": ["face", "happy", "smile", "joy", "kawaii"],
     "char": "😁",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "joy": {
     "keywords": ["face", "cry", "tears", "weep", "happy", "happytears", "haha"],
     "char": "😂",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "rofl": {
     "keywords": ["face", "rolling", "floor", "laughing", "lol", "haha"],
     "char": "🤣",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "smiley": {
     "keywords": ["face", "happy", "joy", "haha", ":D", ":)", "smile", "funny"],
     "char": "😃",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "smile": {
     "keywords": ["face", "happy", "joy", "funny", "haha", "laugh", "like", ":D", ":)"],
     "char": "😄",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "sweat_smile": {
     "keywords": ["face", "hot", "happy", "laugh", "sweat", "smile", "relief"],
     "char": "😅",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "laughing": {
     "keywords": ["happy", "joy", "lol", "satisfied", "haha", "face", "glad", "XD", "laugh"],
     "char": "😆",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "innocent": {
     "keywords": ["face", "angel", "heaven", "halo"],
     "char": "😇",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "wink": {
     "keywords": ["face", "happy", "mischievous", "secret", ";)", "smile", "eye"],
     "char": "😉",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "blush": {
     "keywords": ["face", "smile", "happy", "flushed", "crush", "embarrassed", "shy", "joy"],
     "char": "😊",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "slightly_smiling_face": {
     "keywords": ["face", "smile"],
     "char": "🙂",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "upside_down_face": {
     "keywords": ["face", "flipped", "silly", "smile"],
     "char": "🙃",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "relaxed": {
     "keywords": ["face", "blush", "massage", "happiness"],
     "char": "☺️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "1.1"
   },
   "yum": {
     "keywords": ["happy", "joy", "tongue", "smile", "face", "silly", "yummy", "nom", "delicious", "savouring"],
     "char": "😋",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "relieved": {
     "keywords": ["face", "relaxed", "phew", "massage", "happiness"],
     "char": "😌",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "heart_eyes": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "crush", "heart"],
     "char": "😍",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "kissing_heart": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "kiss"],
     "char": "😘",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "kissing": {
     "keywords": ["love", "like", "face", "3", "valentines", "infatuation", "kiss"],
     "char": "😗",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "kissing_smiling_eyes": {
     "keywords": ["face", "affection", "valentines", "infatuation", "kiss"],
     "char": "😙",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "kissing_closed_eyes": {
     "keywords": ["face", "love", "like", "affection", "valentines", "infatuation", "kiss"],
     "char": "😚",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "stuck_out_tongue_winking_eye": {
     "keywords": ["face", "prank", "childish", "playful", "mischievous", "smile", "wink", "tongue"],
     "char": "😜",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "stuck_out_tongue_closed_eyes": {
     "keywords": ["face", "prank", "playful", "mischievous", "smile", "tongue"],
     "char": "😝",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "stuck_out_tongue": {
     "keywords": ["face", "prank", "childish", "playful", "mischievous", "smile", "tongue"],
     "char": "😛",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "money_mouth_face": {
     "keywords": ["face", "rich", "dollar", "money"],
     "char": "🤑",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "nerd_face": {
     "keywords": ["face", "nerdy", "geek", "dork"],
     "char": "🤓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "sunglasses": {
     "keywords": ["face", "cool", "smile", "summer", "beach", "sunglass"],
     "char": "😎",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "clown_face": {
     "keywords": ["face"],
     "char": "🤡",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "cowboy_hat_face": {
     "keywords": ["face", "cowgirl", "hat"],
     "char": "🤠",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "hugs": {
     "keywords": ["face", "smile", "hug"],
     "char": "🤗",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "smirk": {
     "keywords": ["face", "smile", "mean", "prank", "smug", "sarcasm"],
     "char": "😏",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "no_mouth": {
     "keywords": ["face", "hellokitty"],
     "char": "😶",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "neutral_face": {
     "keywords": ["indifference", "meh", ":|", "neutral"],
     "char": "😐",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "expressionless": {
     "keywords": ["face", "indifferent", "-_-", "meh", "deadpan"],
     "char": "😑",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "unamused": {
     "keywords": ["indifference", "bored", "straight face", "serious", "sarcasm"],
     "char": "😒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "roll_eyes": {
     "keywords": ["face", "eyeroll", "frustrated"],
     "char": "🙄",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "thinking": {
     "keywords": ["face", "hmmm", "think", "consider"],
     "char": "🤔",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "lying_face": {
     "keywords": ["face", "lie", "pinocchio"],
     "char": "🤥",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "flushed": {
     "keywords": ["face", "blush", "shy", "flattered"],
     "char": "😳",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "disappointed": {
     "keywords": ["face", "sad", "upset", "depressed", ":("],
     "char": "😞",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "worried": {
     "keywords": ["face", "concern", "nervous", ":("],
     "char": "😟",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "angry": {
     "keywords": ["mad", "face", "annoyed", "frustrated"],
     "char": "😠",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "rage": {
     "keywords": ["angry", "mad", "hate", "despise"],
     "char": "😡",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pensive": {
     "keywords": ["face", "sad", "depressed", "okay", "upset"],
     "char": "😔",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "confused": {
     "keywords": ["face", "indifference", "huh", "weird", "hmmm", ":/"],
     "char": "😕",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "slightly_frowning_face": {
     "keywords": ["face", "frowning", "disappointed", "sad", "upset"],
     "char": "🙁",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "frowning_face": {
     "keywords": ["face", "sad", "upset", "frown"],
     "char": "☹",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "1.1"
   },
   "persevere": {
     "keywords": ["face", "sick", "no", "upset", "oops"],
     "char": "😣",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "confounded": {
     "keywords": ["face", "confused", "sick", "unwell", "oops", ":S"],
     "char": "😖",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "tired_face": {
     "keywords": ["sick", "whine", "upset", "frustrated"],
     "char": "😫",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "weary": {
     "keywords": ["face", "tired", "sleepy", "sad", "frustrated", "upset"],
     "char": "😩",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "triumph": {
     "keywords": ["face", "gas", "phew", "proud", "pride"],
     "char": "😤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "open_mouth": {
     "keywords": ["face", "surprise", "impressed", "wow", "whoa", ":O"],
     "char": "😮",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "scream": {
     "keywords": ["face", "munch", "scared", "omg"],
     "char": "😱",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "fearful": {
     "keywords": ["face", "scared", "terrified", "nervous", "oops", "huh"],
     "char": "😨",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "cold_sweat": {
     "keywords": ["face", "nervous", "sweat"],
     "char": "😰",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "hushed": {
     "keywords": ["face", "woo", "shh"],
     "char": "😯",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "frowning": {
     "keywords": ["face", "aw", "what"],
     "char": "😦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "anguished": {
     "keywords": ["face", "stunned", "nervous"],
     "char": "😧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "cry": {
     "keywords": ["face", "tears", "sad", "depressed", "upset", ":'("],
     "char": "😢",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "disappointed_relieved": {
     "keywords": ["face", "phew", "sweat", "nervous"],
     "char": "😥",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "drooling_face": {
     "keywords": ["face"],
     "char": "🤤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "sleepy": {
     "keywords": ["face", "tired", "rest", "nap"],
     "char": "😪",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "sweat": {
     "keywords": ["face", "hot", "sad", "tired", "exercise"],
     "char": "😓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "sob": {
     "keywords": ["face", "cry", "tears", "sad", "upset", "depressed"],
     "char": "😭",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dizzy_face": {
     "keywords": ["spent", "unconscious", "xox", "dizzy"],
     "char": "😵",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "astonished": {
     "keywords": ["face", "xox", "surprised", "poisoned"],
     "char": "😲",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "zipper_mouth_face": {
     "keywords": ["face", "sealed", "zipper", "secret"],
     "char": "🤐",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "nauseated_face": {
     "keywords": ["face", "vomit", "gross", "green", "sick", "throw up", "ill"],
     "char": "🤢",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "sneezing_face": {
     "keywords": ["face", "gesundheit", "sneeze", "sick", "allergy"],
     "char": "🤧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "mask": {
     "keywords": ["face", "sick", "ill", "disease"],
     "char": "😷",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "face_with_thermometer": {
     "keywords": ["sick", "temperature", "thermometer", "cold", "fever"],
     "char": "🤒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "face_with_head_bandage": {
     "keywords": ["injured", "clumsy", "bandage", "hurt"],
     "char": "🤕",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "sleeping": {
     "keywords": ["face", "tired", "sleepy", "night", "zzz"],
     "char": "😴",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.1"
   },
   "zzz": {
     "keywords": ["sleepy", "tired", "dream"],
     "char": "💤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "poop": {
     "keywords": ["hankey", "shitface", "fail", "turd", "shit"],
     "char": "💩",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "smiling_imp": {
     "keywords": ["devil", "horns"],
     "char": "😈",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "imp": {
     "keywords": ["devil", "angry", "horns"],
     "char": "👿",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "japanese_ogre": {
     "keywords": ["monster", "red", "mask", "halloween", "scary", "creepy", "devil", "demon", "japanese", "ogre"],
     "char": "👹",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "japanese_goblin": {
     "keywords": ["red", "evil", "mask", "monster", "scary", "creepy", "japanese", "goblin"],
     "char": "👺",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "skull": {
     "keywords": ["dead", "skeleton", "creepy", "death"],
     "char": "💀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "ghost": {
     "keywords": ["halloween", "spooky", "scary"],
     "char": "👻",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "alien": {
     "keywords": ["UFO", "paul", "weird", "outer_space"],
     "char": "👽",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "robot": {
     "keywords": ["computer", "machine", "bot"],
     "char": "🤖",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "smiley_cat": {
     "keywords": ["animal", "cats", "happy", "smile"],
     "char": "😺",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "smile_cat": {
     "keywords": ["animal", "cats", "smile"],
     "char": "😸",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "joy_cat": {
     "keywords": ["animal", "cats", "haha", "happy", "tears"],
     "char": "😹",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "heart_eyes_cat": {
     "keywords": ["animal", "love", "like", "affection", "cats", "valentines", "heart"],
     "char": "😻",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "smirk_cat": {
     "keywords": ["animal", "cats", "smirk"],
     "char": "😼",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "kissing_cat": {
     "keywords": ["animal", "cats", "kiss"],
     "char": "😽",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "scream_cat": {
     "keywords": ["animal", "cats", "munch", "scared", "scream"],
     "char": "🙀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "crying_cat_face": {
     "keywords": ["animal", "tears", "weep", "sad", "cats", "upset", "cry"],
     "char": "😿",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pouting_cat": {
     "keywords": ["animal", "cats"],
     "char": "😾",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "raised_hands": {
     "keywords": ["gesture", "hooray", "yea", "celebration", "hands"],
     "char": "🙌",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "clap": {
     "keywords": ["hands", "praise", "applause", "congrats", "yay"],
     "char": "👏",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "wave": {
     "keywords": ["hands", "gesture", "goodbye", "solong", "farewell", "hello", "hi", "palm"],
     "char": "👋",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "call_me_hand": {
     "keywords": ["hands", "gesture"],
     "char": "🤙",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "+1": {
     "keywords": ["thumbsup", "yes", "awesome", "good", "agree", "accept", "cool", "hand", "like"],
     "char": "👍",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "-1": {
     "keywords": ["thumbsdown", "no", "dislike", "hand"],
     "char": "👎",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "facepunch": {
     "keywords": ["angry", "violence", "fist", "hit", "attack", "hand"],
     "char": "👊",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "fist": {
     "keywords": ["fingers", "hand", "grasp"],
     "char": "✊",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "fist_left": {
     "keywords": ["hand", "fistbump"],
     "char": "🤛",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "fist_right": {
     "keywords": ["hand", "fistbump"],
     "char": "🤜",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "v": {
     "keywords": ["fingers", "ohyeah", "hand", "peace", "victory", "two"],
     "char": "✌",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "1.1"
   },
   "ok_hand": {
     "keywords": ["fingers", "limbs", "perfect", "ok"],
     "char": "👌",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "raised_hand": {
     "keywords": ["fingers", "stop", "highfive", "palm", "ban"],
     "char": "✋",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "raised_back_of_hand": {
     "keywords": ["fingers", "raised", "backhand"],
     "char": "🤚",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "open_hands": {
     "keywords": ["fingers", "butterfly", "hands", "open"],
     "char": "👐",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "muscle": {
     "keywords": ["arm", "flex", "hand", "summer", "strong", "biceps"],
     "char": "💪",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pray": {
     "keywords": ["please", "hope", "wish", "namaste", "highfive"],
     "char": "🙏",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "handshake": {
     "keywords": ["agreement", "shake"],
     "char": "🤝",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "point_up": {
     "keywords": ["hand", "fingers", "direction", "up"],
     "char": "☝",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "1.1"
   },
   "point_up_2": {
     "keywords": ["fingers", "hand", "direction", "up"],
     "char": "👆",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "point_down": {
     "keywords": ["fingers", "hand", "direction", "down"],
     "char": "👇",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "point_left": {
     "keywords": ["direction", "fingers", "hand", "left"],
     "char": "👈",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "point_right": {
     "keywords": ["fingers", "hand", "direction", "right"],
     "char": "👉",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "fu": {
     "keywords": ["hand", "fingers", "rude", "middle", "flipping"],
     "char": "🖕",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "raised_hand_with_fingers_splayed": {
     "keywords": ["hand", "fingers", "palm"],
     "char": "🖐",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "metal": {
     "keywords": ["hand", "fingers", "evil_eye", "sign_of_horns", "rock_on"],
     "char": "🤘",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "8.0"
   },
   "crossed_fingers": {
     "keywords": ["good", "lucky"],
     "char": "🤞",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "vulcan_salute": {
     "keywords": ["hand", "fingers", "spock", "star trek"],
     "char": "🖖",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "writing_hand": {
     "keywords": ["lower_left_ballpoint_pen", "stationery", "write", "compose"],
     "char": "✍",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "1.1"
   },
   "selfie": {
     "keywords": ["camera", "phone"],
     "char": "🤳",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "nail_care": {
     "keywords": ["beauty", "manicure", "finger", "fashion", "nail"],
     "char": "💅",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "lips": {
     "keywords": ["mouth", "kiss"],
     "char": "👄",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "tongue": {
     "keywords": ["mouth", "playful"],
     "char": "👅",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "ear": {
     "keywords": ["face", "hear", "sound", "listen"],
     "char": "👂",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "nose": {
     "keywords": ["smell", "sniff"],
     "char": "👃",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "eye": {
     "keywords": ["face", "look", "see", "watch", "stare"],
     "char": "👁",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "eyes": {
     "keywords": ["look", "watch", "stalk", "peek", "see"],
     "char": "👀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "bust_in_silhouette": {
     "keywords": ["user", "person", "human"],
     "char": "👤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "busts_in_silhouette": {
     "keywords": ["user", "person", "human", "group", "team"],
     "char": "👥",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "speaking_head": {
     "keywords": ["user", "person", "human", "sing", "say", "talk"],
     "char": "🗣",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "baby": {
     "keywords": ["child", "boy", "girl", "toddler"],
     "char": "👶",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "boy": {
     "keywords": ["man", "male", "guy", "teenager"],
     "char": "👦",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "girl": {
     "keywords": ["female", "woman", "teenager"],
     "char": "👧",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man": {
     "keywords": ["mustache", "father", "dad", "guy", "classy", "sir", "moustache"],
     "char": "👨",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "woman": {
     "keywords": ["female", "girls", "lady"],
     "char": "👩",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "blonde_woman": {
     "keywords": ["woman", "female", "girl", "blonde", "person"],
     "char": "👱‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "blonde_man": {
     "keywords": ["man", "male", "boy", "blonde", "guy", "person"],
     "char": "👱",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "older_man": {
     "keywords": ["human", "male", "men", "old", "elder", "senior"],
     "char": "👴",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "older_woman": {
     "keywords": ["human", "female", "women", "lady", "old", "elder", "senior"],
     "char": "👵",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man_with_gua_pi_mao": {
     "keywords": ["male", "boy", "chinese"],
     "char": "👲",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "woman_with_turban": {
     "keywords": ["female", "indian", "hinduism", "arabs", "woman"],
     "char": "👳‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man_with_turban": {
     "keywords": ["male", "indian", "hinduism", "arabs"],
     "char": "👳",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "policewoman": {
     "keywords": ["woman", "police", "law", "legal", "enforcement", "arrest", "911", "female"],
     "char": "👮‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "policeman": {
     "keywords": ["man", "police", "law", "legal", "enforcement", "arrest", "911"],
     "char": "👮",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "construction_worker_woman": {
     "keywords": ["female", "human", "wip", "build", "construction", "worker", "labor", "woman"],
     "char": "👷‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "construction_worker_man": {
     "keywords": ["male", "human", "wip", "guy", "build", "construction", "worker", "labor"],
     "char": "👷",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "guardswoman": {
     "keywords": ["uk", "gb", "british", "female", "royal", "woman"],
     "char": "💂‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "guardsman": {
     "keywords": ["uk", "gb", "british", "male", "guy", "royal"],
     "char": "💂",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "female_detective": {
     "keywords": ["human", "spy", "detective", "female", "woman"],
     "char": "🕵️‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "male_detective": {
     "keywords": ["human", "spy", "detective"],
     "char": "🕵",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "woman_health_worker": {
     "keywords": ["doctor", "nurse", "therapist", "healthcare", "woman", "human"],
     "char": "👩‍⚕️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_health_worker": {
     "keywords": ["doctor", "nurse", "therapist", "healthcare", "man", "human"],
     "char": "👨‍⚕️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_farmer": {
     "keywords": ["rancher", "gardener", "woman", "human"],
     "char": "👩‍🌾",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_farmer": {
     "keywords": ["rancher", "gardener", "man", "human"],
     "char": "👨‍🌾",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_cook": {
     "keywords": ["chef", "woman", "human"],
     "char": "👩‍🍳",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_cook": {
     "keywords": ["chef", "man", "human"],
     "char": "👨‍🍳",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_student": {
     "keywords": ["graduate", "woman", "human"],
     "char": "👩‍🎓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_student": {
     "keywords": ["graduate", "man", "human"],
     "char": "👨‍🎓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_singer": {
     "keywords": ["rockstar", "entertainer", "woman", "human"],
     "char": "👩‍🎤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_singer": {
     "keywords": ["rockstar", "entertainer", "man", "human"],
     "char": "👨‍🎤",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_teacher": {
     "keywords": ["instructor", "professor", "woman", "human"],
     "char": "👩‍🏫",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_teacher": {
     "keywords": ["instructor", "professor", "man", "human"],
     "char": "👨‍🏫",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_factory_worker": {
     "keywords": ["assembly", "industrial", "woman", "human"],
     "char": "👩‍🏭",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_factory_worker": {
     "keywords": ["assembly", "industrial", "man", "human"],
     "char": "👨‍🏭",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_technologist": {
     "keywords": ["coder", "developer", "engineer", "programmer", "software", "woman", "human", "laptop", "computer"],
     "char": "👩‍💻",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_technologist": {
     "keywords": ["coder", "developer", "engineer", "programmer", "software", "man", "human", "laptop", "computer"],
     "char": "👨‍💻",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_office_worker": {
     "keywords": ["business", "manager", "woman", "human"],
     "char": "👩‍💼",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_office_worker": {
     "keywords": ["business", "manager", "man", "human"],
     "char": "👨‍💼",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_mechanic": {
     "keywords": ["plumber", "woman", "human", "wrench"],
     "char": "👩‍🔧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_mechanic": {
     "keywords": ["plumber", "man", "human", "wrench"],
     "char": "👨‍🔧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_scientist": {
     "keywords": ["biologist", "chemist", "engineer", "physicist", "woman", "human"],
     "char": "👩‍🔬",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_scientist": {
     "keywords": ["biologist", "chemist", "engineer", "physicist", "man", "human"],
     "char": "👨‍🔬",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_artist": {
     "keywords": ["painter", "woman", "human"],
     "char": "👩‍🎨",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_artist": {
     "keywords": ["painter", "man", "human"],
     "char": "👨‍🎨",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_firefighter": {
     "keywords": ["fireman", "woman", "human"],
     "char": "👩‍🚒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_firefighter": {
     "keywords": ["fireman", "man", "human"],
     "char": "👨‍🚒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_pilot": {
     "keywords": ["aviator", "plane", "woman", "human"],
     "char": "👩‍✈️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_pilot": {
     "keywords": ["aviator", "plane", "man", "human"],
     "char": "👨‍✈️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_astronaut": {
     "keywords": ["space", "rocket", "woman", "human"],
     "char": "👩‍🚀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_astronaut": {
     "keywords": ["space", "rocket", "man", "human"],
     "char": "👨‍🚀",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "woman_judge": {
     "keywords": ["justice", "court", "woman", "human"],
     "char": "👩‍⚖️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "man_judge": {
     "keywords": ["justice", "court", "man", "human"],
     "char": "👨‍⚖️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": ""
   },
   "mrs_claus": {
     "keywords": ["woman", "female", "xmas", "mother christmas"],
     "char": "🤶",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "santa": {
     "keywords": ["festival", "man", "male", "xmas", "father christmas"],
     "char": "🎅",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "angel": {
     "keywords": ["heaven", "wings", "halo"],
     "char": "👼",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pregnant_woman": {
     "keywords": ["baby"],
     "char": "🤰",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "princess": {
     "keywords": ["girl", "woman", "female", "blond", "crown", "royal", "queen"],
     "char": "👸",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "prince": {
     "keywords": ["boy", "man", "male", "crown", "royal", "king"],
     "char": "🤴",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "bride_with_veil": {
     "keywords": ["couple", "marriage", "wedding", "woman", "bride"],
     "char": "👰",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man_in_tuxedo": {
     "keywords": ["couple", "marriage", "wedding", "groom"],
     "char": "🤵",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "running_woman": {
     "keywords": ["woman", "walking", "exercise", "race", "running", "female"],
     "char": "🏃‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "running_man": {
     "keywords": ["man", "walking", "exercise", "race", "running"],
     "char": "🏃",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "walking_woman": {
     "keywords": ["human", "feet", "steps", "woman", "female"],
     "char": "🚶‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "walking_man": {
     "keywords": ["human", "feet", "steps"],
     "char": "🚶",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dancer": {
     "keywords": ["female", "girl", "woman", "fun"],
     "char": "💃",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man_dancing": {
     "keywords": ["male", "boy", "fun", "dancer"],
     "char": "🕺",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "dancing_women": {
     "keywords": ["female", "bunny", "women", "girls"],
     "char": "👯",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dancing_men": {
     "keywords": ["male", "bunny", "men", "boys"],
     "char": "👯‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couple": {
     "keywords": ["pair", "people", "human", "love", "date", "dating", "like", "affection", "valentines", "marriage"],
     "char": "👫",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "two_men_holding_hands": {
     "keywords": ["pair", "couple", "love", "like", "bromance", "friendship", "people", "human"],
     "char": "👬",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "two_women_holding_hands": {
     "keywords": ["pair", "friendship", "couple", "love", "like", "female", "people", "human"],
     "char": "👭",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "bowing_woman": {
     "keywords": ["woman", "female", "girl"],
     "char": "🙇‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "bowing_man": {
     "keywords": ["man", "male", "boy"],
     "char": "🙇",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "man_facepalming": {
     "keywords": ["man", "male", "boy", "disbelief"],
     "char": "🤦",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "woman_facepalming": {
     "keywords": ["woman", "female", "girl", "disbelief"],
     "char": "🤦‍♀️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "woman_shrugging": {
     "keywords": ["woman", "female", "girl", "confused", "indifferent", "doubt"],
     "char": "🤷",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "man_shrugging": {
     "keywords": ["man", "male", "boy", "confused", "indifferent", "doubt"],
     "char": "🤷‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "9.0"
   },
   "tipping_hand_woman": {
     "keywords": ["female", "girl", "woman", "human", "information"],
     "char": "💁",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "tipping_hand_man": {
     "keywords": ["male", "boy", "man", "human", "information"],
     "char": "💁‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "no_good_woman": {
     "keywords": ["female", "girl", "woman", "nope"],
     "char": "🙅",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "no_good_man": {
     "keywords": ["male", "boy", "man", "nope"],
     "char": "🙅‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "ok_woman": {
     "keywords": ["women", "girl", "female", "pink", "human", "woman"],
     "char": "🙆",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "ok_man": {
     "keywords": ["men", "boy", "male", "blue", "human", "man"],
     "char": "🙆‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "raising_hand_woman": {
     "keywords": ["female", "girl", "woman"],
     "char": "🙋",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "raising_hand_man": {
     "keywords": ["male", "boy", "man"],
     "char": "🙋‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pouting_woman": {
     "keywords": ["female", "girl", "woman"],
     "char": "🙎",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pouting_man": {
     "keywords": ["male", "boy", "man"],
     "char": "🙎‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "frowning_woman": {
     "keywords": ["female", "girl", "woman", "sad", "depressed", "discouraged", "unhappy"],
     "char": "🙍",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "frowning_man": {
     "keywords": ["male", "boy", "man", "sad", "depressed", "discouraged", "unhappy"],
     "char": "🙍‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "haircut_woman": {
     "keywords": ["female", "girl", "woman"],
     "char": "💇",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "haircut_man": {
     "keywords": ["male", "boy", "man"],
     "char": "💇‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "massage_woman": {
     "keywords": ["female", "girl", "woman", "head"],
     "char": "💆",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "massage_man": {
     "keywords": ["male", "boy", "man", "head"],
     "char": "💆‍♂️",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couple_with_heart_woman_man": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "💑",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couple_with_heart_woman_woman": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "👩‍❤️‍👩",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couple_with_heart_man_man": {
     "keywords": ["pair", "love", "like", "affection", "human", "dating", "valentines", "marriage"],
     "char": "👨‍❤️‍👨",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couplekiss_man_woman": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "💏",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couplekiss_woman_woman": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "👩‍❤️‍💋‍👩",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "couplekiss_man_man": {
     "keywords": ["pair", "valentines", "love", "like", "dating", "marriage"],
     "char": "👨‍❤️‍💋‍👨",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_woman_boy": {
     "keywords": ["home", "parents", "child", "mom", "dad", "father", "mother", "people", "human"],
     "char": "👪",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_woman_girl": {
     "keywords": ["home", "parents", "people", "human", "child"],
     "char": "👨‍👩‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_woman_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👧‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_woman_boy_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👦‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_woman_girl_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👩‍👧‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_woman_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_woman_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_woman_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_woman_boy_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👦‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_woman_girl_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👩‍👩‍👧‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_man_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_man_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_man_girl_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_man_boy_boy": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👦‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_man_girl_girl": {
     "keywords": ["home", "parents", "people", "human", "children"],
     "char": "👨‍👨‍👧‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_boy": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👩‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_girl": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👩‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_girl_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👧‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_boy_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👦‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_woman_girl_girl": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👩‍👧‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_boy": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👨‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_girl": {
     "keywords": ["home", "parent", "people", "human", "child"],
     "char": "👨‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_girl_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👧‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_boy_boy": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👦‍👦",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "family_man_girl_girl": {
     "keywords": ["home", "parent", "people", "human", "children"],
     "char": "👨‍👧‍👧",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "womans_clothes": {
     "keywords": ["fashion", "shopping_bags", "female"],
     "char": "👚",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "tshirt": {
     "keywords": ["fashion", "cloth", "casual", "shirt", "tee"],
     "char": "👕",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "jeans": {
     "keywords": ["fashion", "shopping"],
     "char": "👖",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "necktie": {
     "keywords": ["shirt", "suitup", "formal", "fashion", "cloth", "business"],
     "char": "👔",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dress": {
     "keywords": ["clothes", "fashion", "shopping"],
     "char": "👗",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "bikini": {
     "keywords": ["swimming", "female", "woman", "girl", "fashion", "beach", "summer"],
     "char": "👙",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "kimono": {
     "keywords": ["dress", "fashion", "women", "female", "japanese"],
     "char": "👘",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "lipstick": {
     "keywords": ["female", "girl", "fashion", "woman"],
     "char": "💄",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "kiss": {
     "keywords": ["face", "lips", "love", "like", "affection", "valentines"],
     "char": "💋",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "footprints": {
     "keywords": ["feet", "tracking", "walking", "beach"],
     "char": "👣",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "high_heel": {
     "keywords": ["fashion", "shoes", "female", "pumps", "stiletto"],
     "char": "👠",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "sandal": {
     "keywords": ["shoes", "fashion", "flip flops"],
     "char": "👡",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "boot": {
     "keywords": ["shoes", "fashion"],
     "char": "👢",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "mans_shoe": {
     "keywords": ["fashion", "male"],
     "char": "👞",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "athletic_shoe": {
     "keywords": ["shoes", "sports", "sneakers"],
     "char": "👟",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "womans_hat": {
     "keywords": ["fashion", "accessories", "female", "lady", "spring"],
     "char": "👒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "tophat": {
     "keywords": ["magic", "gentleman", "classy", "circus"],
     "char": "🎩",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "rescue_worker_helmet": {
     "keywords": ["construction", "build"],
     "char": "⛑",
     "fitzpatrick_scale": true,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "5.2"
   },
   "mortar_board": {
     "keywords": ["school", "college", "degree", "university", "graduation", "cap", "hat", "legal", "learn", "education"],
     "char": "🎓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "crown": {
     "keywords": ["king", "kod", "leader", "royalty", "lord"],
     "char": "👑",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "school_satchel": {
     "keywords": ["student", "education", "bag", "backpack"],
     "char": "🎒",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "pouch": {
     "keywords": ["bag", "accessories", "shopping"],
     "char": "👝",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "purse": {
     "keywords": ["fashion", "accessories", "money", "sales", "shopping"],
     "char": "👛",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "handbag": {
     "keywords": ["fashion", "accessory", "accessories", "shopping"],
     "char": "👜",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "briefcase": {
     "keywords": ["business", "documents", "work", "law", "legal"],
     "char": "💼",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "eyeglasses": {
     "keywords": ["fashion", "accessories", "eyesight", "nerdy", "dork", "geek"],
     "char": "👓",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dark_sunglasses": {
     "keywords": ["face", "cool", "accessories"],
     "char": "🕶",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "7.0"
   },
   "ring": {
     "keywords": ["wedding", "propose", "marriage", "valentines", "diamond", "fashion", "jewelry", "gem", "engagement"],
     "char": "💍",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "closed_umbrella": {
     "keywords": ["weather", "rain", "drizzle"],
     "char": "🌂",
     "fitzpatrick_scale": false,
-    "category": "people"
+    "category": "people",
+    "unicode_version": "6.0"
   },
   "dog": {
     "keywords": ["animal", "friend", "nature", "woof", "puppy", "pet", "faithful"],
     "char": "🐶",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "cat": {
     "keywords": ["animal", "meow", "nature", "pet", "kitten"],
     "char": "🐱",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "mouse": {
     "keywords": ["animal", "nature", "cheese_wedge", "rodent"],
     "char": "🐭",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "hamster": {
     "keywords": ["animal", "nature"],
     "char": "🐹",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rabbit": {
     "keywords": ["animal", "nature", "pet", "spring", "magic", "bunny"],
     "char": "🐰",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "fox_face": {
     "keywords": ["animal", "nature", "face"],
     "char": "🦊",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "bear": {
     "keywords": ["animal", "nature", "wild"],
     "char": "🐻",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "panda_face": {
     "keywords": ["animal", "nature", "panda"],
     "char": "🐼",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "koala": {
     "keywords": ["animal", "nature"],
     "char": "🐨",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "tiger": {
     "keywords": ["animal", "cat", "danger", "wild", "nature", "roar"],
     "char": "🐯",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "lion": {
     "keywords": ["animal", "nature"],
     "char": "🦁",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "8.0"
   },
   "cow": {
     "keywords": ["beef", "ox", "animal", "nature", "moo", "milk"],
     "char": "🐮",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "pig": {
     "keywords": ["animal", "oink", "nature"],
     "char": "🐷",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "pig_nose": {
     "keywords": ["animal", "oink"],
     "char": "🐽",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "frog": {
     "keywords": ["animal", "nature", "croak", "toad"],
     "char": "🐸",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "squid": {
     "keywords": ["animal", "nature", "ocean", "sea"],
     "char": "🦑",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "octopus": {
     "keywords": ["animal", "creature", "ocean", "sea", "nature", "beach"],
     "char": "🐙",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "shrimp": {
     "keywords": ["animal", "ocean", "nature", "seafood"],
     "char": "🦐",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "monkey_face": {
     "keywords": ["animal", "nature", "circus"],
     "char": "🐵",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "gorilla": {
     "keywords": ["animal", "nature", "circus"],
     "char": "🦍",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "see_no_evil": {
     "keywords": ["monkey", "animal", "nature", "haha"],
     "char": "🙈",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "hear_no_evil": {
     "keywords": ["animal", "monkey", "nature"],
     "char": "🙉",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "speak_no_evil": {
     "keywords": ["monkey", "animal", "nature", "omg"],
     "char": "🙊",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "monkey": {
     "keywords": ["animal", "nature", "banana", "circus"],
     "char": "🐒",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "chicken": {
     "keywords": ["animal", "cluck", "nature", "bird"],
     "char": "🐔",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "penguin": {
     "keywords": ["animal", "nature"],
     "char": "🐧",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "bird": {
     "keywords": ["animal", "nature", "fly", "tweet", "spring"],
     "char": "🐦",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "baby_chick": {
     "keywords": ["animal", "chicken", "bird"],
     "char": "🐤",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "hatching_chick": {
     "keywords": ["animal", "chicken", "egg", "born", "baby", "bird"],
     "char": "🐣",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "hatched_chick": {
     "keywords": ["animal", "chicken", "baby", "bird"],
     "char": "🐥",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "duck": {
     "keywords": ["animal", "nature", "bird", "mallard"],
     "char": "🦆",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "eagle": {
     "keywords": ["animal", "nature", "bird"],
     "char": "🦅",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "owl": {
     "keywords": ["animal", "nature", "bird", "hoot"],
     "char": "🦉",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "bat": {
     "keywords": ["animal", "nature", "blind", "vampire"],
     "char": "🦇",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "wolf": {
     "keywords": ["animal", "nature", "wild"],
     "char": "🐺",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "boar": {
     "keywords": ["animal", "nature"],
     "char": "🐗",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "horse": {
     "keywords": ["animal", "brown", "nature"],
     "char": "🐴",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "unicorn": {
     "keywords": ["animal", "nature", "mystical"],
     "char": "🦄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "8.0"
   },
   "honeybee": {
     "keywords": ["animal", "insect", "nature", "bug", "spring", "honey"],
     "char": "🐝",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "bug": {
     "keywords": ["animal", "insect", "nature", "worm"],
     "char": "🐛",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "butterfly": {
     "keywords": ["animal", "insect", "nature", "caterpillar"],
     "char": "🦋",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "snail": {
     "keywords": ["slow", "animal", "shell"],
     "char": "🐌",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "beetle": {
     "keywords": ["animal", "insect", "nature", "ladybug"],
     "char": "🐞",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "ant": {
     "keywords": ["animal", "insect", "nature", "bug"],
     "char": "🐜",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "spider": {
     "keywords": ["animal", "arachnid"],
     "char": "🕷",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "scorpion": {
     "keywords": ["animal", "arachnid"],
     "char": "🦂",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "8.0"
   },
   "crab": {
     "keywords": ["animal", "crustacean"],
     "char": "🦀",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "8.0"
   },
   "snake": {
     "keywords": ["animal", "evil", "nature", "hiss", "python"],
     "char": "🐍",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "lizard": {
     "keywords": ["animal", "nature", "reptile"],
     "char": "🦎",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "turtle": {
     "keywords": ["animal", "slow", "nature", "tortoise"],
     "char": "🐢",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "tropical_fish": {
     "keywords": ["animal", "swim", "ocean", "beach", "nemo"],
     "char": "🐠",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "fish": {
     "keywords": ["animal", "food", "nature"],
     "char": "🐟",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "blowfish": {
     "keywords": ["animal", "nature", "food", "sea", "ocean"],
     "char": "🐡",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "dolphin": {
     "keywords": ["animal", "nature", "fish", "sea", "ocean", "flipper", "fins", "beach"],
     "char": "🐬",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "shark": {
     "keywords": ["animal", "nature", "fish", "sea", "ocean", "jaws", "fins", "beach"],
     "char": "🦈",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "whale": {
     "keywords": ["animal", "nature", "sea", "ocean"],
     "char": "🐳",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "whale2": {
     "keywords": ["animal", "nature", "sea", "ocean"],
     "char": "🐋",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "crocodile": {
     "keywords": ["animal", "nature", "reptile", "lizard", "alligator"],
     "char": "🐊",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "leopard": {
     "keywords": ["animal", "nature"],
     "char": "🐆",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "tiger2": {
     "keywords": ["animal", "nature", "roar"],
     "char": "🐅",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "water_buffalo": {
     "keywords": ["animal", "nature", "ox", "cow"],
     "char": "🐃",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "ox": {
     "keywords": ["animal", "cow", "beef"],
     "char": "🐂",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "cow2": {
     "keywords": ["beef", "ox", "animal", "nature", "moo", "milk"],
     "char": "🐄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "deer": {
     "keywords": ["animal", "nature", "horns", "venison"],
     "char": "🦌",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "dromedary_camel": {
     "keywords": ["animal", "hot", "desert", "hump"],
     "char": "🐪",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "camel": {
     "keywords": ["animal", "nature", "hot", "desert", "hump"],
     "char": "🐫",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "elephant": {
     "keywords": ["animal", "nature", "nose", "th", "circus"],
     "char": "🐘",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rhinoceros": {
     "keywords": ["animal", "nature", "horn"],
     "char": "🦏",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "goat": {
     "keywords": ["animal", "nature"],
     "char": "🐐",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "ram": {
     "keywords": ["animal", "sheep", "nature"],
     "char": "🐏",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "sheep": {
     "keywords": ["animal", "nature", "wool", "shipit"],
     "char": "🐑",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "racehorse": {
     "keywords": ["animal", "gamble", "luck"],
     "char": "🐎",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "pig2": {
     "keywords": ["animal", "nature"],
     "char": "🐖",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rat": {
     "keywords": ["animal", "mouse", "rodent"],
     "char": "🐀",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "mouse2": {
     "keywords": ["animal", "nature", "rodent"],
     "char": "🐁",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rooster": {
     "keywords": ["animal", "nature", "chicken"],
     "char": "🐓",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "turkey": {
     "keywords": ["animal", "bird"],
     "char": "🦃",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "8.0"
   },
   "dove": {
     "keywords": ["animal", "bird"],
     "char": "🕊",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "dog2": {
     "keywords": ["animal", "nature", "friend", "doge", "pet", "faithful"],
     "char": "🐕",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "poodle": {
     "keywords": ["dog", "animal", "101", "nature", "pet"],
     "char": "🐩",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "cat2": {
     "keywords": ["animal", "meow", "pet", "cats"],
     "char": "🐈",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rabbit2": {
     "keywords": ["animal", "nature", "pet", "magic", "spring"],
     "char": "🐇",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "chipmunk": {
     "keywords": ["animal", "nature", "rodent", "squirrel"],
     "char": "🐿",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "paw_prints": {
     "keywords": ["animal", "tracking", "footprints", "dog", "cat", "pet", "feet"],
     "char": "🐾",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "dragon": {
     "keywords": ["animal", "myth", "nature", "chinese", "green"],
     "char": "🐉",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "dragon_face": {
     "keywords": ["animal", "myth", "nature", "chinese", "green"],
     "char": "🐲",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "cactus": {
     "keywords": ["vegetable", "plant", "nature"],
     "char": "🌵",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "christmas_tree": {
     "keywords": ["festival", "vacation", "december", "xmas", "celebration"],
     "char": "🎄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "evergreen_tree": {
     "keywords": ["plant", "nature"],
     "char": "🌲",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "deciduous_tree": {
     "keywords": ["plant", "nature"],
     "char": "🌳",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "palm_tree": {
     "keywords": ["plant", "vegetable", "nature", "summer", "beach", "mojito", "tropical"],
     "char": "🌴",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "seedling": {
     "keywords": ["plant", "nature", "grass", "lawn", "spring"],
     "char": "🌱",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "herb": {
     "keywords": ["vegetable", "plant", "medicine", "weed", "grass", "lawn"],
     "char": "🌿",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "shamrock": {
     "keywords": ["vegetable", "plant", "nature", "irish", "clover"],
     "char": "☘",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "4.1"
   },
   "four_leaf_clover": {
     "keywords": ["vegetable", "plant", "nature", "lucky", "irish"],
     "char": "🍀",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "bamboo": {
     "keywords": ["plant", "nature", "vegetable", "panda", "pine_decoration"],
     "char": "🎍",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "tanabata_tree": {
     "keywords": ["plant", "nature", "branch", "summer"],
     "char": "🎋",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "leaves": {
     "keywords": ["nature", "plant", "tree", "vegetable", "grass", "lawn", "spring"],
     "char": "🍃",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "fallen_leaf": {
     "keywords": ["nature", "plant", "vegetable", "leaves"],
     "char": "🍂",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "maple_leaf": {
     "keywords": ["nature", "plant", "vegetable", "ca", "fall"],
     "char": "🍁",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "ear_of_rice": {
     "keywords": ["nature", "plant"],
     "char": "🌾",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "hibiscus": {
     "keywords": ["plant", "vegetable", "flowers", "beach"],
     "char": "🌺",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "sunflower": {
     "keywords": ["nature", "plant", "fall"],
     "char": "🌻",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "rose": {
     "keywords": ["flowers", "valentines", "love", "spring"],
     "char": "🌹",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "wilted_flower": {
     "keywords": ["plant", "nature", "flower"],
     "char": "🥀",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "9.0"
   },
   "tulip": {
     "keywords": ["flowers", "plant", "nature", "summer", "spring"],
     "char": "🌷",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "blossom": {
     "keywords": ["nature", "flowers", "yellow"],
     "char": "🌼",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "cherry_blossom": {
     "keywords": ["nature", "plant", "spring", "flower"],
     "char": "🌸",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "bouquet": {
     "keywords": ["flowers", "nature", "spring"],
     "char": "💐",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "mushroom": {
     "keywords": ["plant", "vegetable"],
     "char": "🍄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "chestnut": {
     "keywords": ["food", "squirrel"],
     "char": "🌰",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "jack_o_lantern": {
     "keywords": ["halloween", "light", "pumpkin", "creepy", "fall"],
     "char": "🎃",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "shell": {
     "keywords": ["nature", "sea", "beach"],
     "char": "🐚",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "spider_web": {
     "keywords": ["animal", "insect", "arachnid", "silk"],
     "char": "🕸",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "earth_americas": {
     "keywords": ["globe", "world", "USA", "international"],
     "char": "🌎",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "earth_africa": {
     "keywords": ["globe", "world", "international"],
     "char": "🌍",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "earth_asia": {
     "keywords": ["globe", "world", "east", "international"],
     "char": "🌏",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "full_moon": {
     "keywords": ["nature", "yellow", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌕",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "waning_gibbous_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep", "waxing_gibbous_moon"],
     "char": "🌖",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "last_quarter_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌗",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "waning_crescent_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌘",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "new_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌑",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "waxing_crescent_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌒",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "first_quarter_moon": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌓",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "waxing_gibbous_moon": {
     "keywords": ["nature", "night", "sky", "gray", "twilight", "planet", "space", "evening", "sleep"],
     "char": "🌔",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "new_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌚",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "full_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌝",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "first_quarter_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌛",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "last_quarter_moon_with_face": {
     "keywords": ["nature", "twilight", "planet", "space", "night", "evening", "sleep"],
     "char": "🌜",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "sun_with_face": {
     "keywords": ["nature", "morning", "sky"],
     "char": "🌞",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "crescent_moon": {
     "keywords": ["night", "sleep", "sky", "evening", "magic"],
     "char": "🌙",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "star": {
     "keywords": ["night", "yellow"],
     "char": "⭐",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "5.1"
   },
   "star2": {
     "keywords": ["night", "sparkle", "awesome", "good", "magic"],
     "char": "🌟",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "dizzy": {
     "keywords": ["star", "sparkle", "shoot", "magic"],
     "char": "💫",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "sparkles": {
     "keywords": ["stars", "shine", "shiny", "cool", "awesome", "good", "magic"],
     "char": "✨",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "comet": {
     "keywords": ["space"],
     "char": "☄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "sunny": {
     "keywords": ["weather", "nature", "brightness", "summer", "beach", "spring"],
     "char": "☀️",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "sun_behind_small_cloud": {
     "keywords": ["weather"],
     "char": "🌤",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "partly_sunny": {
     "keywords": ["weather", "nature", "cloudy", "morning", "fall", "spring"],
     "char": "⛅",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "5.2"
   },
   "sun_behind_large_cloud": {
     "keywords": ["weather"],
     "char": "🌥",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "sun_behind_rain_cloud": {
     "keywords": ["weather"],
     "char": "🌦",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "cloud": {
     "keywords": ["weather", "sky"],
     "char": "☁️",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "cloud_with_rain": {
     "keywords": ["weather"],
     "char": "🌧",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "cloud_with_lightning_and_rain": {
     "keywords": ["weather", "lightning"],
     "char": "⛈",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "5.2"
   },
   "cloud_with_lightning": {
     "keywords": ["weather", "thunder"],
     "char": "🌩",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "zap": {
     "keywords": ["thunder", "weather", "lightning bolt", "fast"],
     "char": "⚡",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "4.0"
   },
   "fire": {
     "keywords": ["hot", "cook", "flame"],
     "char": "🔥",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "boom": {
     "keywords": ["bomb", "explode", "explosion", "collision", "blown"],
     "char": "💥",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "snowflake": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas"],
     "char": "❄️",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "cloud_with_snow": {
     "keywords": ["weather"],
     "char": "🌨",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "snowman": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas", "frozen", "without_snow"],
     "char": "⛄",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "5.2"
   },
   "snowman_with_snow": {
     "keywords": ["winter", "season", "cold", "weather", "christmas", "xmas", "frozen"],
     "char": "☃",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "wind_face": {
     "keywords": ["gust", "air"],
     "char": "🌬",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "dash": {
     "keywords": ["wind", "air", "fast", "shoo", "fart", "smoke", "puff"],
     "char": "💨",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "tornado": {
     "keywords": ["weather", "cyclone", "twister"],
     "char": "🌪",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "fog": {
     "keywords": ["weather"],
     "char": "🌫",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "7.0"
   },
   "open_umbrella": {
     "keywords": ["weather", "spring"],
     "char": "☂",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "1.1"
   },
   "umbrella": {
     "keywords": ["rainy", "weather", "spring"],
     "char": "☔",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "4.0"
   },
   "droplet": {
     "keywords": ["water", "drip", "faucet", "spring"],
     "char": "💧",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "sweat_drops": {
     "keywords": ["water", "drip", "oops"],
     "char": "💦",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "ocean": {
     "keywords": ["sea", "water", "wave", "nature", "tsunami", "disaster"],
     "char": "🌊",
     "fitzpatrick_scale": false,
-    "category": "animals_and_nature"
+    "category": "animals_and_nature",
+    "unicode_version": "6.0"
   },
   "green_apple": {
     "keywords": ["fruit", "nature"],
     "char": "🍏",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "apple": {
     "keywords": ["fruit", "mac", "school"],
     "char": "🍎",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "pear": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍐",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "tangerine": {
     "keywords": ["food", "fruit", "nature", "orange"],
     "char": "🍊",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "lemon": {
     "keywords": ["fruit", "nature"],
     "char": "🍋",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "banana": {
     "keywords": ["fruit", "food", "monkey"],
     "char": "🍌",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "watermelon": {
     "keywords": ["fruit", "food", "picnic", "summer"],
     "char": "🍉",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "grapes": {
     "keywords": ["fruit", "food", "wine"],
     "char": "🍇",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "strawberry": {
     "keywords": ["fruit", "food", "nature"],
     "char": "🍓",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "melon": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍈",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "cherries": {
     "keywords": ["food", "fruit"],
     "char": "🍒",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "peach": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍑",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "pineapple": {
     "keywords": ["fruit", "nature", "food"],
     "char": "🍍",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "kiwi_fruit": {
     "keywords": ["fruit", "food"],
     "char": "🥝",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "avocado": {
     "keywords": ["fruit", "food"],
     "char": "🥑",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "tomato": {
     "keywords": ["fruit", "vegetable", "nature", "food"],
     "char": "🍅",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "eggplant": {
     "keywords": ["vegetable", "nature", "food", "aubergine"],
     "char": "🍆",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "cucumber": {
     "keywords": ["fruit", "food", "pickle"],
     "char": "🥒",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "carrot": {
     "keywords": ["vegetable", "food", "orange"],
     "char": "🥕",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "hot_pepper": {
     "keywords": ["food", "spicy", "chilli", "chili"],
     "char": "🌶",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "7.0"
   },
   "potato": {
     "keywords": ["food", "tuber", "vegatable", "starch"],
     "char": "🥔",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "corn": {
     "keywords": ["food", "vegetable", "plant"],
     "char": "🌽",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "sweet_potato": {
     "keywords": ["food", "nature"],
     "char": "🍠",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "peanuts": {
     "keywords": ["food", "nut"],
     "char": "🥜",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "honey_pot": {
     "keywords": ["bees", "sweet", "kitchen"],
     "char": "🍯",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "croissant": {
     "keywords": ["food", "bread", "french"],
     "char": "🥐",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "bread": {
     "keywords": ["food", "wheat", "breakfast", "toast"],
     "char": "🍞",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "baguette_bread": {
     "keywords": ["food", "bread", "french"],
     "char": "🥖",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "cheese": {
     "keywords": ["food", "chadder"],
     "char": "🧀",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "egg": {
     "keywords": ["food", "chicken", "breakfast"],
     "char": "🥚",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "bacon": {
     "keywords": ["food", "breakfast", "pork", "pig", "meat"],
     "char": "🥓",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "pancakes": {
     "keywords": ["food", "breakfast", "flapjacks", "hotcakes"],
     "char": "🥞",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "poultry_leg": {
     "keywords": ["food", "meat", "drumstick", "bird", "chicken", "turkey"],
     "char": "🍗",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "meat_on_bone": {
     "keywords": ["good", "food", "drumstick"],
     "char": "🍖",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "fried_shrimp": {
     "keywords": ["food", "animal", "appetizer", "summer"],
     "char": "🍤",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "fried_egg": {
     "keywords": ["food", "breakfast", "kitchen", "egg"],
     "char": "🍳",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "hamburger": {
     "keywords": ["meat", "fast food", "beef", "cheeseburger", "mcdonalds", "burger king"],
     "char": "🍔",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "fries": {
     "keywords": ["chips", "snack", "fast food"],
     "char": "🍟",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "stuffed_flatbread": {
     "keywords": ["food", "flatbread", "stuffed", "gyro"],
     "char": "🥙",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "hotdog": {
     "keywords": ["food", "frankfurter"],
     "char": "🌭",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "pizza": {
     "keywords": ["food", "party"],
     "char": "🍕",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "spaghetti": {
     "keywords": ["food", "italian", "noodle"],
     "char": "🍝",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "taco": {
     "keywords": ["food", "mexican"],
     "char": "🌮",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "burrito": {
     "keywords": ["food", "mexican"],
     "char": "🌯",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "green_salad": {
     "keywords": ["food", "healthy", "lettuce"],
     "char": "🥗",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "shallow_pan_of_food": {
     "keywords": ["food", "cooking", "casserole", "paella"],
     "char": "🥘",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "ramen": {
     "keywords": ["food", "japanese", "noodle", "chopsticks"],
     "char": "🍜",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "stew": {
     "keywords": ["food", "meat", "soup"],
     "char": "🍲",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "fish_cake": {
     "keywords": ["food", "japan", "sea", "beach"],
     "char": "🍥",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "sushi": {
     "keywords": ["food", "fish", "japanese", "rice"],
     "char": "🍣",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "bento": {
     "keywords": ["food", "japanese", "box"],
     "char": "🍱",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "curry": {
     "keywords": ["food", "spicy", "hot", "indian"],
     "char": "🍛",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "rice_ball": {
     "keywords": ["food", "japanese"],
     "char": "🍙",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "rice": {
     "keywords": ["food", "china", "asian"],
     "char": "🍚",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "rice_cracker": {
     "keywords": ["food", "japanese"],
     "char": "🍘",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "oden": {
     "keywords": ["food", "japanese"],
     "char": "🍢",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "dango": {
     "keywords": ["food", "dessert", "sweet", "japanese", "barbecue", "meat"],
     "char": "🍡",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "shaved_ice": {
     "keywords": ["hot", "dessert", "summer"],
     "char": "🍧",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "ice_cream": {
     "keywords": ["food", "hot", "dessert"],
     "char": "🍨",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "icecream": {
     "keywords": ["food", "hot", "dessert", "summer"],
     "char": "🍦",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "cake": {
     "keywords": ["food", "dessert"],
     "char": "🍰",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "birthday": {
     "keywords": ["food", "dessert", "cake"],
     "char": "🎂",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "custard": {
     "keywords": ["dessert", "food"],
     "char": "🍮",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "candy": {
     "keywords": ["snack", "dessert", "sweet", "lolly"],
     "char": "🍬",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "lollipop": {
     "keywords": ["food", "snack", "candy", "sweet"],
     "char": "🍭",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "chocolate_bar": {
     "keywords": ["food", "snack", "dessert", "sweet"],
     "char": "🍫",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "popcorn": {
     "keywords": ["food", "movie theater", "films", "snack"],
     "char": "🍿",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "doughnut": {
     "keywords": ["food", "dessert", "snack", "sweet", "donut"],
     "char": "🍩",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "cookie": {
     "keywords": ["food", "snack", "oreo", "chocolate", "sweet", "dessert"],
     "char": "🍪",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "milk_glass": {
     "keywords": ["beverage", "drink", "cow"],
     "char": "🥛",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "beer": {
     "keywords": ["relax", "beverage", "drink", "drunk", "party", "pub", "summer", "alcohol", "booze"],
     "char": "🍺",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "beers": {
     "keywords": ["relax", "beverage", "drink", "drunk", "party", "pub", "summer", "alcohol", "booze"],
     "char": "🍻",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "clinking_glasses": {
     "keywords": ["beverage", "drink", "party", "alcohol", "celebrate", "cheers"],
     "char": "🥂",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "wine_glass": {
     "keywords": ["drink", "beverage", "drunk", "alcohol", "booze"],
     "char": "🍷",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "tumbler_glass": {
     "keywords": ["drink", "beverage", "drunk", "alcohol", "liquor", "booze", "bourbon", "scotch", "whisky", "glass", "shot"],
     "char": "🥃",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "cocktail": {
     "keywords": ["drink", "drunk", "alcohol", "beverage", "booze", "mojito"],
     "char": "🍸",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "tropical_drink": {
     "keywords": ["beverage", "cocktail", "summer", "beach", "alcohol", "booze", "mojito"],
     "char": "🍹",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "champagne": {
     "keywords": ["drink", "wine", "bottle", "celebration"],
     "char": "🍾",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "8.0"
   },
   "sake": {
     "keywords": ["wine", "drink", "drunk", "beverage", "japanese", "alcohol", "booze"],
     "char": "🍶",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "tea": {
     "keywords": ["drink", "bowl", "breakfast", "green", "british"],
     "char": "🍵",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "coffee": {
     "keywords": ["beverage", "caffeine", "latte", "espresso"],
     "char": "☕",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "4.0"
   },
   "baby_bottle": {
     "keywords": ["food", "container", "milk"],
     "char": "🍼",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "spoon": {
     "keywords": ["cutlery", "kitchen", "tableware"],
     "char": "🥄",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "9.0"
   },
   "fork_and_knife": {
     "keywords": ["cutlery", "kitchen"],
     "char": "🍴",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "6.0"
   },
   "plate_with_cutlery": {
     "keywords": ["food", "eat", "meal", "lunch", "dinner", "restaurant"],
     "char": "🍽",
     "fitzpatrick_scale": false,
-    "category": "food_and_drink"
+    "category": "food_and_drink",
+    "unicode_version": "7.0"
   },
   "soccer": {
     "keywords": ["sports", "football"],
     "char": "⚽",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "basketball": {
     "keywords": ["sports", "balls", "NBA"],
     "char": "🏀",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "football": {
     "keywords": ["sports", "balls", "NFL"],
     "char": "🏈",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "baseball": {
     "keywords": ["sports", "balls"],
     "char": "⚾",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "tennis": {
     "keywords": ["sports", "balls", "green"],
     "char": "🎾",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "volleyball": {
     "keywords": ["sports", "balls"],
     "char": "🏐",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "rugby_football": {
     "keywords": ["sports", "team"],
     "char": "🏉",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "8ball": {
     "keywords": ["pool", "hobby", "game", "luck", "magic"],
     "char": "🎱",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "golf": {
     "keywords": ["sports", "business", "flag", "hole", "summer"],
     "char": "⛳",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "golfing_woman": {
     "keywords": ["sports", "business", "woman", "female"],
     "char": "🏌️‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": ""
   },
   "golfing_man": {
     "keywords": ["sports", "business"],
     "char": "🏌",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "ping_pong": {
     "keywords": ["sports", "pingpong"],
     "char": "🏓",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "badminton": {
     "keywords": ["sports"],
     "char": "🏸",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "goal_net": {
     "keywords": ["sports"],
     "char": "🥅",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "ice_hockey": {
     "keywords": ["sports"],
     "char": "🏒",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "field_hockey": {
     "keywords": ["sports"],
     "char": "🏑",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "cricket": {
     "keywords": ["sports"],
     "char": "🏏",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "ski": {
     "keywords": ["sports", "winter", "cold", "snow"],
     "char": "🎿",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "skier": {
     "keywords": ["sports", "winter", "snow"],
     "char": "⛷",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "snowboarder": {
     "keywords": ["sports", "winter"],
     "char": "🏂",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "person_fencing": {
     "keywords": ["sports", "fencing", "sword"],
     "char": "🤺",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "women_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♀️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "men_wrestling": {
     "keywords": ["sports", "wrestlers"],
     "char": "🤼‍♂️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "woman_cartwheeling": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♀️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": ""
   },
   "man_cartwheeling": {
     "keywords": ["gymnastics"],
     "char": "🤸‍♂️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": ""
   },
   "woman_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♀️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "man_playing_handball": {
     "keywords": ["sports"],
     "char": "🤾‍♂️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "ice_skate": {
     "keywords": ["sports"],
     "char": "⛸",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "bow_and_arrow": {
     "keywords": ["sports"],
     "char": "🏹",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "8.0"
   },
   "fishing_pole_and_fish": {
     "keywords": ["food", "hobby", "summer"],
     "char": "🎣",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "boxing_glove": {
     "keywords": ["sports", "fighting"],
     "char": "🥊",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "martial_arts_uniform": {
     "keywords": ["judo", "karate", "taekwondo"],
     "char": "🥋",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "rowing_woman": {
     "keywords": ["sports", "hobby", "water", "ship", "woman", "female"],
     "char": "🚣‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "rowing_man": {
     "keywords": ["sports", "hobby", "water", "ship"],
     "char": "🚣",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "swimming_woman": {
     "keywords": ["sports", "exercise", "human", "athlete", "water", "summer", "woman", "female"],
     "char": "🏊‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "swimming_man": {
     "keywords": ["sports", "exercise", "human", "athlete", "water", "summer"],
     "char": "🏊",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "woman_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♀️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "man_playing_water_polo": {
     "keywords": ["sports", "pool"],
     "char": "🤽‍♂️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "surfing_woman": {
     "keywords": ["sports", "ocean", "sea", "summer", "beach", "woman", "female"],
     "char": "🏄‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "surfing_man": {
     "keywords": ["sports", "ocean", "sea", "summer", "beach"],
     "char": "🏄",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "bath": {
     "keywords": ["clean", "shower", "bathroom"],
     "char": "🛀",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "basketball_woman": {
     "keywords": ["sports", "human", "woman", "female"],
     "char": "⛹️‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "basketball_man": {
     "keywords": ["sports", "human"],
     "char": "⛹",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "5.2"
   },
   "weight_lifting_woman": {
     "keywords": ["sports", "training", "exercise", "woman", "female"],
     "char": "🏋️‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "weight_lifting_man": {
     "keywords": ["sports", "training", "exercise"],
     "char": "🏋",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "biking_woman": {
     "keywords": ["sports", "bike", "exercise", "hipster", "woman", "female"],
     "char": "🚴‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "biking_man": {
     "keywords": ["sports", "bike", "exercise", "hipster"],
     "char": "🚴",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "mountain_biking_woman": {
     "keywords": ["transportation", "sports", "human", "race", "bike", "woman", "female"],
     "char": "🚵‍♀️",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "mountain_biking_man": {
     "keywords": ["transportation", "sports", "human", "race", "bike"],
     "char": "🚵",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "horse_racing": {
     "keywords": ["animal", "betting", "competition", "gambling", "luck"],
     "char": "🏇",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "business_suit_levitating": {
     "keywords": ["suit", "business", "levitate", "hover", "jump"],
     "char": "🕴",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "trophy": {
     "keywords": ["win", "award", "contest", "place", "ftw", "ceremony"],
     "char": "🏆",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "running_shirt_with_sash": {
     "keywords": ["play", "pageant"],
     "char": "🎽",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "medal_sports": {
     "keywords": ["award", "winning"],
     "char": "🏅",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "medal_military": {
     "keywords": ["award", "winning", "army"],
     "char": "🎖",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "1st_place_medal": {
     "keywords": ["award", "winning", "first"],
     "char": "🥇",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "2nd_place_medal": {
     "keywords": ["award", "second"],
     "char": "🥈",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "3rd_place_medal": {
     "keywords": ["award", "third"],
     "char": "🥉",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "reminder_ribbon": {
     "keywords": ["sports", "cause", "support", "awareness"],
     "char": "🎗",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "rosette": {
     "keywords": ["flower", "decoration", "military"],
     "char": "🏵",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "ticket": {
     "keywords": ["event", "concert", "pass"],
     "char": "🎫",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "tickets": {
     "keywords": ["sports", "concert", "entrance"],
     "char": "🎟",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "7.0"
   },
   "performing_arts": {
     "keywords": ["acting", "theater", "drama"],
     "char": "🎭",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "art": {
     "keywords": ["design", "paint", "draw", "colors"],
     "char": "🎨",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "circus_tent": {
     "keywords": ["festival", "carnival", "party"],
     "char": "🎪",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "woman_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♀️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "man_juggling": {
     "keywords": ["juggle", "balance", "skill", "multitask"],
     "char": "🤹‍♂️",
     "fitzpatrick_scale": true,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "microphone": {
     "keywords": ["sound", "music", "PA", "sing", "talkshow"],
     "char": "🎤",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "headphones": {
     "keywords": ["music", "score", "gadgets"],
     "char": "🎧",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "musical_score": {
     "keywords": ["treble", "clef", "compose"],
     "char": "🎼",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "musical_keyboard": {
     "keywords": ["piano", "instrument", "compose"],
     "char": "🎹",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "drum": {
     "keywords": ["music", "instrument", "drumsticks"],
     "char": "🥁",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "9.0"
   },
   "saxophone": {
     "keywords": ["music", "instrument", "jazz", "blues"],
     "char": "🎷",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "trumpet": {
     "keywords": ["music", "brass"],
     "char": "🎺",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "guitar": {
     "keywords": ["music", "instrument"],
     "char": "🎸",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "violin": {
     "keywords": ["music", "instrument", "orchestra", "symphony"],
     "char": "🎻",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "clapper": {
     "keywords": ["movie", "film", "record"],
     "char": "🎬",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "video_game": {
     "keywords": ["play", "console", "PS4", "controller"],
     "char": "🎮",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "space_invader": {
     "keywords": ["game", "arcade", "play"],
     "char": "👾",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "dart": {
     "keywords": ["game", "play", "bar"],
     "char": "🎯",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "game_die": {
     "keywords": ["dice", "random", "tabletop", "play", "luck"],
     "char": "🎲",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "slot_machine": {
     "keywords": ["bet", "gamble", "vegas", "fruit machine", "luck", "casino"],
     "char": "🎰",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "bowling": {
     "keywords": ["sports", "fun", "play"],
     "char": "🎳",
     "fitzpatrick_scale": false,
-    "category": "activity"
+    "category": "activity",
+    "unicode_version": "6.0"
   },
   "red_car": {
     "keywords": ["red", "transportation", "vehicle"],
     "char": "🚗",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "taxi": {
     "keywords": ["uber", "vehicle", "cars", "transportation"],
     "char": "🚕",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "blue_car": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚙",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "bus": {
     "keywords": ["car", "vehicle", "transportation"],
     "char": "🚌",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "trolleybus": {
     "keywords": ["bart", "transportation", "vehicle"],
     "char": "🚎",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "racing_car": {
     "keywords": ["sports", "race", "fast", "formula", "f1"],
     "char": "🏎",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "police_car": {
     "keywords": ["vehicle", "cars", "transportation", "law", "legal", "enforcement"],
     "char": "🚓",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "ambulance": {
     "keywords": ["health", "911", "hospital"],
     "char": "🚑",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "fire_engine": {
     "keywords": ["transportation", "cars", "vehicle"],
     "char": "🚒",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "minibus": {
     "keywords": ["vehicle", "car", "transportation"],
     "char": "🚐",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "truck": {
     "keywords": ["cars", "transportation"],
     "char": "🚚",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "articulated_lorry": {
     "keywords": ["vehicle", "cars", "transportation", "express"],
     "char": "🚛",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "tractor": {
     "keywords": ["vehicle", "car", "farming", "agriculture"],
     "char": "🚜",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "kick_scooter": {
     "keywords": ["vehicle", "kick", "razor"],
     "char": "🛴",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "9.0"
   },
   "motorcycle": {
     "keywords": ["race", "sports", "fast"],
     "char": "🏍",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "bike": {
     "keywords": ["sports", "bicycle", "exercise", "hipster"],
     "char": "🚲",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "motor_scooter": {
     "keywords": ["vehicle", "vespa", "sasha"],
     "char": "🛵",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "9.0"
   },
   "rotating_light": {
     "keywords": ["police", "ambulance", "911", "emergency", "alert", "error", "pinged", "law", "legal"],
     "char": "🚨",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "oncoming_police_car": {
     "keywords": ["vehicle", "law", "legal", "enforcement", "911"],
     "char": "🚔",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "oncoming_bus": {
     "keywords": ["vehicle", "transportation"],
     "char": "🚍",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "oncoming_automobile": {
     "keywords": ["car", "vehicle", "transportation"],
     "char": "🚘",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "oncoming_taxi": {
     "keywords": ["vehicle", "cars", "uber"],
     "char": "🚖",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "aerial_tramway": {
     "keywords": ["transportation", "vehicle", "ski"],
     "char": "🚡",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "mountain_cableway": {
     "keywords": ["transportation", "vehicle", "ski"],
     "char": "🚠",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "suspension_railway": {
     "keywords": ["vehicle", "transportation"],
     "char": "🚟",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "railway_car": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚃",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "train": {
     "keywords": ["transportation", "vehicle", "carriage", "public", "travel"],
     "char": "🚋",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "monorail": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚝",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "bullettrain_side": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚄",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "bullettrain_front": {
     "keywords": ["transportation", "vehicle", "speed", "fast", "public", "travel"],
     "char": "🚅",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "light_rail": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚈",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "mountain_railway": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚞",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "steam_locomotive": {
     "keywords": ["transportation", "vehicle", "train"],
     "char": "🚂",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "train2": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚆",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "metro": {
     "keywords": ["transportation", "blue-square", "mrt", "underground", "tube"],
     "char": "🚇",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "tram": {
     "keywords": ["transportation", "vehicle"],
     "char": "🚊",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "station": {
     "keywords": ["transportation", "vehicle", "public"],
     "char": "🚉",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "helicopter": {
     "keywords": ["transportation", "vehicle", "fly"],
     "char": "🚁",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "small_airplane": {
     "keywords": ["flight", "transportation", "fly", "vehicle"],
     "char": "🛩",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "airplane": {
     "keywords": ["vehicle", "transportation", "flight", "fly"],
     "char": "✈️",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "1.1"
   },
   "flight_departure": {
     "keywords": ["airport", "flight", "landing"],
     "char": "🛫",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "flight_arrival": {
     "keywords": ["airport", "flight", "boarding"],
     "char": "🛬",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "sailboat": {
     "keywords": ["ship", "summer", "transportation", "water", "sailing"],
     "char": "⛵",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "motor_boat": {
     "keywords": ["ship"],
     "char": "🛥",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "speedboat": {
     "keywords": ["ship", "transportation", "vehicle", "summer"],
     "char": "🚤",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "ferry": {
     "keywords": ["boat", "ship", "yacht"],
     "char": "⛴",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "passenger_ship": {
     "keywords": ["yacht", "cruise", "ferry"],
     "char": "🛳",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "rocket": {
     "keywords": ["launch", "ship", "staffmode", "NASA", "outer space", "outer_space", "fly"],
     "char": "🚀",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "artificial_satellite": {
     "keywords": ["communication", "gps", "orbit", "spaceflight", "NASA", "ISS"],
     "char": "🛰",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "seat": {
     "keywords": ["sit", "airplane", "transport", "bus", "flight", "fly"],
     "char": "💺",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "canoe": {
     "keywords": ["boat", "paddle", "water", "ship"],
     "char": "🛶",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "9.0"
   },
   "anchor": {
     "keywords": ["ship", "ferry", "sea", "boat"],
     "char": "⚓",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "4.1"
   },
   "construction": {
     "keywords": ["wip", "progress", "caution", "warning"],
     "char": "🚧",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "fuelpump": {
     "keywords": ["gas station", "petroleum"],
     "char": "⛽",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "busstop": {
     "keywords": ["transportation", "wait"],
     "char": "🚏",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "vertical_traffic_light": {
     "keywords": ["transportation", "driving"],
     "char": "🚦",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "traffic_light": {
     "keywords": ["transportation", "signal"],
     "char": "🚥",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "checkered_flag": {
     "keywords": ["contest", "finishline", "race", "gokart"],
     "char": "🏁",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "ship": {
     "keywords": ["transportation", "titanic", "deploy"],
     "char": "🚢",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "ferris_wheel": {
     "keywords": ["photo", "carnival", "londoneye"],
     "char": "🎡",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "roller_coaster": {
     "keywords": ["carnival", "playground", "photo", "fun"],
     "char": "🎢",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "carousel_horse": {
     "keywords": ["photo", "carnival"],
     "char": "🎠",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "building_construction": {
     "keywords": ["wip", "working", "progress"],
     "char": "🏗",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "foggy": {
     "keywords": ["photo", "mountain"],
     "char": "🌁",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "tokyo_tower": {
     "keywords": ["photo", "japanese"],
     "char": "🗼",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "factory": {
     "keywords": ["building", "industry", "pollution", "smoke"],
     "char": "🏭",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "fountain": {
     "keywords": ["photo", "summer", "water", "fresh"],
     "char": "⛲",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "rice_scene": {
     "keywords": ["photo", "japan", "asia", "tsukimi"],
     "char": "🎑",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "mountain": {
     "keywords": ["photo", "nature", "environment"],
     "char": "⛰",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "mountain_snow": {
     "keywords": ["photo", "nature", "environment", "winter", "cold"],
     "char": "🏔",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "mount_fuji": {
     "keywords": ["photo", "mountain", "nature", "japanese"],
     "char": "🗻",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "volcano": {
     "keywords": ["photo", "nature", "disaster"],
     "char": "🌋",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "japan": {
     "keywords": ["nation", "country", "japanese", "asia"],
     "char": "🗾",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "camping": {
     "keywords": ["photo", "outdoors", "tent"],
     "char": "🏕",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "tent": {
     "keywords": ["photo", "camping", "outdoors"],
     "char": "⛺",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "national_park": {
     "keywords": ["photo", "environment", "nature"],
     "char": "🏞",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "motorway": {
     "keywords": ["road", "cupertino", "interstate", "highway"],
     "char": "🛣",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "railway_track": {
     "keywords": ["train", "transportation"],
     "char": "🛤",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "sunrise": {
     "keywords": ["morning", "view", "vacation", "photo"],
     "char": "🌅",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "sunrise_over_mountains": {
     "keywords": ["view", "vacation", "photo"],
     "char": "🌄",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "desert": {
     "keywords": ["photo", "warm", "saharah"],
     "char": "🏜",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "beach_umbrella": {
     "keywords": ["weather", "summer", "sunny", "sand", "mojito"],
     "char": "🏖",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "desert_island": {
     "keywords": ["photo", "tropical", "mojito"],
     "char": "🏝",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "city_sunrise": {
     "keywords": ["photo", "good morning", "dawn"],
     "char": "🌇",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "city_sunset": {
     "keywords": ["photo", "evening", "sky", "buildings"],
     "char": "🌆",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "cityscape": {
     "keywords": ["photo", "night life", "urban"],
     "char": "🏙",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "night_with_stars": {
     "keywords": ["evening", "city", "downtown"],
     "char": "🌃",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "bridge_at_night": {
     "keywords": ["photo", "sanfrancisco"],
     "char": "🌉",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "milky_way": {
     "keywords": ["photo", "space", "stars"],
     "char": "🌌",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "stars": {
     "keywords": ["night", "photo"],
     "char": "🌠",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "sparkler": {
     "keywords": ["stars", "night", "shine"],
     "char": "🎇",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "fireworks": {
     "keywords": ["photo", "festival", "carnival", "congratulations"],
     "char": "🎆",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "rainbow": {
     "keywords": ["nature", "happy", "unicorn_face", "photo", "sky", "spring"],
     "char": "🌈",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "houses": {
     "keywords": ["buildings", "photo"],
     "char": "🏘",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "european_castle": {
     "keywords": ["building", "royalty", "history"],
     "char": "🏰",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "japanese_castle": {
     "keywords": ["photo", "building"],
     "char": "🏯",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "stadium": {
     "keywords": ["photo", "place", "sports", "concert", "venue"],
     "char": "🏟",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "statue_of_liberty": {
     "keywords": ["american", "newyork"],
     "char": "🗽",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "house": {
     "keywords": ["building", "home"],
     "char": "🏠",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "house_with_garden": {
     "keywords": ["home", "plant", "nature"],
     "char": "🏡",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "derelict_house": {
     "keywords": ["abandon", "evict", "broken", "building"],
     "char": "🏚",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "office": {
     "keywords": ["building", "bureau", "work"],
     "char": "🏢",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "department_store": {
     "keywords": ["building", "shopping", "mall"],
     "char": "🏬",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "post_office": {
     "keywords": ["building", "envelope", "communication"],
     "char": "🏣",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "european_post_office": {
     "keywords": ["building", "email"],
     "char": "🏤",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "hospital": {
     "keywords": ["building", "health", "surgery", "doctor"],
     "char": "🏥",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "bank": {
     "keywords": ["building", "money", "sales", "cash", "business", "enterprise"],
     "char": "🏦",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "hotel": {
     "keywords": ["building", "accomodation", "checkin"],
     "char": "🏨",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "convenience_store": {
     "keywords": ["building", "shopping", "groceries"],
     "char": "🏪",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "school": {
     "keywords": ["building", "student", "education", "learn", "teach"],
     "char": "🏫",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "love_hotel": {
     "keywords": ["like", "affection", "dating"],
     "char": "🏩",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "wedding": {
     "keywords": ["love", "like", "affection", "couple", "marriage", "bride", "groom"],
     "char": "💒",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "6.0"
   },
   "classical_building": {
     "keywords": ["art", "culture", "history"],
     "char": "🏛",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "7.0"
   },
   "church": {
     "keywords": ["building", "religion", "christ"],
     "char": "⛪",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "mosque": {
     "keywords": ["islam", "worship", "minaret"],
     "char": "🕌",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "8.0"
   },
   "synagogue": {
     "keywords": ["judaism", "worship", "temple", "jewish"],
     "char": "🕍",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "8.0"
   },
   "kaaba": {
     "keywords": ["mecca", "mosque", "islam"],
     "char": "🕋",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "8.0"
   },
   "shinto_shrine": {
     "keywords": ["temple", "japan", "kyoto"],
     "char": "⛩",
     "fitzpatrick_scale": false,
-    "category": "travel_and_places"
+    "category": "travel_and_places",
+    "unicode_version": "5.2"
   },
   "watch": {
     "keywords": ["time", "accessories"],
     "char": "⌚",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "iphone": {
     "keywords": ["technology", "apple", "gadgets", "dial"],
     "char": "📱",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "calling": {
     "keywords": ["iphone", "incoming"],
     "char": "📲",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "computer": {
     "keywords": ["technology", "laptop", "screen", "display", "monitor"],
     "char": "💻",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "keyboard": {
     "keywords": ["technology", "computer", "type", "input", "text"],
     "char": "⌨",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "desktop_computer": {
     "keywords": ["technology", "computing", "screen"],
     "char": "🖥",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "printer": {
     "keywords": ["paper", "ink"],
     "char": "🖨",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "computer_mouse": {
     "keywords": ["click"],
     "char": "🖱",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "trackball": {
     "keywords": ["technology", "trackpad"],
     "char": "🖲",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "joystick": {
     "keywords": ["game", "play"],
     "char": "🕹",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "clamp": {
     "keywords": ["tool"],
     "char": "🗜",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "minidisc": {
     "keywords": ["technology", "record", "data", "disk", "90s"],
     "char": "💽",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "floppy_disk": {
     "keywords": ["oldschool", "technology", "save", "90s", "80s"],
     "char": "💾",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "cd": {
     "keywords": ["technology", "dvd", "disk", "disc", "90s"],
     "char": "💿",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "dvd": {
     "keywords": ["cd", "disk", "disc"],
     "char": "📀",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "vhs": {
     "keywords": ["record", "video", "oldschool", "90s", "80s"],
     "char": "📼",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "camera": {
     "keywords": ["gadgets", "photography"],
     "char": "📷",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "camera_flash": {
     "keywords": ["photography", "gadgets"],
     "char": "📸",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "video_camera": {
     "keywords": ["film", "record"],
     "char": "📹",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "movie_camera": {
     "keywords": ["film", "record"],
     "char": "🎥",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "film_projector": {
     "keywords": ["video", "tape", "record", "movie"],
     "char": "📽",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "film_strip": {
     "keywords": ["movie"],
     "char": "🎞",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "telephone_receiver": {
     "keywords": ["technology", "communication", "dial"],
     "char": "📞",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "phone": {
     "keywords": ["technology", "communication", "dial", "telephone"],
     "char": "☎️",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "pager": {
     "keywords": ["bbcall", "oldschool", "90s"],
     "char": "📟",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "fax": {
     "keywords": ["communication", "technology"],
     "char": "📠",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "tv": {
     "keywords": ["technology", "program", "oldschool", "show", "television"],
     "char": "📺",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "radio": {
     "keywords": ["communication", "music", "podcast", "program"],
     "char": "📻",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "studio_microphone": {
     "keywords": ["sing", "recording", "artist", "talkshow"],
     "char": "🎙",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "level_slider": {
     "keywords": ["scale"],
     "char": "🎚",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "control_knobs": {
     "keywords": ["dial"],
     "char": "🎛",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "stopwatch": {
     "keywords": ["time", "deadline"],
     "char": "⏱",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "timer_clock": {
     "keywords": ["alarm"],
     "char": "⏲",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "alarm_clock": {
     "keywords": ["time", "wake"],
     "char": "⏰",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mantelpiece_clock": {
     "keywords": ["time"],
     "char": "🕰",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "hourglass_flowing_sand": {
     "keywords": ["oldschool", "time", "countdown"],
     "char": "⏳",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "hourglass": {
     "keywords": ["time", "clock", "oldschool", "limit", "exam", "quiz", "test"],
     "char": "⌛",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "satellite": {
     "keywords": ["communication", "future", "radio", "space"],
     "char": "📡",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "battery": {
     "keywords": ["power", "energy", "sustain"],
     "char": "🔋",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "electric_plug": {
     "keywords": ["charger", "power"],
     "char": "🔌",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bulb": {
     "keywords": ["light", "electricity", "idea"],
     "char": "💡",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "flashlight": {
     "keywords": ["dark", "camping", "sight", "night"],
     "char": "🔦",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "candle": {
     "keywords": ["fire", "wax"],
     "char": "🕯",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "wastebasket": {
     "keywords": ["bin", "trash", "rubbish", "garbage", "toss"],
     "char": "🗑",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "oil_drum": {
     "keywords": ["barrell"],
     "char": "🛢",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "money_with_wings": {
     "keywords": ["dollar", "bills", "payment", "sale"],
     "char": "💸",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "dollar": {
     "keywords": ["money", "sales", "bill", "currency"],
     "char": "💵",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "yen": {
     "keywords": ["money", "sales", "japanese", "dollar", "currency"],
     "char": "💴",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "euro": {
     "keywords": ["money", "sales", "dollar", "currency"],
     "char": "💶",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "pound": {
     "keywords": ["british", "sterling", "money", "sales", "bills", "uk", "england", "currency"],
     "char": "💷",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "moneybag": {
     "keywords": ["dollar", "payment", "coins", "sale"],
     "char": "💰",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "credit_card": {
     "keywords": ["money", "sales", "dollar", "bill", "payment", "shopping"],
     "char": "💳",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "gem": {
     "keywords": ["blue", "ruby", "diamond", "jewelry"],
     "char": "💎",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "balance_scale": {
     "keywords": ["law", "fairness", "weight"],
     "char": "⚖",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "wrench": {
     "keywords": ["tools", "diy", "ikea", "fix", "maintainer"],
     "char": "🔧",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "hammer": {
     "keywords": ["tools", "build", "create"],
     "char": "🔨",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "hammer_and_pick": {
     "keywords": ["tools", "build", "create"],
     "char": "⚒",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "hammer_and_wrench": {
     "keywords": ["tools", "build", "create"],
     "char": "🛠",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "pick": {
     "keywords": ["tools", "dig"],
     "char": "⛏",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "5.2"
   },
   "nut_and_bolt": {
     "keywords": ["handy", "tools", "fix"],
     "char": "🔩",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "gear": {
     "keywords": ["cog"],
     "char": "⚙",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "chains": {
     "keywords": ["lock", "arrest"],
     "char": "⛓",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "5.2"
   },
   "gun": {
     "keywords": ["violence", "weapon", "pistol", "revolver"],
     "char": "🔫",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bomb": {
     "keywords": ["boom", "explode", "explosion", "terrorism"],
     "char": "💣",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "hocho": {
     "keywords": ["knife", "blade", "cutlery", "kitchen", "weapon"],
     "char": "🔪",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "dagger": {
     "keywords": ["weapon"],
     "char": "🗡",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "crossed_swords": {
     "keywords": ["weapon"],
     "char": "⚔",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "shield": {
     "keywords": ["protection", "security"],
     "char": "🛡",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "smoking": {
     "keywords": ["kills", "tobacco", "cigarette", "joint", "smoke"],
     "char": "🚬",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "skull_and_crossbones": {
     "keywords": ["poison", "danger", "deadly", "scary", "death", "pirate", "evil"],
     "char": "☠",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "coffin": {
     "keywords": ["vampire", "dead", "die", "death", "rip", "graveyard", "cemetery", "casket", "funeral", "box"],
     "char": "⚰",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "funeral_urn": {
     "keywords": ["dead", "die", "death", "rip", "ashes"],
     "char": "⚱",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "amphora": {
     "keywords": ["vase", "jar"],
     "char": "🏺",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "8.0"
   },
   "crystal_ball": {
     "keywords": ["disco", "party", "magic", "circus", "fortune_teller"],
     "char": "🔮",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "prayer_beads": {
     "keywords": ["dhikr", "religious"],
     "char": "📿",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "8.0"
   },
   "barber": {
     "keywords": ["hair", "salon", "style"],
     "char": "💈",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "alembic": {
     "keywords": ["distilling", "science", "experiment", "chemistry"],
     "char": "⚗",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "4.1"
   },
   "telescope": {
     "keywords": ["stars", "space", "zoom", "science", "astronomy"],
     "char": "🔭",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "microscope": {
     "keywords": ["laboratory", "experiment", "zoomin", "science", "study"],
     "char": "🔬",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "hole": {
     "keywords": ["embarrassing"],
     "char": "🕳",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "pill": {
     "keywords": ["health", "medicine", "doctor", "pharmacy", "drug"],
     "char": "💊",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "syringe": {
     "keywords": ["health", "hospital", "drugs", "blood", "medicine", "needle", "doctor", "nurse"],
     "char": "💉",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "thermometer": {
     "keywords": ["weather", "temperature", "hot", "cold"],
     "char": "🌡",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "label": {
     "keywords": ["sale", "tag"],
     "char": "🏷",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "bookmark": {
     "keywords": ["favorite", "label", "save"],
     "char": "🔖",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "toilet": {
     "keywords": ["restroom", "wc", "washroom", "bathroom", "potty"],
     "char": "🚽",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "shower": {
     "keywords": ["clean", "water", "bathroom"],
     "char": "🚿",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bathtub": {
     "keywords": ["clean", "shower", "bathroom"],
     "char": "🛁",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "key": {
     "keywords": ["lock", "door", "password"],
     "char": "🔑",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "old_key": {
     "keywords": ["lock", "door", "password"],
     "char": "🗝",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "couch_and_lamp": {
     "keywords": ["read", "chill"],
     "char": "🛋",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "sleeping_bed": {
     "keywords": ["bed", "rest"],
     "char": "🛌",
     "fitzpatrick_scale": true,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "bed": {
     "keywords": ["sleep", "rest"],
     "char": "🛏",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "door": {
     "keywords": ["house", "entry", "exit"],
     "char": "🚪",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bellhop_bell": {
     "keywords": ["service"],
     "char": "🛎",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "framed_picture": {
     "keywords": ["photography"],
     "char": "🖼",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "world_map": {
     "keywords": ["location", "direction"],
     "char": "🗺",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "parasol_on_ground": {
     "keywords": ["weather", "summer"],
     "char": "⛱",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "5.2"
   },
   "moyai": {
     "keywords": ["rock", "easter island", "moai"],
     "char": "🗿",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "shopping": {
     "keywords": ["mall", "buy", "purchase"],
     "char": "🛍",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "shopping_cart": {
     "keywords": ["trolley"],
     "char": "🛒",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "9.0"
   },
   "balloon": {
     "keywords": ["party", "celebration", "birthday", "circus"],
     "char": "🎈",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "flags": {
     "keywords": ["fish", "japanese", "koinobori", "carp", "banner"],
     "char": "🎏",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "ribbon": {
     "keywords": ["decoration", "pink", "girl", "bowtie"],
     "char": "🎀",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "gift": {
     "keywords": ["present", "birthday", "christmas", "xmas"],
     "char": "🎁",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "confetti_ball": {
     "keywords": ["festival", "party", "birthday", "circus"],
     "char": "🎊",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "tada": {
     "keywords": ["party", "congratulations", "birthday", "magic", "circus", "celebration"],
     "char": "🎉",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "dolls": {
     "keywords": ["japanese", "toy", "kimono"],
     "char": "🎎",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "wind_chime": {
     "keywords": ["nature", "ding", "spring", "bell"],
     "char": "🎐",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "crossed_flags": {
     "keywords": ["japanese", "nation", "country", "border"],
     "char": "🎌",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "izakaya_lantern": {
     "keywords": ["light", "paper", "halloween", "spooky"],
     "char": "🏮",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "email": {
     "keywords": ["letter", "postal", "inbox", "communication"],
     "char": "✉️",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "envelope_with_arrow": {
     "keywords": ["email", "communication"],
     "char": "📩",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "incoming_envelope": {
     "keywords": ["email", "inbox"],
     "char": "📨",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "e-mail": {
     "keywords": ["communication", "inbox"],
     "char": "📧",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "love_letter": {
     "keywords": ["email", "like", "affection", "envelope", "valentines"],
     "char": "💌",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "postbox": {
     "keywords": ["email", "letter", "envelope"],
     "char": "📮",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mailbox_closed": {
     "keywords": ["email", "communication", "inbox"],
     "char": "📪",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mailbox": {
     "keywords": ["email", "inbox", "communication"],
     "char": "📫",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mailbox_with_mail": {
     "keywords": ["email", "inbox", "communication"],
     "char": "📬",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mailbox_with_no_mail": {
     "keywords": ["email", "inbox"],
     "char": "📭",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "package": {
     "keywords": ["mail", "gift", "cardboard", "box", "moving"],
     "char": "📦",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "postal_horn": {
     "keywords": ["instrument", "music"],
     "char": "📯",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "inbox_tray": {
     "keywords": ["email", "documents"],
     "char": "📥",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "outbox_tray": {
     "keywords": ["inbox", "email"],
     "char": "📤",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "scroll": {
     "keywords": ["documents", "ancient", "history", "paper"],
     "char": "📜",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "page_with_curl": {
     "keywords": ["documents", "office", "paper"],
     "char": "📃",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bookmark_tabs": {
     "keywords": ["favorite", "save", "order", "tidy"],
     "char": "📑",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "bar_chart": {
     "keywords": ["graph", "presentation", "stats"],
     "char": "📊",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "chart_with_upwards_trend": {
     "keywords": ["graph", "presentation", "stats", "recovery", "business", "economics", "money", "sales", "good", "success"],
     "char": "📈",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "chart_with_downwards_trend": {
     "keywords": ["graph", "presentation", "stats", "recession", "business", "economics", "money", "sales", "bad", "failure"],
     "char": "📉",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "page_facing_up": {
     "keywords": ["documents", "office", "paper", "information"],
     "char": "📄",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "date": {
     "keywords": ["calendar", "schedule"],
     "char": "📅",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "calendar": {
     "keywords": ["schedule", "date", "planning"],
     "char": "📆",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "spiral_calendar": {
     "keywords": ["date", "schedule", "planning"],
     "char": "🗓",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "card_index": {
     "keywords": ["business", "stationery"],
     "char": "📇",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "card_file_box": {
     "keywords": ["business", "stationery"],
     "char": "🗃",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "ballot_box": {
     "keywords": ["election", "vote"],
     "char": "🗳",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "file_cabinet": {
     "keywords": ["filing", "organizing"],
     "char": "🗄",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "clipboard": {
     "keywords": ["stationery", "documents"],
     "char": "📋",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "spiral_notepad": {
     "keywords": ["memo", "stationery"],
     "char": "🗒",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "file_folder": {
     "keywords": ["documents", "business", "office"],
     "char": "📁",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "open_file_folder": {
     "keywords": ["documents", "load"],
     "char": "📂",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "card_index_dividers": {
     "keywords": ["organizing", "business", "stationery"],
     "char": "🗂",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "newspaper_roll": {
     "keywords": ["press", "headline"],
     "char": "🗞",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "newspaper": {
     "keywords": ["press", "headline"],
     "char": "📰",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "notebook": {
     "keywords": ["stationery", "record", "notes", "paper", "study"],
     "char": "📓",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "closed_book": {
     "keywords": ["read", "library", "knowledge", "textbook", "learn"],
     "char": "📕",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "green_book": {
     "keywords": ["read", "library", "knowledge", "study"],
     "char": "📗",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "blue_book": {
     "keywords": ["read", "library", "knowledge", "learn", "study"],
     "char": "📘",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "orange_book": {
     "keywords": ["read", "library", "knowledge", "textbook", "study"],
     "char": "📙",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "notebook_with_decorative_cover": {
     "keywords": ["classroom", "notes", "record", "paper", "study"],
     "char": "📔",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "ledger": {
     "keywords": ["notes", "paper"],
     "char": "📒",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "books": {
     "keywords": ["literature", "library", "study"],
     "char": "📚",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "open_book": {
     "keywords": ["book", "read", "library", "knowledge", "literature", "learn", "study"],
     "char": "📖",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "link": {
     "keywords": ["rings", "url"],
     "char": "🔗",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "paperclip": {
     "keywords": ["documents", "stationery"],
     "char": "📎",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "paperclips": {
     "keywords": ["documents", "stationery"],
     "char": "🖇",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "scissors": {
     "keywords": ["stationery", "cut"],
     "char": "✂️",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "triangular_ruler": {
     "keywords": ["stationery", "math", "architect", "sketch"],
     "char": "📐",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "straight_ruler": {
     "keywords": ["stationery", "calculate", "length", "math", "school", "drawing", "architect", "sketch"],
     "char": "📏",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "pushpin": {
     "keywords": ["stationery", "mark", "here"],
     "char": "📌",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "round_pushpin": {
     "keywords": ["stationery", "location", "map", "here"],
     "char": "📍",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "triangular_flag_on_post": {
     "keywords": ["mark", "milestone", "place"],
     "char": "🚩",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "white_flag": {
     "keywords": ["losing", "loser", "lost", "surrender", "give up", "fail"],
     "char": "🏳",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "black_flag": {
     "keywords": ["pirate"],
     "char": "🏴",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "rainbow_flag": {
     "keywords": ["flag", "rainbow", "pride", "gay", "lgbt", "glbt", "queer", "homosexual", "lesbian", "bisexual", "transgender"],
     "char": "🏳️‍🌈",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "closed_lock_with_key": {
     "keywords": ["security", "privacy"],
     "char": "🔐",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "lock": {
     "keywords": ["security", "password", "padlock"],
     "char": "🔒",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "unlock": {
     "keywords": ["privacy", "security"],
     "char": "🔓",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "lock_with_ink_pen": {
     "keywords": ["security", "secret"],
     "char": "🔏",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "pen": {
     "keywords": ["stationery", "writing", "write"],
     "char": "🖊",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "fountain_pen": {
     "keywords": ["stationery", "writing", "write"],
     "char": "🖋",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "black_nib": {
     "keywords": ["pen", "stationery", "writing", "write"],
     "char": "✒️",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "memo": {
     "keywords": ["write", "documents", "stationery", "pencil", "paper", "writing", "legal", "exam", "quiz", "test", "study", "compose"],
     "char": "📝",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "pencil2": {
     "keywords": ["stationery", "write", "paper", "writing", "school", "study"],
     "char": "✏️",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "1.1"
   },
   "crayon": {
     "keywords": ["drawing", "creativity"],
     "char": "🖍",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "paintbrush": {
     "keywords": ["drawing", "creativity", "art"],
     "char": "🖌",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "7.0"
   },
   "mag": {
     "keywords": ["search", "zoom", "find", "detective"],
     "char": "🔍",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "mag_right": {
     "keywords": ["search", "zoom", "find", "detective"],
     "char": "🔎",
     "fitzpatrick_scale": false,
-    "category": "objects"
+    "category": "objects",
+    "unicode_version": "6.0"
   },
   "heart": {
     "keywords": ["love", "like", "valentines"],
     "char": "❤️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "yellow_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "green_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💚",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "blue_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💙",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "purple_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💜",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "black_heart": {
     "keywords": ["evil"],
     "char": "🖤",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "9.0"
   },
   "broken_heart": {
     "keywords": ["sad", "sorry", "break", "heart", "heartbreak"],
     "char": "💔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_heart_exclamation": {
     "keywords": ["decoration", "love"],
     "char": "❣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "two_hearts": {
     "keywords": ["love", "like", "affection", "valentines", "heart"],
     "char": "💕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "revolving_hearts": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💞",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heartbeat": {
     "keywords": ["love", "like", "affection", "valentines", "pink", "heart"],
     "char": "💓",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heartpulse": {
     "keywords": ["like", "love", "affection", "valentines", "pink"],
     "char": "💗",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "sparkling_heart": {
     "keywords": ["love", "like", "affection", "valentines"],
     "char": "💖",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "cupid": {
     "keywords": ["love", "like", "heart", "affection", "valentines"],
     "char": "💘",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "gift_heart": {
     "keywords": ["love", "valentines"],
     "char": "💝",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heart_decoration": {
     "keywords": ["purple-square", "love", "like"],
     "char": "💟",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "peace_symbol": {
     "keywords": ["hippie"],
     "char": "☮",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "latin_cross": {
     "keywords": ["christianity"],
     "char": "✝",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "star_and_crescent": {
     "keywords": ["islam"],
     "char": "☪",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "om": {
     "keywords": ["hinduism", "buddhism", "sikhism", "jainism"],
     "char": "🕉",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "wheel_of_dharma": {
     "keywords": ["hinduism", "buddhism", "sikhism", "jainism"],
     "char": "☸",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "star_of_david": {
     "keywords": ["judaism"],
     "char": "✡",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "six_pointed_star": {
     "keywords": ["purple-square", "religion", "jewish", "hexagram"],
     "char": "🔯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "menorah": {
     "keywords": ["hanukkah", "candles", "jewish"],
     "char": "🕎",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "8.0"
   },
   "yin_yang": {
     "keywords": ["balance"],
     "char": "☯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "orthodox_cross": {
     "keywords": ["suppedaneum", "religion"],
     "char": "☦",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "place_of_worship": {
     "keywords": ["religion", "church", "temple", "prayer"],
     "char": "🛐",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "8.0"
   },
   "ophiuchus": {
     "keywords": ["sign", "purple-square", "constellation", "astrology"],
     "char": "⛎",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "aries": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♈",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "taurus": {
     "keywords": ["purple-square", "sign", "zodiac", "astrology"],
     "char": "♉",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "gemini": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♊",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "cancer": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♋",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "leo": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♌",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "virgo": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♍",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "libra": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♎",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "scorpius": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology", "scorpio"],
     "char": "♏",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "sagittarius": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♐",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "capricorn": {
     "keywords": ["sign", "zodiac", "purple-square", "astrology"],
     "char": "♑",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "aquarius": {
     "keywords": ["sign", "purple-square", "zodiac", "astrology"],
     "char": "♒",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "pisces": {
     "keywords": ["purple-square", "sign", "zodiac", "astrology"],
     "char": "♓",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "id": {
     "keywords": ["purple-square", "words"],
     "char": "🆔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "atom_symbol": {
     "keywords": ["science", "physics", "chemistry"],
     "char": "⚛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.1"
   },
   "u7a7a": {
     "keywords": ["kanji", "japanese", "chinese", "empty", "sky", "blue-square"],
     "char": "🈳",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u5272": {
     "keywords": ["cut", "divide", "chinese", "kanji", "pink-square"],
     "char": "🈹",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "radioactive": {
     "keywords": ["nuclear", "danger"],
     "char": "☢",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "biohazard": {
     "keywords": ["danger"],
     "char": "☣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "mobile_phone_off": {
     "keywords": ["mute", "orange-square", "silence", "quiet"],
     "char": "📴",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "vibration_mode": {
     "keywords": ["orange-square", "phone"],
     "char": "📳",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u6709": {
     "keywords": ["orange-square", "chinese", "have", "kanji"],
     "char": "🈶",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u7121": {
     "keywords": ["nothing", "chinese", "kanji", "japanese", "orange-square"],
     "char": "🈚",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "u7533": {
     "keywords": ["chinese", "japanese", "kanji", "orange-square"],
     "char": "🈸",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u55b6": {
     "keywords": ["japanese", "opening hours", "orange-square"],
     "char": "🈺",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u6708": {
     "keywords": ["chinese", "month", "moon", "japanese", "orange-square", "kanji"],
     "char": "🈷️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "eight_pointed_black_star": {
     "keywords": ["orange-square", "shape", "polygon"],
     "char": "✴️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "vs": {
     "keywords": ["words", "orange-square"],
     "char": "🆚",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "accept": {
     "keywords": ["ok", "good", "chinese", "kanji", "agree", "yes", "orange-circle"],
     "char": "🉑",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "white_flower": {
     "keywords": ["japanese", "spring"],
     "char": "💮",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "ideograph_advantage": {
     "keywords": ["chinese", "kanji", "obtain", "get", "circle"],
     "char": "🉐",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "secret": {
     "keywords": ["privacy", "chinese", "sshh", "kanji", "red-circle"],
     "char": "㊙️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "congratulations": {
     "keywords": ["chinese", "kanji", "japanese", "red-circle"],
     "char": "㊗️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "u5408": {
     "keywords": ["japanese", "chinese", "join", "kanji", "red-square"],
     "char": "🈴",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u6e80": {
     "keywords": ["full", "chinese", "japanese", "red-square", "kanji"],
     "char": "🈵",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "u7981": {
     "keywords": ["kanji", "japanese", "chinese", "forbidden", "limit", "restricted", "red-square"],
     "char": "🈲",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "a": {
     "keywords": ["red-square", "alphabet", "letter"],
     "char": "🅰️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "b": {
     "keywords": ["red-square", "alphabet", "letter"],
     "char": "🅱️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "ab": {
     "keywords": ["red-square", "alphabet"],
     "char": "🆎",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "cl": {
     "keywords": ["alphabet", "words", "red-square"],
     "char": "🆑",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "o2": {
     "keywords": ["alphabet", "red-square", "letter"],
     "char": "🅾️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "sos": {
     "keywords": ["help", "red-square", "words", "emergency", "911"],
     "char": "🆘",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "no_entry": {
     "keywords": ["limit", "security", "privacy", "bad", "denied", "stop", "circle"],
     "char": "⛔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "name_badge": {
     "keywords": ["fire", "forbid"],
     "char": "📛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "no_entry_sign": {
     "keywords": ["forbid", "stop", "limit", "denied", "disallow", "circle"],
     "char": "🚫",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "x": {
     "keywords": ["no", "delete", "remove", "cancel"],
     "char": "❌",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "o": {
     "keywords": ["circle", "round"],
     "char": "⭕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "stop_sign": {
     "keywords": ["stop"],
     "char": "🛑",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "9.0"
   },
   "anger": {
     "keywords": ["angry", "mad"],
     "char": "💢",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "hotsprings": {
     "keywords": ["bath", "warm", "relax"],
     "char": "♨️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "no_pedestrians": {
     "keywords": ["rules", "crossing", "walking", "circle"],
     "char": "🚷",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "do_not_litter": {
     "keywords": ["trash", "bin", "garbage", "circle"],
     "char": "🚯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "no_bicycles": {
     "keywords": ["cyclist", "prohibited", "circle"],
     "char": "🚳",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "non-potable_water": {
     "keywords": ["drink", "faucet", "tap", "circle"],
     "char": "🚱",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "underage": {
     "keywords": ["18", "drink", "pub", "night", "minor", "circle"],
     "char": "🔞",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "no_mobile_phones": {
     "keywords": ["iphone", "mute", "circle"],
     "char": "📵",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "exclamation": {
     "keywords": ["heavy_exclamation_mark", "danger", "surprise", "punctuation", "wow", "warning"],
     "char": "❗",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "grey_exclamation": {
     "keywords": ["surprise", "punctuation", "gray", "wow", "warning"],
     "char": "❕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "question": {
     "keywords": ["doubt", "confused"],
     "char": "❓",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "grey_question": {
     "keywords": ["doubts", "gray", "huh", "confused"],
     "char": "❔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "bangbang": {
     "keywords": ["exclamation", "surprise"],
     "char": "‼️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "interrobang": {
     "keywords": ["wat", "punctuation", "surprise"],
     "char": "⁉️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.0"
   },
   "100": {
     "keywords": ["score", "perfect", "numbers", "century", "exam", "quiz", "test", "pass", "hundred"],
     "char": "💯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "low_brightness": {
     "keywords": ["sun", "afternoon", "warm", "summer"],
     "char": "🔅",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "high_brightness": {
     "keywords": ["sun", "light"],
     "char": "🔆",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "trident": {
     "keywords": ["weapon", "spear"],
     "char": "🔱",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "fleur_de_lis": {
     "keywords": ["decorative", "scout"],
     "char": "⚜",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.1"
   },
   "part_alternation_mark": {
     "keywords": ["graph", "presentation", "stats", "business", "economics", "bad"],
     "char": "〽️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "warning": {
     "keywords": ["exclamation", "wip", "alert", "error", "problem", "issue"],
     "char": "⚠️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.0"
   },
   "children_crossing": {
     "keywords": ["school", "warning", "danger", "sign", "driving", "yellow-diamond"],
     "char": "🚸",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "beginner": {
     "keywords": ["badge", "shield"],
     "char": "🔰",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "recycle": {
     "keywords": ["arrow", "environment", "garbage", "trash"],
     "char": "♻️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "u6307": {
     "keywords": ["chinese", "point", "green-square", "kanji"],
     "char": "🈯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "chart": {
     "keywords": ["green-square", "graph", "presentation", "stats"],
     "char": "💹",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "sparkle": {
     "keywords": ["stars", "green-square", "awesome", "good", "fireworks"],
     "char": "❇️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "eight_spoked_asterisk": {
     "keywords": ["star", "sparkle", "green-square"],
     "char": "✳️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "negative_squared_cross_mark": {
     "keywords": ["x", "green-square", "no", "deny"],
     "char": "❎",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "white_check_mark": {
     "keywords": ["green-square", "ok", "agree", "vote", "election", "answer", "tick"],
     "char": "✅",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "diamond_shape_with_a_dot_inside": {
     "keywords": ["jewel", "blue", "gem", "crystal", "fancy"],
     "char": "💠",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "cyclone": {
     "keywords": ["weather", "swirl", "blue", "cloud", "vortex", "spiral", "whirlpool", "spin"],
     "char": "🌀",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "loop": {
     "keywords": ["tape", "cassette"],
     "char": "➿",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "globe_with_meridians": {
     "keywords": ["earth", "international", "world", "internet", "interweb", "i18n"],
     "char": "🌐",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "m": {
     "keywords": ["alphabet", "blue-circle", "letter"],
     "char": "Ⓜ️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "atm": {
     "keywords": ["money", "sales", "cash", "blue-square", "payment", "bank"],
     "char": "🏧",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "sa": {
     "keywords": ["japanese", "blue-square", "katakana"],
     "char": "🈂️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "passport_control": {
     "keywords": ["custom", "blue-square"],
     "char": "🛂",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "customs": {
     "keywords": ["passport", "border", "blue-square"],
     "char": "🛃",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "baggage_claim": {
     "keywords": ["blue-square", "airport", "transport"],
     "char": "🛄",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "left_luggage": {
     "keywords": ["blue-square", "travel"],
     "char": "🛅",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "wheelchair": {
     "keywords": ["blue-square", "disabled", "a11y", "accessibility"],
     "char": "♿",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.1"
   },
   "no_smoking": {
     "keywords": ["cigarette", "blue-square", "smell", "smoke"],
     "char": "🚭",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "wc": {
     "keywords": ["toilet", "restroom", "blue-square"],
     "char": "🚾",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "parking": {
     "keywords": ["cars", "blue-square", "alphabet", "letter"],
     "char": "🅿️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.2"
   },
   "potable_water": {
     "keywords": ["blue-square", "liquid", "restroom", "cleaning", "faucet"],
     "char": "🚰",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "mens": {
     "keywords": ["toilet", "restroom", "wc", "blue-square", "gender", "male"],
     "char": "🚹",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "womens": {
     "keywords": ["purple-square", "woman", "female", "toilet", "loo", "restroom", "gender"],
     "char": "🚺",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "baby_symbol": {
     "keywords": ["orange-square", "child"],
     "char": "🚼",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "restroom": {
     "keywords": ["blue-square", "toilet", "refresh", "wc", "gender"],
     "char": "🚻",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "put_litter_in_its_place": {
     "keywords": ["blue-square", "sign", "human", "info"],
     "char": "🚮",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "cinema": {
     "keywords": ["blue-square", "record", "film", "movie", "curtain", "stage", "theater"],
     "char": "🎦",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "signal_strength": {
     "keywords": ["blue-square", "reception", "phone", "internet", "connection", "wifi", "bluetooth", "bars"],
     "char": "📶",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "koko": {
     "keywords": ["blue-square", "here", "katakana", "japanese", "destination"],
     "char": "🈁",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "ng": {
     "keywords": ["blue-square", "words", "shape", "icon"],
     "char": "🆖",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "ok": {
     "keywords": ["good", "agree", "yes", "blue-square"],
     "char": "🆗",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "up": {
     "keywords": ["blue-square", "above", "high"],
     "char": "🆙",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "cool": {
     "keywords": ["words", "blue-square"],
     "char": "🆒",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "new": {
     "keywords": ["blue-square", "words", "start"],
     "char": "🆕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "free": {
     "keywords": ["blue-square", "words"],
     "char": "🆓",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "zero": {
     "keywords": ["0", "numbers", "blue-square", "null"],
     "char": "0️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "one": {
     "keywords": ["blue-square", "numbers", "1"],
     "char": "1️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "two": {
     "keywords": ["numbers", "2", "prime", "blue-square"],
     "char": "2️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "three": {
     "keywords": ["3", "numbers", "prime", "blue-square"],
     "char": "3️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "four": {
     "keywords": ["4", "numbers", "blue-square"],
     "char": "4️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "five": {
     "keywords": ["5", "numbers", "blue-square", "prime"],
     "char": "5️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "six": {
     "keywords": ["6", "numbers", "blue-square"],
     "char": "6️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "seven": {
     "keywords": ["7", "numbers", "blue-square", "prime"],
     "char": "7️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "eight": {
     "keywords": ["8", "blue-square", "numbers"],
     "char": "8️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "nine": {
     "keywords": ["blue-square", "numbers", "9"],
     "char": "9️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "keycap_ten": {
     "keywords": ["numbers", "10", "blue-square"],
     "char": "🔟",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "asterisk": {
     "keywords": ["star", "keycap"],
     "char": "*⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "1234": {
     "keywords": ["numbers", "blue-square"],
     "char": "🔢",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_forward": {
     "keywords": ["blue-square", "right", "direction", "play"],
     "char": "▶️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "pause_button": {
     "keywords": ["pause", "blue-square"],
     "char": "⏸",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "next_track_button": {
     "keywords": ["forward", "next", "blue-square"],
     "char": "⏭",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "stop_button": {
     "keywords": ["blue-square"],
     "char": "⏹",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "record_button": {
     "keywords": ["blue-square"],
     "char": "⏺",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "play_or_pause_button": {
     "keywords": ["blue-square", "play", "pause"],
     "char": "⏯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "previous_track_button": {
     "keywords": ["backward"],
     "char": "⏮",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "fast_forward": {
     "keywords": ["blue-square", "play", "speed", "continue"],
     "char": "⏩",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "rewind": {
     "keywords": ["play", "blue-square"],
     "char": "⏪",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "twisted_rightwards_arrows": {
     "keywords": ["blue-square", "shuffle", "music", "random"],
     "char": "🔀",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "repeat": {
     "keywords": ["loop", "record"],
     "char": "🔁",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "repeat_one": {
     "keywords": ["blue-square", "loop"],
     "char": "🔂",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_backward": {
     "keywords": ["blue-square", "left", "direction"],
     "char": "◀️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_up_small": {
     "keywords": ["blue-square", "triangle", "direction", "point", "forward", "top"],
     "char": "🔼",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_down_small": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "🔽",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_double_up": {
     "keywords": ["blue-square", "direction", "top"],
     "char": "⏫",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_double_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⏬",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_right": {
     "keywords": ["blue-square", "next"],
     "char": "➡️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_left": {
     "keywords": ["blue-square", "previous", "back"],
     "char": "⬅️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.0"
   },
   "arrow_up": {
     "keywords": ["blue-square", "continue", "top", "direction"],
     "char": "⬆️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.0"
   },
   "arrow_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⬇️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.0"
   },
   "arrow_upper_right": {
     "keywords": ["blue-square", "point", "direction", "diagonal", "northeast"],
     "char": "↗️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_lower_right": {
     "keywords": ["blue-square", "direction", "diagonal", "southeast"],
     "char": "↘️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_lower_left": {
     "keywords": ["blue-square", "direction", "diagonal", "southwest"],
     "char": "↙️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_upper_left": {
     "keywords": ["blue-square", "point", "direction", "diagonal", "northwest"],
     "char": "↖️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_up_down": {
     "keywords": ["blue-square", "direction", "way", "vertical"],
     "char": "↕️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "left_right_arrow": {
     "keywords": ["shape", "direction", "horizontal", "sideways"],
     "char": "↔️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrows_counterclockwise": {
     "keywords": ["blue-square", "sync", "cycle"],
     "char": "🔄",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "arrow_right_hook": {
     "keywords": ["blue-square", "return", "rotate", "direction"],
     "char": "↪️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "leftwards_arrow_with_hook": {
     "keywords": ["back", "return", "blue-square", "undo", "enter"],
     "char": "↩️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrow_heading_up": {
     "keywords": ["blue-square", "direction", "top"],
     "char": "⤴️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "arrow_heading_down": {
     "keywords": ["blue-square", "direction", "bottom"],
     "char": "⤵️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "hash": {
     "keywords": ["symbol", "blue-square", "twitter"],
     "char": "#️⃣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "information_source": {
     "keywords": ["blue-square", "alphabet", "letter"],
     "char": "ℹ️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.0"
   },
   "abc": {
     "keywords": ["blue-square", "alphabet"],
     "char": "🔤",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "abcd": {
     "keywords": ["blue-square", "alphabet"],
     "char": "🔡",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "capital_abcd": {
     "keywords": ["alphabet", "words", "blue-square"],
     "char": "🔠",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "symbols": {
     "keywords": ["blue-square", "music", "note", "ampersand", "percent", "glyphs", "characters"],
     "char": "🔣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "musical_note": {
     "keywords": ["score", "tone", "sound"],
     "char": "🎵",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "notes": {
     "keywords": ["music", "score"],
     "char": "🎶",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "wavy_dash": {
     "keywords": ["draw", "line", "moustache", "mustache", "squiggle", "scribble"],
     "char": "〰️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "curly_loop": {
     "keywords": ["scribble", "draw", "shape", "squiggle"],
     "char": "➰",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_check_mark": {
     "keywords": ["ok", "nike", "answer", "yes", "tick"],
     "char": "✔️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "arrows_clockwise": {
     "keywords": ["sync", "cycle", "round", "repeat"],
     "char": "🔃",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_plus_sign": {
     "keywords": ["math", "calculation", "addition", "more", "increase"],
     "char": "➕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_minus_sign": {
     "keywords": ["math", "calculation", "subtract", "less"],
     "char": "➖",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_division_sign": {
     "keywords": ["divide", "math", "calculation"],
     "char": "➗",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "heavy_multiplication_x": {
     "keywords": ["math", "calculation"],
     "char": "✖️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "heavy_dollar_sign": {
     "keywords": ["money", "sales", "payment", "currency", "buck"],
     "char": "💲",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "currency_exchange": {
     "keywords": ["money", "sales", "dollar", "travel"],
     "char": "💱",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "copyright": {
     "keywords": ["ip", "license", "circle", "law", "legal"],
     "char": "©️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "registered": {
     "keywords": ["alphabet", "circle"],
     "char": "®️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "tm": {
     "keywords": ["trademark", "brand", "law", "legal"],
     "char": "™️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "end": {
     "keywords": ["words", "arrow"],
     "char": "🔚",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "back": {
     "keywords": ["arrow", "words", "return"],
     "char": "🔙",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "on": {
     "keywords": ["arrow", "words"],
     "char": "🔛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "top": {
     "keywords": ["words", "blue-square"],
     "char": "🔝",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "soon": {
     "keywords": ["arrow", "words"],
     "char": "🔜",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "ballot_box_with_check": {
     "keywords": ["ok", "agree", "confirm", "black-square", "vote", "election", "yes", "tick"],
     "char": "☑️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "radio_button": {
     "keywords": ["input", "old", "music", "circle"],
     "char": "🔘",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "white_circle": {
     "keywords": ["shape", "round"],
     "char": "⚪",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.1"
   },
   "black_circle": {
     "keywords": ["shape", "button", "round"],
     "char": "⚫",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "4.1"
   },
   "red_circle": {
     "keywords": ["shape", "error", "danger"],
     "char": "🔴",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "large_blue_circle": {
     "keywords": ["shape", "icon", "button"],
     "char": "🔵",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "small_orange_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔸",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "small_blue_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔹",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "large_orange_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔶",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "large_blue_diamond": {
     "keywords": ["shape", "jewel", "gem"],
     "char": "🔷",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "small_red_triangle": {
     "keywords": ["shape", "direction", "up", "top"],
     "char": "🔺",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "black_small_square": {
     "keywords": ["shape", "icon"],
     "char": "▪️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "white_small_square": {
     "keywords": ["shape", "icon"],
     "char": "▫️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "black_large_square": {
     "keywords": ["shape", "icon", "button"],
     "char": "⬛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.1"
   },
   "white_large_square": {
     "keywords": ["shape", "icon", "stone", "button"],
     "char": "⬜",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.1"
   },
   "small_red_triangle_down": {
     "keywords": ["shape", "direction", "bottom"],
     "char": "🔻",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "black_medium_square": {
     "keywords": ["shape", "button", "icon"],
     "char": "◼️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "white_medium_square": {
     "keywords": ["shape", "stone", "icon"],
     "char": "◻️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "black_medium_small_square": {
     "keywords": ["icon", "shape", "button"],
     "char": "◾",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "white_medium_small_square": {
     "keywords": ["shape", "stone", "icon", "button"],
     "char": "◽",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "3.2"
   },
   "black_square_button": {
     "keywords": ["shape", "input", "frame"],
     "char": "🔲",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "white_square_button": {
     "keywords": ["shape", "input"],
     "char": "🔳",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "speaker": {
     "keywords": ["sound", "volume", "silence", "broadcast"],
     "char": "🔈",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "sound": {
     "keywords": ["volume", "speaker", "broadcast"],
     "char": "🔉",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "loud_sound": {
     "keywords": ["volume", "noise", "noisy", "speaker", "broadcast"],
     "char": "🔊",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "mute": {
     "keywords": ["sound", "volume", "silence", "quiet"],
     "char": "🔇",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "mega": {
     "keywords": ["sound", "speaker", "volume"],
     "char": "📣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "loudspeaker": {
     "keywords": ["volume", "sound"],
     "char": "📢",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "bell": {
     "keywords": ["sound", "notification", "christmas", "xmas", "chime"],
     "char": "🔔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "no_bell": {
     "keywords": ["sound", "volume", "mute", "quiet", "silent"],
     "char": "🔕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "black_joker": {
     "keywords": ["poker", "cards", "game", "play", "magic"],
     "char": "🃏",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "mahjong": {
     "keywords": ["game", "play", "chinese", "kanji"],
     "char": "🀄",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "5.1"
   },
   "spades": {
     "keywords": ["poker", "cards", "suits", "magic"],
     "char": "♠️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "clubs": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♣️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "hearts": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♥️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "diamonds": {
     "keywords": ["poker", "cards", "magic", "suits"],
     "char": "♦️",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "1.1"
   },
   "flower_playing_cards": {
     "keywords": ["game", "sunset", "red"],
     "char": "🎴",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "thought_balloon": {
     "keywords": ["bubble", "cloud", "speech", "thinking", "dream"],
     "char": "💭",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "right_anger_bubble": {
     "keywords": ["caption", "speech", "thinking", "mad"],
     "char": "🗯",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "speech_balloon": {
     "keywords": ["bubble", "words", "message", "talk", "chatting"],
     "char": "💬",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "left_speech_bubble": {
     "keywords": ["words", "message", "talk", "chatting"],
     "char": "🗨",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "7.0"
   },
   "clock1": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕐",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock2": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕑",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock3": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕒",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock4": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕓",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock5": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕔",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock6": {
     "keywords": ["time", "late", "early", "schedule", "dawn", "dusk"],
     "char": "🕕",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock7": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕖",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock8": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕗",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock9": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕘",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock10": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕙",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock11": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕚",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock12": {
     "keywords": ["time", "noon", "midnight", "midday", "late", "early", "schedule"],
     "char": "🕛",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock130": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕜",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock230": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕝",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock330": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕞",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock430": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕟",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock530": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕠",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock630": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕡",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock730": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕢",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock830": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕣",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock930": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕤",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock1030": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕥",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock1130": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕦",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "clock1230": {
     "keywords": ["time", "late", "early", "schedule"],
     "char": "🕧",
     "fitzpatrick_scale": false,
-    "category": "symbols"
+    "category": "symbols",
+    "unicode_version": "6.0"
   },
   "afghanistan": {
     "keywords": ["af", "flag", "nation", "country", "banner"],
     "char": "🇦🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "aland_islands": {
     "keywords": ["Åland", "islands", "flag", "nation", "country", "banner"],
     "char": "🇦🇽",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "albania": {
     "keywords": ["al", "flag", "nation", "country", "banner"],
     "char": "🇦🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "algeria": {
     "keywords": ["dz", "flag", "nation", "country", "banner"],
     "char": "🇩🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "american_samoa": {
     "keywords": ["american", "ws", "flag", "nation", "country", "banner"],
     "char": "🇦🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "andorra": {
     "keywords": ["ad", "flag", "nation", "country", "banner"],
     "char": "🇦🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "angola": {
     "keywords": ["ao", "flag", "nation", "country", "banner"],
     "char": "🇦🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "anguilla": {
     "keywords": ["ai", "flag", "nation", "country", "banner"],
     "char": "🇦🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "antarctica": {
     "keywords": ["aq", "flag", "nation", "country", "banner"],
     "char": "🇦🇶",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "antigua_barbuda": {
     "keywords": ["antigua", "barbuda", "flag", "nation", "country", "banner"],
     "char": "🇦🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "argentina": {
     "keywords": ["ar", "flag", "nation", "country", "banner"],
     "char": "🇦🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "armenia": {
     "keywords": ["am", "flag", "nation", "country", "banner"],
     "char": "🇦🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "aruba": {
     "keywords": ["aw", "flag", "nation", "country", "banner"],
     "char": "🇦🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "australia": {
     "keywords": ["au", "flag", "nation", "country", "banner"],
     "char": "🇦🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "austria": {
     "keywords": ["at", "flag", "nation", "country", "banner"],
     "char": "🇦🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "azerbaijan": {
     "keywords": ["az", "flag", "nation", "country", "banner"],
     "char": "🇦🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bahamas": {
     "keywords": ["bs", "flag", "nation", "country", "banner"],
     "char": "🇧🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bahrain": {
     "keywords": ["bh", "flag", "nation", "country", "banner"],
     "char": "🇧🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bangladesh": {
     "keywords": ["bd", "flag", "nation", "country", "banner"],
     "char": "🇧🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "barbados": {
     "keywords": ["bb", "flag", "nation", "country", "banner"],
     "char": "🇧🇧",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "belarus": {
     "keywords": ["by", "flag", "nation", "country", "banner"],
     "char": "🇧🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "belgium": {
     "keywords": ["be", "flag", "nation", "country", "banner"],
     "char": "🇧🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "belize": {
     "keywords": ["bz", "flag", "nation", "country", "banner"],
     "char": "🇧🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "benin": {
     "keywords": ["bj", "flag", "nation", "country", "banner"],
     "char": "🇧🇯",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bermuda": {
     "keywords": ["bm", "flag", "nation", "country", "banner"],
     "char": "🇧🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bhutan": {
     "keywords": ["bt", "flag", "nation", "country", "banner"],
     "char": "🇧🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bolivia": {
     "keywords": ["bo", "flag", "nation", "country", "banner"],
     "char": "🇧🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "caribbean_netherlands": {
     "keywords": ["bonaire", "flag", "nation", "country", "banner"],
     "char": "🇧🇶",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bosnia_herzegovina": {
     "keywords": ["bosnia", "herzegovina", "flag", "nation", "country", "banner"],
     "char": "🇧🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "botswana": {
     "keywords": ["bw", "flag", "nation", "country", "banner"],
     "char": "🇧🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "brazil": {
     "keywords": ["br", "flag", "nation", "country", "banner"],
     "char": "🇧🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "british_indian_ocean_territory": {
     "keywords": ["british", "indian", "ocean", "territory", "flag", "nation", "country", "banner"],
     "char": "🇮🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "british_virgin_islands": {
     "keywords": ["british", "virgin", "islands", "bvi", "flag", "nation", "country", "banner"],
     "char": "🇻🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "brunei": {
     "keywords": ["bn", "darussalam", "flag", "nation", "country", "banner"],
     "char": "🇧🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "bulgaria": {
     "keywords": ["bg", "flag", "nation", "country", "banner"],
     "char": "🇧🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "burkina_faso": {
     "keywords": ["burkina", "faso", "flag", "nation", "country", "banner"],
     "char": "🇧🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "burundi": {
     "keywords": ["bi", "flag", "nation", "country", "banner"],
     "char": "🇧🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cape_verde": {
     "keywords": ["cabo", "verde", "flag", "nation", "country", "banner"],
     "char": "🇨🇻",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cambodia": {
     "keywords": ["kh", "flag", "nation", "country", "banner"],
     "char": "🇰🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cameroon": {
     "keywords": ["cm", "flag", "nation", "country", "banner"],
     "char": "🇨🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "canada": {
     "keywords": ["ca", "flag", "nation", "country", "banner"],
     "char": "🇨🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "canary_islands": {
     "keywords": ["canary", "islands", "flag", "nation", "country", "banner"],
     "char": "🇮🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cayman_islands": {
     "keywords": ["cayman", "islands", "flag", "nation", "country", "banner"],
     "char": "🇰🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "central_african_republic": {
     "keywords": ["central", "african", "republic", "flag", "nation", "country", "banner"],
     "char": "🇨🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "chad": {
     "keywords": ["td", "flag", "nation", "country", "banner"],
     "char": "🇹🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "chile": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇨🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cn": {
     "keywords": ["china", "chinese", "prc", "flag", "country", "nation", "banner"],
     "char": "🇨🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "christmas_island": {
     "keywords": ["christmas", "island", "flag", "nation", "country", "banner"],
     "char": "🇨🇽",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cocos_islands": {
     "keywords": ["cocos", "keeling", "islands", "flag", "nation", "country", "banner"],
     "char": "🇨🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "colombia": {
     "keywords": ["co", "flag", "nation", "country", "banner"],
     "char": "🇨🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "comoros": {
     "keywords": ["km", "flag", "nation", "country", "banner"],
     "char": "🇰🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "congo_brazzaville": {
     "keywords": ["congo", "flag", "nation", "country", "banner"],
     "char": "🇨🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "congo_kinshasa": {
     "keywords": ["congo", "democratic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇨🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cook_islands": {
     "keywords": ["cook", "islands", "flag", "nation", "country", "banner"],
     "char": "🇨🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "costa_rica": {
     "keywords": ["costa", "rica", "flag", "nation", "country", "banner"],
     "char": "🇨🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "croatia": {
     "keywords": ["hr", "flag", "nation", "country", "banner"],
     "char": "🇭🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cuba": {
     "keywords": ["cu", "flag", "nation", "country", "banner"],
     "char": "🇨🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "curacao": {
     "keywords": ["curaçao", "flag", "nation", "country", "banner"],
     "char": "🇨🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cyprus": {
     "keywords": ["cy", "flag", "nation", "country", "banner"],
     "char": "🇨🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "czech_republic": {
     "keywords": ["cz", "flag", "nation", "country", "banner"],
     "char": "🇨🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "denmark": {
     "keywords": ["dk", "flag", "nation", "country", "banner"],
     "char": "🇩🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "djibouti": {
     "keywords": ["dj", "flag", "nation", "country", "banner"],
     "char": "🇩🇯",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "dominica": {
     "keywords": ["dm", "flag", "nation", "country", "banner"],
     "char": "🇩🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "dominican_republic": {
     "keywords": ["dominican", "republic", "flag", "nation", "country", "banner"],
     "char": "🇩🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ecuador": {
     "keywords": ["ec", "flag", "nation", "country", "banner"],
     "char": "🇪🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "egypt": {
     "keywords": ["eg", "flag", "nation", "country", "banner"],
     "char": "🇪🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "el_salvador": {
     "keywords": ["el", "salvador", "flag", "nation", "country", "banner"],
     "char": "🇸🇻",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "equatorial_guinea": {
     "keywords": ["equatorial", "gn", "flag", "nation", "country", "banner"],
     "char": "🇬🇶",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "eritrea": {
     "keywords": ["er", "flag", "nation", "country", "banner"],
     "char": "🇪🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "estonia": {
     "keywords": ["ee", "flag", "nation", "country", "banner"],
     "char": "🇪🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ethiopia": {
     "keywords": ["et", "flag", "nation", "country", "banner"],
     "char": "🇪🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "eu": {
     "keywords": ["european", "union", "flag", "banner"],
     "char": "🇪🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "falkland_islands": {
     "keywords": ["falkland", "islands", "malvinas", "flag", "nation", "country", "banner"],
     "char": "🇫🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "faroe_islands": {
     "keywords": ["faroe", "islands", "flag", "nation", "country", "banner"],
     "char": "🇫🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "fiji": {
     "keywords": ["fj", "flag", "nation", "country", "banner"],
     "char": "🇫🇯",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "finland": {
     "keywords": ["fi", "flag", "nation", "country", "banner"],
     "char": "🇫🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "fr": {
     "keywords": ["banner", "flag", "nation", "france", "french", "country"],
     "char": "🇫🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "french_guiana": {
     "keywords": ["french", "guiana", "flag", "nation", "country", "banner"],
     "char": "🇬🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "french_polynesia": {
     "keywords": ["french", "polynesia", "flag", "nation", "country", "banner"],
     "char": "🇵🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "french_southern_territories": {
     "keywords": ["french", "southern", "territories", "flag", "nation", "country", "banner"],
     "char": "🇹🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "gabon": {
     "keywords": ["ga", "flag", "nation", "country", "banner"],
     "char": "🇬🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "gambia": {
     "keywords": ["gm", "flag", "nation", "country", "banner"],
     "char": "🇬🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "georgia": {
     "keywords": ["ge", "flag", "nation", "country", "banner"],
     "char": "🇬🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "de": {
     "keywords": ["german", "nation", "flag", "country", "banner"],
     "char": "🇩🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ghana": {
     "keywords": ["gh", "flag", "nation", "country", "banner"],
     "char": "🇬🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "gibraltar": {
     "keywords": ["gi", "flag", "nation", "country", "banner"],
     "char": "🇬🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "greece": {
     "keywords": ["gr", "flag", "nation", "country", "banner"],
     "char": "🇬🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "greenland": {
     "keywords": ["gl", "flag", "nation", "country", "banner"],
     "char": "🇬🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "grenada": {
     "keywords": ["gd", "flag", "nation", "country", "banner"],
     "char": "🇬🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guadeloupe": {
     "keywords": ["gp", "flag", "nation", "country", "banner"],
     "char": "🇬🇵",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guam": {
     "keywords": ["gu", "flag", "nation", "country", "banner"],
     "char": "🇬🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guatemala": {
     "keywords": ["gt", "flag", "nation", "country", "banner"],
     "char": "🇬🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guernsey": {
     "keywords": ["gg", "flag", "nation", "country", "banner"],
     "char": "🇬🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guinea": {
     "keywords": ["gn", "flag", "nation", "country", "banner"],
     "char": "🇬🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guinea_bissau": {
     "keywords": ["gw", "bissau", "flag", "nation", "country", "banner"],
     "char": "🇬🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "guyana": {
     "keywords": ["gy", "flag", "nation", "country", "banner"],
     "char": "🇬🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "haiti": {
     "keywords": ["ht", "flag", "nation", "country", "banner"],
     "char": "🇭🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "honduras": {
     "keywords": ["hn", "flag", "nation", "country", "banner"],
     "char": "🇭🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "hong_kong": {
     "keywords": ["hong", "kong", "flag", "nation", "country", "banner"],
     "char": "🇭🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "hungary": {
     "keywords": ["hu", "flag", "nation", "country", "banner"],
     "char": "🇭🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "iceland": {
     "keywords": ["is", "flag", "nation", "country", "banner"],
     "char": "🇮🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "india": {
     "keywords": ["in", "flag", "nation", "country", "banner"],
     "char": "🇮🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "indonesia": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇮🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "iran": {
     "keywords": ["iran,", "islamic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇮🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "iraq": {
     "keywords": ["iq", "flag", "nation", "country", "banner"],
     "char": "🇮🇶",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ireland": {
     "keywords": ["ie", "flag", "nation", "country", "banner"],
     "char": "🇮🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "isle_of_man": {
     "keywords": ["isle", "man", "flag", "nation", "country", "banner"],
     "char": "🇮🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "israel": {
     "keywords": ["il", "flag", "nation", "country", "banner"],
     "char": "🇮🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "it": {
     "keywords": ["italy", "flag", "nation", "country", "banner"],
     "char": "🇮🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "cote_divoire": {
     "keywords": ["ivory", "coast", "flag", "nation", "country", "banner"],
     "char": "🇨🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "jamaica": {
     "keywords": ["jm", "flag", "nation", "country", "banner"],
     "char": "🇯🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "jp": {
     "keywords": ["japanese", "nation", "flag", "country", "banner"],
     "char": "🇯🇵",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "jersey": {
     "keywords": ["je", "flag", "nation", "country", "banner"],
     "char": "🇯🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "jordan": {
     "keywords": ["jo", "flag", "nation", "country", "banner"],
     "char": "🇯🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kazakhstan": {
     "keywords": ["kz", "flag", "nation", "country", "banner"],
     "char": "🇰🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kenya": {
     "keywords": ["ke", "flag", "nation", "country", "banner"],
     "char": "🇰🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kiribati": {
     "keywords": ["ki", "flag", "nation", "country", "banner"],
     "char": "🇰🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kosovo": {
     "keywords": ["xk", "flag", "nation", "country", "banner"],
     "char": "🇽🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kuwait": {
     "keywords": ["kw", "flag", "nation", "country", "banner"],
     "char": "🇰🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kyrgyzstan": {
     "keywords": ["kg", "flag", "nation", "country", "banner"],
     "char": "🇰🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "laos": {
     "keywords": ["lao", "democratic", "republic", "flag", "nation", "country", "banner"],
     "char": "🇱🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "latvia": {
     "keywords": ["lv", "flag", "nation", "country", "banner"],
     "char": "🇱🇻",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "lebanon": {
     "keywords": ["lb", "flag", "nation", "country", "banner"],
     "char": "🇱🇧",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "lesotho": {
     "keywords": ["ls", "flag", "nation", "country", "banner"],
     "char": "🇱🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "liberia": {
     "keywords": ["lr", "flag", "nation", "country", "banner"],
     "char": "🇱🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "libya": {
     "keywords": ["ly", "flag", "nation", "country", "banner"],
     "char": "🇱🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "liechtenstein": {
     "keywords": ["li", "flag", "nation", "country", "banner"],
     "char": "🇱🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "lithuania": {
     "keywords": ["lt", "flag", "nation", "country", "banner"],
     "char": "🇱🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "luxembourg": {
     "keywords": ["lu", "flag", "nation", "country", "banner"],
     "char": "🇱🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "macau": {
     "keywords": ["macao", "flag", "nation", "country", "banner"],
     "char": "🇲🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "macedonia": {
     "keywords": ["macedonia,", "flag", "nation", "country", "banner"],
     "char": "🇲🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "madagascar": {
     "keywords": ["mg", "flag", "nation", "country", "banner"],
     "char": "🇲🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "malawi": {
     "keywords": ["mw", "flag", "nation", "country", "banner"],
     "char": "🇲🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "malaysia": {
     "keywords": ["my", "flag", "nation", "country", "banner"],
     "char": "🇲🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "maldives": {
     "keywords": ["mv", "flag", "nation", "country", "banner"],
     "char": "🇲🇻",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mali": {
     "keywords": ["ml", "flag", "nation", "country", "banner"],
     "char": "🇲🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "malta": {
     "keywords": ["mt", "flag", "nation", "country", "banner"],
     "char": "🇲🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "marshall_islands": {
     "keywords": ["marshall", "islands", "flag", "nation", "country", "banner"],
     "char": "🇲🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "martinique": {
     "keywords": ["mq", "flag", "nation", "country", "banner"],
     "char": "🇲🇶",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mauritania": {
     "keywords": ["mr", "flag", "nation", "country", "banner"],
     "char": "🇲🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mauritius": {
     "keywords": ["mu", "flag", "nation", "country", "banner"],
     "char": "🇲🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mayotte": {
     "keywords": ["yt", "flag", "nation", "country", "banner"],
     "char": "🇾🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mexico": {
     "keywords": ["mx", "flag", "nation", "country", "banner"],
     "char": "🇲🇽",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "micronesia": {
     "keywords": ["micronesia,", "federated", "states", "flag", "nation", "country", "banner"],
     "char": "🇫🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "moldova": {
     "keywords": ["moldova,", "republic", "flag", "nation", "country", "banner"],
     "char": "🇲🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "monaco": {
     "keywords": ["mc", "flag", "nation", "country", "banner"],
     "char": "🇲🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mongolia": {
     "keywords": ["mn", "flag", "nation", "country", "banner"],
     "char": "🇲🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "montenegro": {
     "keywords": ["me", "flag", "nation", "country", "banner"],
     "char": "🇲🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "montserrat": {
     "keywords": ["ms", "flag", "nation", "country", "banner"],
     "char": "🇲🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "morocco": {
     "keywords": ["ma", "flag", "nation", "country", "banner"],
     "char": "🇲🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "mozambique": {
     "keywords": ["mz", "flag", "nation", "country", "banner"],
     "char": "🇲🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "myanmar": {
     "keywords": ["mm", "flag", "nation", "country", "banner"],
     "char": "🇲🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "namibia": {
     "keywords": ["na", "flag", "nation", "country", "banner"],
     "char": "🇳🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "nauru": {
     "keywords": ["nr", "flag", "nation", "country", "banner"],
     "char": "🇳🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "nepal": {
     "keywords": ["np", "flag", "nation", "country", "banner"],
     "char": "🇳🇵",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "netherlands": {
     "keywords": ["nl", "flag", "nation", "country", "banner"],
     "char": "🇳🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "new_caledonia": {
     "keywords": ["new", "caledonia", "flag", "nation", "country", "banner"],
     "char": "🇳🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "new_zealand": {
     "keywords": ["new", "zealand", "flag", "nation", "country", "banner"],
     "char": "🇳🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "nicaragua": {
     "keywords": ["ni", "flag", "nation", "country", "banner"],
     "char": "🇳🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "niger": {
     "keywords": ["ne", "flag", "nation", "country", "banner"],
     "char": "🇳🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "nigeria": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇳🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "niue": {
     "keywords": ["nu", "flag", "nation", "country", "banner"],
     "char": "🇳🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "norfolk_island": {
     "keywords": ["norfolk", "island", "flag", "nation", "country", "banner"],
     "char": "🇳🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "northern_mariana_islands": {
     "keywords": ["northern", "mariana", "islands", "flag", "nation", "country", "banner"],
     "char": "🇲🇵",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "north_korea": {
     "keywords": ["north", "korea", "nation", "flag", "country", "banner"],
     "char": "🇰🇵",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "norway": {
     "keywords": ["no", "flag", "nation", "country", "banner"],
     "char": "🇳🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "oman": {
     "keywords": ["om_symbol", "flag", "nation", "country", "banner"],
     "char": "🇴🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "pakistan": {
     "keywords": ["pk", "flag", "nation", "country", "banner"],
     "char": "🇵🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "palau": {
     "keywords": ["pw", "flag", "nation", "country", "banner"],
     "char": "🇵🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "palestinian_territories": {
     "keywords": ["palestine", "palestinian", "territories", "flag", "nation", "country", "banner"],
     "char": "🇵🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "panama": {
     "keywords": ["pa", "flag", "nation", "country", "banner"],
     "char": "🇵🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "papua_new_guinea": {
     "keywords": ["papua", "new", "guinea", "flag", "nation", "country", "banner"],
     "char": "🇵🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "paraguay": {
     "keywords": ["py", "flag", "nation", "country", "banner"],
     "char": "🇵🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "peru": {
     "keywords": ["pe", "flag", "nation", "country", "banner"],
     "char": "🇵🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "philippines": {
     "keywords": ["ph", "flag", "nation", "country", "banner"],
     "char": "🇵🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "pitcairn_islands": {
     "keywords": ["pitcairn", "flag", "nation", "country", "banner"],
     "char": "🇵🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "poland": {
     "keywords": ["pl", "flag", "nation", "country", "banner"],
     "char": "🇵🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "portugal": {
     "keywords": ["pt", "flag", "nation", "country", "banner"],
     "char": "🇵🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "puerto_rico": {
     "keywords": ["puerto", "rico", "flag", "nation", "country", "banner"],
     "char": "🇵🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "qatar": {
     "keywords": ["qa", "flag", "nation", "country", "banner"],
     "char": "🇶🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "reunion": {
     "keywords": ["réunion", "flag", "nation", "country", "banner"],
     "char": "🇷🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "romania": {
     "keywords": ["ro", "flag", "nation", "country", "banner"],
     "char": "🇷🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ru": {
     "keywords": ["russian", "federation", "flag", "nation", "country", "banner"],
     "char": "🇷🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "rwanda": {
     "keywords": ["rw", "flag", "nation", "country", "banner"],
     "char": "🇷🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_barthelemy": {
     "keywords": ["saint", "barthélemy", "flag", "nation", "country", "banner"],
     "char": "🇧🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_helena": {
     "keywords": ["saint", "helena", "ascension", "tristan", "cunha", "flag", "nation", "country", "banner"],
     "char": "🇸🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_kitts_nevis": {
     "keywords": ["saint", "kitts", "nevis", "flag", "nation", "country", "banner"],
     "char": "🇰🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_lucia": {
     "keywords": ["saint", "lucia", "flag", "nation", "country", "banner"],
     "char": "🇱🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_pierre_miquelon": {
     "keywords": ["saint", "pierre", "miquelon", "flag", "nation", "country", "banner"],
     "char": "🇵🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "st_vincent_grenadines": {
     "keywords": ["saint", "vincent", "grenadines", "flag", "nation", "country", "banner"],
     "char": "🇻🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "samoa": {
     "keywords": ["ws", "flag", "nation", "country", "banner"],
     "char": "🇼🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "san_marino": {
     "keywords": ["san", "marino", "flag", "nation", "country", "banner"],
     "char": "🇸🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sao_tome_principe": {
     "keywords": ["sao", "tome", "principe", "flag", "nation", "country", "banner"],
     "char": "🇸🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "saudi_arabia": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇸🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "senegal": {
     "keywords": ["sn", "flag", "nation", "country", "banner"],
     "char": "🇸🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "serbia": {
     "keywords": ["rs", "flag", "nation", "country", "banner"],
     "char": "🇷🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "seychelles": {
     "keywords": ["sc", "flag", "nation", "country", "banner"],
     "char": "🇸🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sierra_leone": {
     "keywords": ["sierra", "leone", "flag", "nation", "country", "banner"],
     "char": "🇸🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "singapore": {
     "keywords": ["sg", "flag", "nation", "country", "banner"],
     "char": "🇸🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sint_maarten": {
     "keywords": ["sint", "maarten", "dutch", "flag", "nation", "country", "banner"],
     "char": "🇸🇽",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "slovakia": {
     "keywords": ["sk", "flag", "nation", "country", "banner"],
     "char": "🇸🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "slovenia": {
     "keywords": ["si", "flag", "nation", "country", "banner"],
     "char": "🇸🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "solomon_islands": {
     "keywords": ["solomon", "islands", "flag", "nation", "country", "banner"],
     "char": "🇸🇧",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "somalia": {
     "keywords": ["so", "flag", "nation", "country", "banner"],
     "char": "🇸🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "south_africa": {
     "keywords": ["south", "africa", "flag", "nation", "country", "banner"],
     "char": "🇿🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "south_georgia_south_sandwich_islands": {
     "keywords": ["south", "georgia", "sandwich", "islands", "flag", "nation", "country", "banner"],
     "char": "🇬🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "kr": {
     "keywords": ["south", "korea", "nation", "flag", "country", "banner"],
     "char": "🇰🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "south_sudan": {
     "keywords": ["south", "sd", "flag", "nation", "country", "banner"],
     "char": "🇸🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "es": {
     "keywords": ["spain", "flag", "nation", "country", "banner"],
     "char": "🇪🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sri_lanka": {
     "keywords": ["sri", "lanka", "flag", "nation", "country", "banner"],
     "char": "🇱🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sudan": {
     "keywords": ["sd", "flag", "nation", "country", "banner"],
     "char": "🇸🇩",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "suriname": {
     "keywords": ["sr", "flag", "nation", "country", "banner"],
     "char": "🇸🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "swaziland": {
     "keywords": ["sz", "flag", "nation", "country", "banner"],
     "char": "🇸🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "sweden": {
     "keywords": ["se", "flag", "nation", "country", "banner"],
     "char": "🇸🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "switzerland": {
     "keywords": ["ch", "flag", "nation", "country", "banner"],
     "char": "🇨🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "syria": {
     "keywords": ["syrian", "arab", "republic", "flag", "nation", "country", "banner"],
     "char": "🇸🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "taiwan": {
     "keywords": ["tw", "flag", "nation", "country", "banner"],
     "char": "🇹🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tajikistan": {
     "keywords": ["tj", "flag", "nation", "country", "banner"],
     "char": "🇹🇯",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tanzania": {
     "keywords": ["tanzania,", "united", "republic", "flag", "nation", "country", "banner"],
     "char": "🇹🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "thailand": {
     "keywords": ["th", "flag", "nation", "country", "banner"],
     "char": "🇹🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "timor_leste": {
     "keywords": ["timor", "leste", "flag", "nation", "country", "banner"],
     "char": "🇹🇱",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "togo": {
     "keywords": ["tg", "flag", "nation", "country", "banner"],
     "char": "🇹🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tokelau": {
     "keywords": ["tk", "flag", "nation", "country", "banner"],
     "char": "🇹🇰",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tonga": {
     "keywords": ["to", "flag", "nation", "country", "banner"],
     "char": "🇹🇴",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "trinidad_tobago": {
     "keywords": ["trinidad", "tobago", "flag", "nation", "country", "banner"],
     "char": "🇹🇹",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tunisia": {
     "keywords": ["tn", "flag", "nation", "country", "banner"],
     "char": "🇹🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tr": {
     "keywords": ["turkey", "flag", "nation", "country", "banner"],
     "char": "🇹🇷",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "8.0"
   },
   "turkmenistan": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇹🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "turks_caicos_islands": {
     "keywords": ["turks", "caicos", "islands", "flag", "nation", "country", "banner"],
     "char": "🇹🇨",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "tuvalu": {
     "keywords": ["flag", "nation", "country", "banner"],
     "char": "🇹🇻",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "uganda": {
     "keywords": ["ug", "flag", "nation", "country", "banner"],
     "char": "🇺🇬",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "ukraine": {
     "keywords": ["ua", "flag", "nation", "country", "banner"],
     "char": "🇺🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "united_arab_emirates": {
     "keywords": ["united", "arab", "emirates", "flag", "nation", "country", "banner"],
     "char": "🇦🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "uk": {
     "keywords": ["united", "kingdom", "great", "britain", "northern", "ireland", "flag", "nation", "country", "banner", "british", "UK", "english", "england", "union jack"],
     "char": "🇬🇧",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "us": {
     "keywords": ["united", "states", "america", "flag", "nation", "country", "banner"],
     "char": "🇺🇸",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "us_virgin_islands": {
     "keywords": ["virgin", "islands", "us", "flag", "nation", "country", "banner"],
     "char": "🇻🇮",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "uruguay": {
     "keywords": ["uy", "flag", "nation", "country", "banner"],
     "char": "🇺🇾",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "uzbekistan": {
     "keywords": ["uz", "flag", "nation", "country", "banner"],
     "char": "🇺🇿",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "vanuatu": {
     "keywords": ["vu", "flag", "nation", "country", "banner"],
     "char": "🇻🇺",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "vatican_city": {
     "keywords": ["vatican", "city", "flag", "nation", "country", "banner"],
     "char": "🇻🇦",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "venezuela": {
     "keywords": ["ve", "bolivarian", "republic", "flag", "nation", "country", "banner"],
     "char": "🇻🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "vietnam": {
     "keywords": ["viet", "nam", "flag", "nation", "country", "banner"],
     "char": "🇻🇳",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "wallis_futuna": {
     "keywords": ["wallis", "futuna", "flag", "nation", "country", "banner"],
     "char": "🇼🇫",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "western_sahara": {
     "keywords": ["western", "sahara", "flag", "nation", "country", "banner"],
     "char": "🇪🇭",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "yemen": {
     "keywords": ["ye", "flag", "nation", "country", "banner"],
     "char": "🇾🇪",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "zambia": {
     "keywords": ["zm", "flag", "nation", "country", "banner"],
     "char": "🇿🇲",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "zimbabwe": {
     "keywords": ["zw", "flag", "nation", "country", "banner"],
     "char": "🇿🇼",
     "fitzpatrick_scale": false,
-    "category": "flags"
+    "category": "flags",
+    "unicode_version": "6.0"
   },
   "octocat": {
     "keywords": ["animal", "octopus", "github", "custom_"],


### PR DESCRIPTION
Fixes #126.

There are still some missing versions (for woman health worker and man health worker for example). Many of these [are in Emoji 4.0](http://emojipedia.org/male-health-worker/) but I'm not sure what unicode version to list them as.

Currently I have the unicode versions for those 35 emojis set to an empty string. I'm not sure whether I should remove the `unicode_version` key for those ones, set it to something useful, or leave it empty.