### PR TITLE
🐛🔨 Remove stray whitespace from definition for 🧐 emoji

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -151,7 +151,7 @@
   },
   "monocle": {
     "keywords": ["face", "stuffy", "wealthy"],
-    "char": "🧐 ",
+    "char": "🧐",
     "fitzpatrick_scale": false,
     "category": "people"
   },


### PR DESCRIPTION
https://github.com/muan/emojilib/pull/145 accidentally included a space in the definition of the 🧐 emoji. Oops! 🙈

This pull request removes that stray whitespace. 😅