### PR TITLE
Add +1/-1 keywords for thumbs up/down emoji

### DIFF
--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -1268,14 +1268,16 @@
     "accept",
     "cool",
     "hand",
-    "like"
+    "like",
+    "+1"
   ],
   "👎": [
     "thumbs_down",
     "thumbsdown",
     "no",
     "dislike",
-    "hand"
+    "hand",
+    "-1"
   ],
   "✊": [
     "raised_fist",


### PR DESCRIPTION
In 2.4 these were sort-of present because they were being used as the "name" of the emoji. The switch to keying this data by the emoji-character has effectively removed these keywords from the list.