### PR TITLE
Add world currency signs

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -9418,5 +9418,35 @@
     "char": "🏴‍☠️",
     "fitzpatrick_scale": false,
     "category": "flags"
+  },
+  "pound_sign": {
+    "keywords": ["gbp", "british", "pound", "sterling", "currency"],
+    "char": "£",
+    "fitzpatrick_scale": false,
+    "category": "currency"
+  },
+  "euro_sign": {
+    "keywords": ["euro", "eur", "currency"],
+    "char": "€",
+    "fitzpatrick_scale": false,
+    "category": "currency"
+  },
+  "indian_rupee_sign": {
+    "keywords": ["inr", "rupee", "currency"],
+    "char": "₹",
+    "fitzpatrick_scale": false,
+    "category": "currency"
+  },
+  "yen_sign": {
+    "keywords": ["jpy", "yuan", "yen", "chinese", "japanese", "japan", "china", "currency"],
+    "char":"¥",
+    "fitzpatrick_scale": false,
+    "category": "currency"
+  },
+  "dollar_sign": {
+    "keywords": ["dollar", "usd", "sgd", "currency"],
+    "char": "$",
+    "fitzpatrick_scale": false,
+    "category": "currency"
   }
 }

--- a/ordered.json
+++ b/ordered.json
@@ -1568,5 +1568,10 @@
   "western_sahara",
   "yemen",
   "zambia",
-  "zimbabwe"
+  "zimbabwe",
+  "dollar_sign",
+  "euro_sign",
+  "pound_sign",
+  "indian_rupee_sign",
+  "yen_sign"
 ]


### PR DESCRIPTION
Would be nice to have. I use mojibar and this is something I miss a lot
If you do end up seeing this PR @muan, I also have a [PR in mojibar](https://github.com/muan/mojibar/pull/124) that adds vim shortcuts. do take a look.