### PR TITLE
Fix man_facepalming 🤦‍♂️

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -1435,7 +1435,7 @@
   },
   "man_facepalming": {
     "keywords": ["man", "male", "boy", "disbelief"],
-    "char": "🤦",
+    "char": "🤦‍♂️",
     "fitzpatrick_scale": true,
     "category": "people"
   },


### PR DESCRIPTION
On its own, 🤦‍ is only a man facepalming on iOS. With the gender code added, it is correct everywhere (eg. twemoji).