### PR TITLE
Add "red" as keyword for ❌emoji

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -6312,7 +6312,7 @@
     "category": "symbols"
   },
   "x": {
-    "keywords": ["no", "delete", "remove", "cancel"],
+    "keywords": ["no", "delete", "remove", "cancel", "red"],
     "char": "❌",
     "fitzpatrick_scale": false,
     "category": "symbols"


### PR DESCRIPTION
☝️

/xref https://emojipedia.org/cross-mark