### PR TITLE
Added 'augment-en' script to pull keywords from platform data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ Is ":D" a suitable keyword for 😀? (y/n/e) n
 [saved] 😀: grinning face, face, smile, happy, joy, grin
 ```
 
-- **Augment dataset** with `npm run augment [en-US]` to bring in keywords used in common emoji platforms
+- **Augment dataset** with `npm run augment-en` to bring in en-US keywords used in common emoji platforms
 
 ```
-$ npm run augment en-US
+$ npm run augment-en
 Augmented 123 emoji with a total of 456 keyword(s)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,10 @@ Is "joy" a suitable keyword for 😀? (y/n/e) y
 Is ":D" a suitable keyword for 😀? (y/n/e) n
 [saved] 😀: grinning face, face, smile, happy, joy, grin
 ```
+
+- **Augment dataset** with `npm run augment [en-US]` to bring in keywords used in common emoji platforms
+
+```
+$ npm run augment en-US
+Augmented 123 emoji with a total of 456 keyword(s)
+```

--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -6,7 +6,8 @@
     "happy",
     "joy",
     ":D",
-    "grin"
+    "grin",
+    "smiley"
   ],
   "😃": [
     "grinning_face_with_big_eyes",
@@ -17,7 +18,11 @@
     ":D",
     ":)",
     "smile",
-    "funny"
+    "funny",
+    "mouth",
+    "open",
+    "smiley",
+    "smiling"
   ],
   "😄": [
     "grinning_face_with_smiling_eyes",
@@ -30,7 +35,13 @@
     "like",
     ":D",
     ":)",
-    "smile"
+    "smile",
+    "eye",
+    "grin",
+    "mouth",
+    "open",
+    "pleased",
+    "smiley"
   ],
   "😁": [
     "beaming_face_with_smiling_eyes",
@@ -38,7 +49,10 @@
     "happy",
     "smile",
     "joy",
-    "kawaii"
+    "kawaii",
+    "eye",
+    "grin",
+    "grinning"
   ],
   "😆": [
     "grinning_squinting_face",
@@ -50,7 +64,17 @@
     "face",
     "glad",
     "XD",
-    "laugh"
+    "laugh",
+    "big",
+    "closed",
+    "eyes",
+    "grin",
+    "laughing",
+    "mouth",
+    "open",
+    "smile",
+    "smiling",
+    "tightly"
   ],
   "😅": [
     "grinning_face_with_sweat",
@@ -60,7 +84,12 @@
     "laugh",
     "sweat",
     "smile",
-    "relief"
+    "relief",
+    "cold",
+    "exercise",
+    "mouth",
+    "open",
+    "smiling"
   ],
   "🤣": [
     "rolling_on_the_floor_laughing",
@@ -70,7 +99,9 @@
     "laughing",
     "lol",
     "haha",
-    "rofl"
+    "rofl",
+    "laugh",
+    "rotfl"
   ],
   "😂": [
     "face_with_tears_of_joy",
@@ -80,19 +111,28 @@
     "weep",
     "happy",
     "happytears",
-    "haha"
+    "haha",
+    "crying",
+    "laugh",
+    "laughing",
+    "lol",
+    "tear"
   ],
   "🙂": [
     "slightly_smiling_face",
     "face",
-    "smile"
+    "smile",
+    "fine",
+    "happy",
+    "this"
   ],
   "🙃": [
     "upside_down_face",
     "face",
     "flipped",
     "silly",
-    "smile"
+    "smile",
+    "sarcasm"
   ],
   "😉": [
     "winking_face",
@@ -102,7 +142,10 @@
     "secret",
     ";)",
     "smile",
-    "eye"
+    "eye",
+    "flirt",
+    "wink",
+    "winky"
   ],
   "😊": [
     "smiling_face_with_smiling_eyes",
@@ -113,7 +156,12 @@
     "crush",
     "embarrassed",
     "shy",
-    "joy"
+    "joy",
+    "^^",
+    "blush",
+    "eye",
+    "proud",
+    "smiley"
   ],
   "😇": [
     "smiling_face_with_halo",
@@ -121,7 +169,11 @@
     "angel",
     "heaven",
     "halo",
-    "innocent"
+    "innocent",
+    "fairy",
+    "fantasy",
+    "smile",
+    "tale"
   ],
   "🥰": [
     "smiling_face_with_hearts",
@@ -133,7 +185,9 @@
     "infatuation",
     "crush",
     "hearts",
-    "adore"
+    "adore",
+    "eyes",
+    "three"
   ],
   "😍": [
     "smiling_face_with_heart_eyes",
@@ -144,7 +198,10 @@
     "valentines",
     "infatuation",
     "crush",
-    "heart"
+    "heart",
+    "eye",
+    "shaped",
+    "smile"
   ],
   "🤩": [
     "star_struck",
@@ -152,7 +209,10 @@
     "smile",
     "starry",
     "eyes",
-    "grinning"
+    "grinning",
+    "excited",
+    "eyed",
+    "wow"
   ],
   "😘": [
     "face_blowing_a_kiss",
@@ -162,7 +222,12 @@
     "affection",
     "valentines",
     "infatuation",
-    "kiss"
+    "kiss",
+    "blow",
+    "flirt",
+    "heart",
+    "kissing",
+    "throwing"
   ],
   "😗": [
     "kissing_face",
@@ -172,14 +237,24 @@
     "3",
     "valentines",
     "infatuation",
-    "kiss"
+    "kiss",
+    "duck",
+    "kissy",
+    "whistling"
   ],
   "☺️": [
     "smiling_face",
     "face",
     "blush",
     "massage",
-    "happiness"
+    "happiness",
+    "happy",
+    "outlined",
+    "pleased",
+    "relaxed",
+    "smile",
+    "smiley",
+    "white"
   ],
   "😚": [
     "kissing_face_with_closed_eyes",
@@ -189,7 +264,9 @@
     "affection",
     "valentines",
     "infatuation",
-    "kiss"
+    "kiss",
+    "eye",
+    "kissy"
   ],
   "😙": [
     "kissing_face_with_smiling_eyes",
@@ -197,7 +274,12 @@
     "affection",
     "valentines",
     "infatuation",
-    "kiss"
+    "kiss",
+    "eye",
+    "kissy",
+    "smile",
+    "whistle",
+    "whistling"
   ],
   "😋": [
     "face_savoring_food",
@@ -210,7 +292,15 @@
     "yummy",
     "nom",
     "delicious",
-    "savouring"
+    "savouring",
+    "goofy",
+    "hungry",
+    "lick",
+    "licking",
+    "lips",
+    "smiling",
+    "um",
+    "yum"
   ],
   "😛": [
     "face_with_tongue",
@@ -220,7 +310,10 @@
     "playful",
     "mischievous",
     "smile",
-    "tongue"
+    "tongue",
+    "cheeky",
+    "out",
+    "stuck"
   ],
   "😜": [
     "winking_face_with_tongue",
@@ -231,13 +324,28 @@
     "mischievous",
     "smile",
     "wink",
-    "tongue"
+    "tongue",
+    "crazy",
+    "eye",
+    "joke",
+    "out",
+    "silly",
+    "stuck"
   ],
   "🤪": [
     "zany_face",
     "face",
     "goofy",
-    "crazy"
+    "crazy",
+    "excited",
+    "eye",
+    "eyes",
+    "grinning",
+    "large",
+    "one",
+    "small",
+    "wacky",
+    "wild"
   ],
   "😝": [
     "squinting_face_with_tongue",
@@ -246,47 +354,83 @@
     "playful",
     "mischievous",
     "smile",
-    "tongue"
+    "tongue",
+    "closed",
+    "eye",
+    "eyes",
+    "horrible",
+    "out",
+    "stuck",
+    "taste",
+    "tightly"
   ],
   "🤑": [
     "money_mouth_face",
     "face",
     "rich",
     "dollar",
-    "money"
+    "money",
+    "eyes",
+    "sign"
   ],
   "🤗": [
     "hugging_face",
     "face",
     "smile",
-    "hug"
+    "hug",
+    "hands",
+    "hugs",
+    "open",
+    "smiling"
   ],
   "🤭": [
     "face_with_hand_over_mouth",
     "face",
     "whoops",
     "shock",
-    "surprise"
+    "surprise",
+    "blushing",
+    "covering",
+    "eyes",
+    "quiet",
+    "smiling"
   ],
   "🤫": [
     "shushing_face",
     "face",
     "quiet",
-    "shhh"
+    "shhh",
+    "closed",
+    "covering",
+    "finger",
+    "hush",
+    "lips",
+    "shh",
+    "shush",
+    "silence"
   ],
   "🤔": [
     "thinking_face",
     "face",
     "hmmm",
     "think",
-    "consider"
+    "consider",
+    "chin",
+    "shade",
+    "thinker",
+    "throwing",
+    "thumb"
   ],
   "🤐": [
     "zipper_mouth_face",
     "face",
     "sealed",
     "zipper",
-    "secret"
+    "secret",
+    "hush",
+    "lips",
+    "silence",
+    "zip"
   ],
   "🤨": [
     "face_with_raised_eyebrow",
@@ -296,14 +440,23 @@
     "disapproval",
     "disbelief",
     "surprise",
-    "suspicious"
+    "suspicious",
+    "colbert",
+    "mild",
+    "one",
+    "rock",
+    "skeptic"
   ],
   "😐": [
     "neutral_face",
     "indifference",
     "meh",
     ":|",
-    "neutral"
+    "neutral",
+    "deadpan",
+    "faced",
+    "mouth",
+    "straight"
   ],
   "😑": [
     "expressionless_face",
@@ -311,11 +464,22 @@
     "indifferent",
     "-_-",
     "meh",
-    "deadpan"
+    "deadpan",
+    "inexpressive",
+    "mouth",
+    "straight",
+    "unexpressive"
   ],
   "😶": [
     "face_without_mouth",
-    "face"
+    "face",
+    "blank",
+    "mouthless",
+    "mute",
+    "no",
+    "quiet",
+    "silence",
+    "silent"
   ],
   "😏": [
     "smirking_face",
@@ -324,7 +488,11 @@
     "mean",
     "prank",
     "smug",
-    "sarcasm"
+    "sarcasm",
+    "flirting",
+    "sexual",
+    "smirk",
+    "suggestive"
   ],
   "😒": [
     "unamused_face",
@@ -337,25 +505,42 @@
     "skeptical",
     "dubious",
     "ugh",
-    "side_eye"
+    "side_eye",
+    "dissatisfied",
+    "meh",
+    "unhappy"
   ],
   "🙄": [
     "face_with_rolling_eyes",
     "face",
     "eyeroll",
-    "frustrated"
+    "frustrated",
+    "eye",
+    "roll"
   ],
   "😬": [
     "grimacing_face",
     "face",
     "grimace",
-    "teeth"
+    "teeth",
+    "#1 best",
+    "awkward",
+    "eek",
+    "foot",
+    "friend",
+    "mouth",
+    "mutual",
+    "nervous",
+    "snapchat"
   ],
   "🤥": [
     "lying_face",
     "face",
     "lie",
-    "pinocchio"
+    "pinocchio",
+    "liar",
+    "long",
+    "nose"
   ],
   "😌": [
     "relieved_face",
@@ -363,25 +548,37 @@
     "relaxed",
     "phew",
     "massage",
-    "happiness"
+    "happiness",
+    "content",
+    "pleased",
+    "whew"
   ],
   "😔": [
     "pensive_face",
     "face",
     "sad",
     "depressed",
-    "upset"
+    "upset",
+    "dejected",
+    "sadface",
+    "sorrowful"
   ],
   "😪": [
     "sleepy_face",
     "face",
     "tired",
     "rest",
-    "nap"
+    "nap",
+    "bubble",
+    "side",
+    "sleep",
+    "snot",
+    "tear"
   ],
   "🤤": [
     "drooling_face",
-    "face"
+    "face",
+    "drool"
   ],
   "😴": [
     "sleeping_face",
@@ -389,7 +586,9 @@
     "tired",
     "sleepy",
     "night",
-    "zzz"
+    "zzz",
+    "sleep",
+    "snoring"
   ],
   "😷": [
     "face_with_medical_mask",
@@ -397,7 +596,12 @@
     "sick",
     "ill",
     "disease",
-    "covid"
+    "covid",
+    "cold",
+    "coronavirus",
+    "doctor",
+    "medicine",
+    "surgical"
   ],
   "🤒": [
     "face_with_thermometer",
@@ -406,14 +610,17 @@
     "thermometer",
     "cold",
     "fever",
-    "covid"
+    "covid",
+    "ill"
   ],
   "🤕": [
     "face_with_head_bandage",
     "injured",
     "clumsy",
     "bandage",
-    "hurt"
+    "hurt",
+    "bandaged",
+    "injury"
   ],
   "🤢": [
     "nauseated_face",
@@ -423,12 +630,25 @@
     "green",
     "sick",
     "throw up",
-    "ill"
+    "ill",
+    "barf",
+    "disgust",
+    "disgusted",
+    "green face"
   ],
   "🤮": [
     "face_vomiting",
     "face",
-    "sick"
+    "sick",
+    "barf",
+    "ill",
+    "mouth",
+    "open",
+    "puke",
+    "spew",
+    "throwing",
+    "up",
+    "vomit"
   ],
   "🤧": [
     "sneezing_face",
@@ -436,7 +656,8 @@
     "gesundheit",
     "sneeze",
     "sick",
-    "allergy"
+    "allergy",
+    "achoo"
   ],
   "🥵": [
     "hot_face",
@@ -444,7 +665,9 @@
     "feverish",
     "heat",
     "red",
-    "sweating"
+    "sweating",
+    "overheated",
+    "stroke"
   ],
   "🥶": [
     "cold_face",
@@ -453,7 +676,8 @@
     "freezing",
     "frozen",
     "frostbite",
-    "icicles"
+    "icicles",
+    "ice"
   ],
   "🥴": [
     "woozy_face",
@@ -461,21 +685,36 @@
     "dizzy",
     "intoxicated",
     "tipsy",
-    "wavy"
+    "wavy",
+    "drunk",
+    "eyes",
+    "groggy",
+    "mouth",
+    "uneven"
   ],
   "😵": [
     "dizzy_face",
     "spent",
     "unconscious",
     "xox",
-    "dizzy"
+    "dizzy",
+    "cross",
+    "crossed",
+    "dead",
+    "eyes",
+    "knocked",
+    "out",
+    "spiral eyes"
   ],
   "🤯": [
     "exploding_head",
     "face",
     "shocked",
     "mind",
-    "blown"
+    "blown",
+    "blowing",
+    "explosion",
+    "mad"
   ],
   "🤠": [
     "cowboy_hat_face",
@@ -487,7 +726,11 @@
     "partying_face",
     "face",
     "celebration",
-    "woohoo"
+    "woohoo",
+    "birthday",
+    "hat",
+    "horn",
+    "party"
   ],
   "😎": [
     "smiling_face_with_sunglasses",
@@ -496,20 +739,33 @@
     "smile",
     "summer",
     "beach",
-    "sunglass"
+    "sunglass",
+    "best",
+    "bright",
+    "eye",
+    "eyewear",
+    "friends",
+    "glasses",
+    "mutual",
+    "snapchat",
+    "sun",
+    "weather"
   ],
   "🤓": [
     "nerd_face",
     "face",
     "nerdy",
     "geek",
-    "dork"
+    "dork",
+    "glasses",
+    "smiling"
   ],
   "🧐": [
     "face_with_monocle",
     "face",
     "stuffy",
-    "wealthy"
+    "wealthy",
+    "rich"
   ],
   "😕": [
     "confused_face",
@@ -518,14 +774,20 @@
     "huh",
     "weird",
     "hmmm",
-    ":/"
+    ":/",
+    "meh",
+    "nonplussed",
+    "puzzled",
+    "s"
   ],
   "😟": [
     "worried_face",
     "face",
     "concern",
     "nervous",
-    ":("
+    ":(",
+    "sad",
+    "sadface"
   ],
   "🙁": [
     "slightly_frowning_face",
@@ -533,14 +795,19 @@
     "frowning",
     "disappointed",
     "sad",
-    "upset"
+    "upset",
+    "frown",
+    "unhappy"
   ],
   "☹️": [
     "frowning_face",
     "face",
     "sad",
     "upset",
-    "frown"
+    "frown",
+    "megafrown",
+    "unhappy",
+    "white"
   ],
   "😮": [
     "face_with_open_mouth",
@@ -549,27 +816,47 @@
     "impressed",
     "wow",
     "whoa",
-    ":O"
+    ":O",
+    "surprised",
+    "sympathy"
   ],
   "😯": [
     "hushed_face",
     "face",
     "woo",
-    "shh"
+    "shh",
+    "silence",
+    "speechless",
+    "stunned",
+    "surprise",
+    "surprised"
   ],
   "😲": [
     "astonished_face",
     "face",
     "xox",
     "surprised",
-    "poisoned"
+    "poisoned",
+    "amazed",
+    "drunk face",
+    "gasp",
+    "gasping",
+    "shocked",
+    "totally"
   ],
   "😳": [
     "flushed_face",
     "face",
     "blush",
     "shy",
-    "flattered"
+    "flattered",
+    "blushing",
+    "dazed",
+    "embarrassed",
+    "eyes",
+    "open",
+    "shame",
+    "wide"
   ],
   "🥺": [
     "pleading_face",
@@ -579,39 +866,59 @@
     "cry",
     "tears",
     "sad",
-    "grievance"
+    "grievance",
+    "eyes",
+    "glossy",
+    "puppy",
+    "simp"
   ],
   "😦": [
     "frowning_face_with_open_mouth",
     "face",
     "aw",
-    "what"
+    "what",
+    "frown",
+    "yawning"
   ],
   "😧": [
     "anguished_face",
     "face",
     "stunned",
-    "nervous"
+    "nervous",
+    "pained"
   ],
   "😨": [
     "fearful_face",
     "face",
     "scared",
     "terrified",
-    "nervous"
+    "nervous",
+    "fear",
+    "oops",
+    "shocked",
+    "surprised"
   ],
   "😰": [
     "anxious_face_with_sweat",
     "face",
     "nervous",
-    "sweat"
+    "sweat",
+    "blue",
+    "cold",
+    "concerned face",
+    "mouth",
+    "open",
+    "rushed"
   ],
   "😥": [
     "sad_but_relieved_face",
     "face",
     "phew",
     "sweat",
-    "nervous"
+    "nervous",
+    "disappointed",
+    "eyebrow",
+    "whew"
   ],
   "😢": [
     "crying_face",
@@ -620,7 +927,9 @@
     "sad",
     "depressed",
     "upset",
-    ":'("
+    ":'(",
+    "cry",
+    "tear"
   ],
   "😭": [
     "loudly_crying_face",
@@ -630,14 +939,23 @@
     "tears",
     "sad",
     "upset",
-    "depressed"
+    "depressed",
+    "bawling",
+    "sob",
+    "tear"
   ],
   "😱": [
     "face_screaming_in_fear",
     "face",
     "munch",
     "scared",
-    "omg"
+    "omg",
+    "alone",
+    "fearful",
+    "home",
+    "horror",
+    "scream",
+    "shocked"
   ],
   "😖": [
     "confounded_face",
@@ -646,7 +964,10 @@
     "sick",
     "unwell",
     "oops",
-    ":S"
+    ":S",
+    "mouth",
+    "quivering",
+    "scrunched"
   ],
   "😣": [
     "persevering_face",
@@ -654,7 +975,12 @@
     "sick",
     "no",
     "upset",
-    "oops"
+    "oops",
+    "eyes",
+    "helpless",
+    "persevere",
+    "scrunched",
+    "struggling"
   ],
   "😞": [
     "disappointed_face",
@@ -662,7 +988,8 @@
     "sad",
     "upset",
     "depressed",
-    ":("
+    ":(",
+    "sadface"
   ],
   "😓": [
     "downcast_face_with_sweat",
@@ -670,7 +997,10 @@
     "hot",
     "sad",
     "tired",
-    "exercise"
+    "exercise",
+    "cold",
+    "hard",
+    "work"
   ],
   "😩": [
     "weary_face",
@@ -679,19 +1009,27 @@
     "sleepy",
     "sad",
     "frustrated",
-    "upset"
+    "upset",
+    "distraught",
+    "wailing"
   ],
   "😫": [
     "tired_face",
     "sick",
     "whine",
     "upset",
-    "frustrated"
+    "frustrated",
+    "distraught",
+    "exhausted",
+    "fed",
+    "up"
   ],
   "🥱": [
     "yawning_face",
     "tired",
-    "sleepy"
+    "sleepy",
+    "bored",
+    "yawn"
   ],
   "😤": [
     "face_with_steam_from_nose",
@@ -700,21 +1038,36 @@
     "phew",
     "proud",
     "pride",
-    "triumph"
+    "triumph",
+    "airing",
+    "frustrated",
+    "grievances",
+    "look",
+    "mad",
+    "smug",
+    "steaming",
+    "won"
   ],
   "😡": [
     "pouting_face",
     "angry",
     "mad",
     "hate",
-    "despise"
+    "despise",
+    "enraged",
+    "grumpy",
+    "pout",
+    "rage",
+    "red"
   ],
   "😠": [
     "angry_face",
     "mad",
     "face",
     "annoyed",
-    "frustrated"
+    "frustrated",
+    "anger",
+    "grumpy"
   ],
   "🤬": [
     "face_with_symbols_on_mouth",
@@ -723,18 +1076,41 @@
     "cursing",
     "cussing",
     "profanity",
-    "expletive"
+    "expletive",
+    "covering",
+    "foul",
+    "grawlix",
+    "over",
+    "serious"
   ],
   "😈": [
     "smiling_face_with_horns",
     "devil",
-    "horns"
+    "horns",
+    "evil",
+    "fairy",
+    "fantasy",
+    "happy",
+    "imp",
+    "purple",
+    "red devil",
+    "smile",
+    "tale"
   ],
   "👿": [
     "angry_face_with_horns",
     "devil",
     "angry",
-    "horns"
+    "horns",
+    "demon",
+    "evil",
+    "fairy",
+    "fantasy",
+    "goblin",
+    "imp",
+    "purple",
+    "sad",
+    "tale"
   ],
   "💀": [
     "skull",
@@ -742,7 +1118,16 @@
     "skeleton",
     "creepy",
     "death",
-    "dead"
+    "dead",
+    "body",
+    "danger",
+    "face",
+    "fairy",
+    "grey",
+    "halloween",
+    "monster",
+    "poison",
+    "tale"
   ],
   "☠️": [
     "skull_and_crossbones",
@@ -752,7 +1137,11 @@
     "scary",
     "death",
     "pirate",
-    "evil"
+    "evil",
+    "body",
+    "face",
+    "halloween",
+    "monster"
   ],
   "💩": [
     "pile_of_poo",
@@ -760,7 +1149,16 @@
     "shitface",
     "fail",
     "turd",
-    "shit"
+    "shit",
+    "comic",
+    "crap",
+    "dirt",
+    "dog",
+    "dung",
+    "face",
+    "monster",
+    "poop",
+    "smiling"
   ],
   "🤡": [
     "clown_face",
@@ -776,7 +1174,13 @@
     "creepy",
     "devil",
     "demon",
-    "japanese_ogre"
+    "japanese_ogre",
+    "creature",
+    "face",
+    "fairy",
+    "fantasy",
+    "oni",
+    "tale"
   ],
   "👺": [
     "goblin",
@@ -786,45 +1190,91 @@
     "monster",
     "scary",
     "creepy",
-    "japanese_goblin"
+    "japanese_goblin",
+    "creature",
+    "face",
+    "fairy",
+    "fantasy",
+    "long",
+    "nose",
+    "tale",
+    "tengu"
   ],
   "👻": [
     "ghost",
     "halloween",
     "spooky",
-    "scary"
+    "scary",
+    "creature",
+    "disappear",
+    "face",
+    "fairy",
+    "fantasy",
+    "ghoul",
+    "monster",
+    "tale"
   ],
   "👽": [
     "alien",
     "UFO",
     "paul",
     "weird",
-    "outer_space"
+    "outer_space",
+    "creature",
+    "et",
+    "extraterrestrial",
+    "face",
+    "fairy",
+    "fantasy",
+    "monster",
+    "tale"
   ],
   "👾": [
     "alien_monster",
     "game",
     "arcade",
-    "play"
+    "play",
+    "creature",
+    "extraterrestrial",
+    "face",
+    "fairy",
+    "fantasy",
+    "invader",
+    "retro",
+    "space",
+    "tale",
+    "ufo",
+    "video"
   ],
   "🤖": [
     "robot",
     "computer",
     "machine",
-    "bot"
+    "bot",
+    "face",
+    "monster"
   ],
   "😺": [
     "grinning_cat",
     "animal",
     "cats",
     "happy",
-    "smile"
+    "smile",
+    "face",
+    "mouth",
+    "open",
+    "smiley",
+    "smiling"
   ],
   "😸": [
     "grinning_cat_with_smiling_eyes",
     "animal",
     "cats",
-    "smile"
+    "smile",
+    "eye",
+    "face",
+    "grin",
+    "happy"
   ],
   "😹": [
     "cat_with_tears_of_joy",
@@ -832,7 +1282,10 @@
     "cats",
     "haha",
     "happy",
-    "tears"
+    "tears",
+    "face",
+    "laughing",
+    "tear"
   ],
   "😻": [
     "smiling_cat_with_heart_eyes",
@@ -842,19 +1295,31 @@
     "affection",
     "cats",
     "valentines",
-    "heart"
+    "heart",
+    "eye",
+    "face",
+    "loving cat",
+    "shaped",
+    "smile"
   ],
   "😼": [
     "cat_with_wry_smile",
     "animal",
     "cats",
-    "smirk"
+    "smirk",
+    "face",
+    "ironic",
+    "smirking"
   ],
   "😽": [
     "kissing_cat",
     "animal",
     "cats",
-    "kiss"
+    "kiss",
+    "closed",
+    "eye",
+    "eyes",
+    "face"
   ],
   "🙀": [
     "weary_cat",
@@ -862,7 +1327,13 @@
     "cats",
     "munch",
     "scared",
-    "scream"
+    "scream",
+    "face",
+    "fear",
+    "horror",
+    "oh",
+    "screaming",
+    "surprised"
   ],
   "😿": [
     "crying_cat",
@@ -872,32 +1343,67 @@
     "sad",
     "cats",
     "upset",
-    "cry"
+    "cry",
+    "face",
+    "sad cat",
+    "tear"
   ],
   "😾": [
     "pouting_cat",
     "animal",
-    "cats"
+    "cats",
+    "face",
+    "grumpy"
   ],
   "🙈": [
     "see_no_evil_monkey",
     "monkey",
     "animal",
     "nature",
-    "haha"
+    "haha",
+    "blind",
+    "covering",
+    "eyes",
+    "face",
+    "forbidden",
+    "gesture",
+    "ignore",
+    "mizaru",
+    "not",
+    "prohibited"
   ],
   "🙉": [
     "hear_no_evil_monkey",
     "animal",
     "monkey",
-    "nature"
+    "nature",
+    "covering",
+    "deaf",
+    "ears",
+    "face",
+    "forbidden",
+    "gesture",
+    "kikazaru",
+    "not",
+    "prohibited"
   ],
   "🙊": [
     "speak_no_evil_monkey",
     "monkey",
     "animal",
     "nature",
-    "omg"
+    "omg",
+    "covering",
+    "face",
+    "forbidden",
+    "gesture",
+    "hush",
+    "iwazaru",
+    "mouth",
+    "mute",
+    "not",
+    "no speaking",
+    "prohibited"
   ],
   "💋": [
     "kiss_mark",
@@ -906,7 +1412,11 @@
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "heart",
+    "kissing",
+    "lipstick",
+    "romance"
   ],
   "💌": [
     "love_letter",
@@ -914,7 +1424,11 @@
     "like",
     "affection",
     "envelope",
-    "valentines"
+    "valentines",
+    "heart",
+    "mail",
+    "note",
+    "romance"
   ],
   "💘": [
     "heart_with_arrow",
@@ -922,19 +1436,31 @@
     "like",
     "heart",
     "affection",
-    "valentines"
+    "valentines",
+    "cupid",
+    "lovestruck",
+    "romance"
   ],
   "💝": [
     "heart_with_ribbon",
     "love",
-    "valentines"
+    "valentines",
+    "box",
+    "chocolate",
+    "chocolates",
+    "gift",
+    "valentine"
   ],
   "💖": [
     "sparkling_heart",
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "excited",
+    "sparkle",
+    "sparkly",
+    "stars heart"
   ],
   "💗": [
     "growing_heart",
@@ -942,7 +1468,13 @@
     "love",
     "affection",
     "valentines",
-    "pink"
+    "pink",
+    "excited",
+    "heartpulse",
+    "multiple",
+    "nervous",
+    "pulse",
+    "triple"
   ],
   "💓": [
     "beating_heart",
@@ -951,14 +1483,20 @@
     "affection",
     "valentines",
     "pink",
-    "heart"
+    "heart",
+    "alarm",
+    "heartbeat",
+    "pulsating",
+    "wifi"
   ],
   "💞": [
     "revolving_hearts",
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "heart",
+    "two"
   ],
   "💕": [
     "two_hearts",
@@ -966,7 +1504,9 @@
     "like",
     "affection",
     "valentines",
-    "heart"
+    "heart",
+    "pink",
+    "small"
   ],
   "💟": [
     "heart_decoration",
@@ -977,7 +1517,16 @@
   "❣️": [
     "heart_exclamation",
     "decoration",
-    "love"
+    "love",
+    "above",
+    "an",
+    "as",
+    "dot",
+    "heavy",
+    "mark",
+    "ornament",
+    "punctuation",
+    "red"
   ],
   "💔": [
     "broken_heart",
@@ -985,13 +1534,17 @@
     "sorry",
     "break",
     "heart",
-    "heartbreak"
+    "heartbreak",
+    "breaking",
+    "brokenhearted"
   ],
   "❤️": [
     "red_heart",
     "love",
     "like",
-    "valentines"
+    "valentines",
+    "black",
+    "heavy"
   ],
   "🧡": [
     "orange_heart",
@@ -1005,28 +1558,36 @@
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "bf",
+    "gold",
+    "snapchat"
   ],
   "💚": [
     "green_heart",
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "nct"
   ],
   "💙": [
     "blue_heart",
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "brand",
+    "neutral"
   ],
   "💜": [
     "purple_heart",
     "love",
     "like",
     "affection",
-    "valentines"
+    "valentines",
+    "bts",
+    "emoji"
   ],
   "🤎": [
     "brown_heart",
@@ -1034,7 +1595,9 @@
   ],
   "🖤": [
     "black_heart",
-    "evil"
+    "evil",
+    "dark",
+    "wicked"
   ],
   "🤍": [
     "white_heart",
@@ -1051,32 +1614,55 @@
     "test",
     "pass",
     "hundred",
-    "100"
+    "100",
+    "full",
+    "keep",
+    "symbol"
   ],
   "💢": [
     "anger_symbol",
     "angry",
-    "mad"
+    "mad",
+    "comic",
+    "pop",
+    "sign",
+    "vein"
   ],
   "💥": [
     "collision",
     "bomb",
     "explode",
     "explosion",
-    "blown"
+    "blown",
+    "bang",
+    "boom",
+    "comic",
+    "impact",
+    "red",
+    "spark",
+    "symbol"
   ],
   "💫": [
     "dizzy",
     "star",
     "sparkle",
     "shoot",
-    "magic"
+    "magic",
+    "circle",
+    "comic",
+    "symbol"
   ],
   "💦": [
     "sweat_droplets",
     "water",
     "drip",
-    "oops"
+    "oops",
+    "comic",
+    "drops",
+    "plewds",
+    "splashing",
+    "symbol",
+    "workout"
   ],
   "💨": [
     "dashing_away",
@@ -1086,7 +1672,15 @@
     "shoo",
     "fart",
     "smoke",
-    "puff"
+    "puff",
+    "blow",
+    "comic",
+    "dash",
+    "gust",
+    "running",
+    "steam",
+    "symbol",
+    "vaping"
   ],
   "🕳️": [
     "hole",
@@ -1097,7 +1691,8 @@
     "boom",
     "explode",
     "explosion",
-    "terrorism"
+    "terrorism",
+    "comic"
   ],
   "💬": [
     "speech_balloon",
@@ -1105,25 +1700,37 @@
     "words",
     "message",
     "talk",
-    "chatting"
+    "chatting",
+    "chat",
+    "comic",
+    "comment",
+    "dialog"
   ],
   "👁️‍🗨️": [
     "eye_in_speech_bubble",
-    "info"
+    "info",
+    "am",
+    "i",
+    "witness"
   ],
   "🗨️": [
     "left_speech_bubble",
     "words",
     "message",
     "talk",
-    "chatting"
+    "chatting",
+    "dialog"
   ],
   "🗯️": [
     "right_anger_bubble",
     "caption",
     "speech",
     "thinking",
-    "mad"
+    "mad",
+    "angry",
+    "balloon",
+    "zag",
+    "zig"
   ],
   "💭": [
     "thought_balloon",
@@ -1131,13 +1738,21 @@
     "cloud",
     "speech",
     "thinking",
-    "dream"
+    "dream",
+    "comic"
   ],
   "💤": [
     "zzz",
     "sleepy",
     "tired",
-    "dream"
+    "dream",
+    "bedtime",
+    "boring",
+    "comic",
+    "sign",
+    "sleep",
+    "sleeping",
+    "symbol"
   ],
   "👋": [
     "waving_hand",
@@ -1149,19 +1764,26 @@
     "farewell",
     "hello",
     "hi",
-    "palm"
+    "palm",
+    "body",
+    "sign"
   ],
   "🤚": [
     "raised_back_of_hand",
     "fingers",
     "raised",
-    "backhand"
+    "backhand",
+    "body"
   ],
   "🖐️": [
     "hand_with_fingers_splayed",
     "hand",
     "fingers",
-    "palm"
+    "palm",
+    "body",
+    "finger",
+    "five",
+    "raised"
   ],
   "✋": [
     "raised_hand",
@@ -1169,14 +1791,26 @@
     "stop",
     "highfive",
     "palm",
-    "ban"
+    "ban",
+    "body",
+    "five",
+    "high"
   ],
   "🖖": [
     "vulcan_salute",
     "hand",
     "fingers",
     "spock",
-    "star trek"
+    "star trek",
+    "between",
+    "body",
+    "finger",
+    "middle",
+    "part",
+    "prosper",
+    "raised",
+    "ring",
+    "split"
   ],
   "👌": [
     "ok_hand",
@@ -1184,13 +1818,18 @@
     "limbs",
     "perfect",
     "ok",
-    "okay"
+    "okay",
+    "body",
+    "sign"
   ],
   "🤏": [
     "pinching_hand",
     "tiny",
     "small",
-    "size"
+    "size",
+    "amount",
+    "body",
+    "little"
   ],
   "✌️": [
     "victory_hand",
@@ -1199,18 +1838,35 @@
     "hand",
     "peace",
     "victory",
-    "two"
+    "two",
+    "air",
+    "body",
+    "quotes",
+    "sign",
+    "v"
   ],
   "🤞": [
     "crossed_fingers",
     "good",
-    "lucky"
+    "lucky",
+    "body",
+    "cross",
+    "finger",
+    "hand",
+    "hopeful",
+    "index",
+    "luck",
+    "middle"
   ],
   "🤟": [
     "love_you_gesture",
     "hand",
     "fingers",
-    "gesture"
+    "gesture",
+    "body",
+    "i",
+    "ily",
+    "sign"
   ],
   "🤘": [
     "sign_of_the_horns",
@@ -1218,34 +1874,55 @@
     "fingers",
     "evil_eye",
     "sign_of_horns",
-    "rock_on"
+    "rock_on",
+    "body",
+    "devil",
+    "finger",
+    "heavy",
+    "metal"
   ],
   "🤙": [
     "call_me_hand",
     "hands",
     "gesture",
-    "shaka"
+    "shaka",
+    "body",
+    "phone",
+    "sign"
   ],
   "👈": [
     "backhand_index_pointing_left",
     "direction",
     "fingers",
     "hand",
-    "left"
+    "left",
+    "body",
+    "finger",
+    "point",
+    "white"
   ],
   "👉": [
     "backhand_index_pointing_right",
     "fingers",
     "hand",
     "direction",
-    "right"
+    "right",
+    "body",
+    "finger",
+    "point",
+    "white"
   ],
   "👆": [
     "backhand_index_pointing_up",
     "fingers",
     "hand",
     "direction",
-    "up"
+    "up",
+    "body",
+    "finger",
+    "middle",
+    "point",
+    "white"
   ],
   "🖕": [
     "middle_finger",
@@ -1253,21 +1930,38 @@
     "fingers",
     "rude",
     "middle",
-    "flipping"
+    "flipping",
+    "bird",
+    "body",
+    "dito",
+    "extended",
+    "fu",
+    "medio",
+    "middle finger",
+    "reversed"
   ],
   "👇": [
     "backhand_index_pointing_down",
     "fingers",
     "hand",
     "direction",
-    "down"
+    "down",
+    "body",
+    "finger",
+    "point",
+    "white"
   ],
   "☝️": [
     "index_pointing_up",
     "hand",
     "fingers",
     "direction",
-    "up"
+    "up",
+    "body",
+    "finger",
+    "point",
+    "secret",
+    "white"
   ],
   "👍": [
     "thumbs_up",
@@ -1280,7 +1974,12 @@
     "cool",
     "hand",
     "like",
-    "+1"
+    "+1",
+    "approve",
+    "body",
+    "ok",
+    "sign",
+    "thumb"
   ],
   "👎": [
     "thumbs_down",
@@ -1288,13 +1987,24 @@
     "no",
     "dislike",
     "hand",
-    "-1"
+    "-1",
+    "bad",
+    "body",
+    "bury",
+    "disapprove",
+    "sign",
+    "thumb"
   ],
   "✊": [
     "raised_fist",
     "fingers",
     "hand",
-    "grasp"
+    "grasp",
+    "body",
+    "clenched",
+    "power",
+    "pump",
+    "punch"
   ],
   "👊": [
     "oncoming_fist",
@@ -1303,17 +2013,34 @@
     "fist",
     "hit",
     "attack",
-    "hand"
+    "hand",
+    "body",
+    "bro",
+    "brofist",
+    "bump",
+    "clenched",
+    "closed",
+    "facepunch",
+    "fisted",
+    "punch",
+    "sign"
   ],
   "🤛": [
     "left_facing_fist",
     "hand",
-    "fistbump"
+    "fistbump",
+    "body",
+    "bump",
+    "leftwards"
   ],
   "🤜": [
     "right_facing_fist",
     "hand",
-    "fistbump"
+    "fistbump",
+    "body",
+    "bump",
+    "rightwards",
+    "right fist"
   ],
   "👏": [
     "clapping_hands",
@@ -1321,7 +2048,13 @@
     "praise",
     "applause",
     "congrats",
-    "yay"
+    "yay",
+    "body",
+    "clap",
+    "golf",
+    "hand",
+    "round",
+    "sign"
   ],
   "🙌": [
     "raising_hands",
@@ -1329,26 +2062,52 @@
     "hooray",
     "yea",
     "celebration",
-    "hands"
+    "hands",
+    "air",
+    "arms",
+    "banzai",
+    "body",
+    "both",
+    "festivus",
+    "hallelujah",
+    "hand",
+    "miracle",
+    "person",
+    "praise",
+    "raised",
+    "two"
   ],
   "👐": [
     "open_hands",
     "fingers",
     "butterfly",
     "hands",
-    "open"
+    "open",
+    "body",
+    "hand",
+    "hug",
+    "jazz",
+    "sign"
   ],
   "🤲": [
     "palms_up_together",
     "hands",
     "gesture",
     "cupped",
-    "prayer"
+    "prayer",
+    "body",
+    "dua",
+    "facing"
   ],
   "🤝": [
     "handshake",
     "agreement",
-    "shake"
+    "shake",
+    "deal",
+    "hand",
+    "hands",
+    "meeting",
+    "shaking"
   ],
   "🙏": [
     "folded_hands",
@@ -1360,14 +2119,26 @@
     "pray",
     "thank you",
     "thanks",
-    "appreciate"
+    "appreciate",
+    "ask",
+    "body",
+    "bow",
+    "five",
+    "gesture",
+    "hand",
+    "high",
+    "person",
+    "prayer",
+    "pressed",
+    "together"
   ],
   "✍️": [
     "writing_hand",
     "lower_left_ballpoint_pen",
     "stationery",
     "write",
-    "compose"
+    "compose",
+    "body"
   ],
   "💅": [
     "nail_polish",
@@ -1377,12 +2148,18 @@
     "finger",
     "fashion",
     "nail",
-    "slay"
+    "slay",
+    "body",
+    "cosmetics",
+    "fingers",
+    "nonchalant"
   ],
   "🤳": [
     "selfie",
     "camera",
-    "phone"
+    "phone",
+    "arm",
+    "hand"
   ],
   "💪": [
     "flexed_biceps",
@@ -1391,55 +2168,85 @@
     "hand",
     "summer",
     "strong",
-    "biceps"
+    "biceps",
+    "bicep",
+    "body",
+    "comic",
+    "feats",
+    "flexing",
+    "muscle",
+    "muscles",
+    "strength",
+    "workout"
   ],
   "🦾": [
     "mechanical_arm",
-    "accessibility"
+    "accessibility",
+    "body",
+    "prosthetic"
   ],
   "🦿": [
     "mechanical_leg",
-    "accessibility"
+    "accessibility",
+    "body",
+    "prosthetic"
   ],
   "🦵": [
     "leg",
     "kick",
-    "limb"
+    "limb",
+    "body"
   ],
   "🦶": [
     "foot",
     "kick",
-    "stomp"
+    "stomp",
+    "body"
   ],
   "👂": [
     "ear",
     "face",
     "hear",
     "sound",
-    "listen"
+    "listen",
+    "body",
+    "ears",
+    "hearing",
+    "listening",
+    "nose"
   ],
   "🦻": [
     "ear_with_hearing_aid",
-    "accessibility"
+    "accessibility",
+    "body",
+    "hard"
   ],
   "👃": [
     "nose",
     "smell",
-    "sniff"
+    "sniff",
+    "body",
+    "smelling",
+    "sniffing",
+    "stinky"
   ],
   "🧠": [
     "brain",
     "smart",
-    "intelligent"
+    "intelligent",
+    "body",
+    "organ"
   ],
   "🦷": [
     "tooth",
     "teeth",
-    "dentist"
+    "dentist",
+    "body"
   ],
   "🦴": [
     "bone",
-    "skeleton"
+    "skeleton",
+    "body"
   ],
   "👀": [
     "eyes",
@@ -1447,7 +2254,13 @@
     "watch",
     "stalk",
     "peek",
-    "see"
+    "see",
+    "body",
+    "eye",
+    "eyeballs",
+    "face",
+    "shifty",
+    "wide"
   ],
   "👁️": [
     "eye",
@@ -1455,49 +2268,88 @@
     "look",
     "see",
     "watch",
-    "stare"
+    "stare",
+    "body",
+    "single"
   ],
   "👅": [
     "tongue",
     "mouth",
-    "playful"
+    "playful",
+    "body",
+    "out",
+    "taste"
   ],
   "👄": [
     "mouth",
-    "kiss"
+    "kiss",
+    "body",
+    "kissing",
+    "lips"
   ],
   "👶": [
     "baby",
     "child",
     "boy",
     "girl",
-    "toddler"
+    "toddler",
+    "newborn",
+    "young"
   ],
   "🧒": [
     "child",
     "gender-neutral",
-    "young"
+    "young",
+    "boy",
+    "gender",
+    "girl",
+    "inclusive",
+    "neutral",
+    "person",
+    "unspecified"
   ],
   "👦": [
     "boy",
     "man",
     "male",
     "guy",
-    "teenager"
+    "teenager",
+    "child",
+    "young"
   ],
   "👧": [
     "girl",
     "female",
     "woman",
-    "teenager"
+    "teenager",
+    "child",
+    "maiden",
+    "virgin",
+    "virgo",
+    "young",
+    "zodiac"
   ],
   "🧑": [
     "person",
-    "gender-neutral"
+    "gender-neutral",
+    "adult",
+    "female",
+    "gender",
+    "inclusive",
+    "male",
+    "man",
+    "men",
+    "neutral",
+    "unspecified",
+    "woman",
+    "women"
   ],
   "👱": [
     "person_blond_hair",
-    "hairstyle"
+    "hairstyle",
+    "blonde",
+    "haired",
+    "man"
   ],
   "👨": [
     "man",
@@ -1507,69 +2359,131 @@
     "guy",
     "classy",
     "sir",
-    "moustache"
+    "moustache",
+    "adult",
+    "male",
+    "men"
   ],
   "🧔": [
     "man_beard",
     "person",
-    "bewhiskered"
+    "bewhiskered",
+    "bearded"
   ],
   "👨‍🦰": [
     "man_red_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "ginger",
+    "haired",
+    "male",
+    "men",
+    "redhead"
   ],
   "👨‍🦱": [
     "man_curly_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "haired",
+    "male",
+    "men"
   ],
   "👨‍🦳": [
     "man_white_hair",
     "old",
-    "elder"
+    "elder",
+    "adult",
+    "haired",
+    "male",
+    "men"
   ],
   "👨‍🦲": [
     "man_bald",
-    "hairless"
+    "hairless",
+    "adult",
+    "hair",
+    "male",
+    "men",
+    "no"
   ],
   "👩": [
     "woman",
     "female",
     "girls",
-    "lady"
+    "lady",
+    "adult",
+    "women",
+    "yellow"
   ],
   "👩‍🦰": [
     "woman_red_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "female",
+    "ginger",
+    "haired",
+    "redhead",
+    "women"
   ],
   "🧑‍🦰": [
     "person_red_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "gender",
+    "haired",
+    "unspecified"
   ],
   "👩‍🦱": [
     "woman_curly_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "female",
+    "haired",
+    "women"
   ],
   "🧑‍🦱": [
     "person_curly_hair",
-    "hairstyle"
+    "hairstyle",
+    "adult",
+    "gender",
+    "haired",
+    "unspecified"
   ],
   "👩‍🦳": [
     "woman_white_hair",
     "old",
-    "elder"
+    "elder",
+    "adult",
+    "female",
+    "haired",
+    "women"
   ],
   "🧑‍🦳": [
     "person_white_hair",
     "elder",
-    "old"
+    "old",
+    "adult",
+    "gender",
+    "haired",
+    "unspecified"
   ],
   "👩‍🦲": [
     "woman_bald",
-    "hairless"
+    "hairless",
+    "adult",
+    "female",
+    "hair",
+    "no",
+    "women"
   ],
   "🧑‍🦲": [
     "person_bald",
-    "hairless"
+    "hairless",
+    "adult",
+    "gender",
+    "hair",
+    "no",
+    "unspecified"
   ],
   "👱‍♀️": [
     "woman_blond_hair",
@@ -1577,7 +2491,9 @@
     "female",
     "girl",
     "blonde",
-    "person"
+    "person",
+    "haired",
+    "women"
   ],
   "👱‍♂️": [
     "man_blond_hair",
@@ -1586,14 +2502,27 @@
     "boy",
     "blonde",
     "guy",
-    "person"
+    "person",
+    "haired",
+    "men"
   ],
   "🧓": [
     "older_person",
     "human",
     "elder",
     "senior",
-    "gender-neutral"
+    "gender-neutral",
+    "adult",
+    "female",
+    "gender",
+    "male",
+    "man",
+    "men",
+    "neutral",
+    "old",
+    "unspecified",
+    "woman",
+    "women"
   ],
   "👴": [
     "old_man",
@@ -1602,7 +2531,11 @@
     "men",
     "old",
     "elder",
-    "senior"
+    "senior",
+    "adult",
+    "elderly",
+    "grandpa",
+    "older"
   ],
   "👵": [
     "old_woman",
@@ -1612,11 +2545,20 @@
     "lady",
     "old",
     "elder",
-    "senior"
+    "senior",
+    "adult",
+    "elderly",
+    "grandma",
+    "nanna",
+    "older"
   ],
   "🙍": [
     "person_frowning",
-    "worried"
+    "worried",
+    "frown",
+    "gesture",
+    "sad",
+    "woman"
   ],
   "🙍‍♂️": [
     "man_frowning",
@@ -1626,7 +2568,10 @@
     "sad",
     "depressed",
     "discouraged",
-    "unhappy"
+    "unhappy",
+    "frown",
+    "gesture",
+    "men"
   ],
   "🙍‍♀️": [
     "woman_frowning",
@@ -1636,45 +2581,102 @@
     "sad",
     "depressed",
     "discouraged",
-    "unhappy"
+    "unhappy",
+    "frown",
+    "gesture",
+    "women"
   ],
   "🙎": [
     "person_pouting",
-    "upset"
+    "upset",
+    "blank",
+    "face",
+    "fed",
+    "gesture",
+    "look",
+    "up"
   ],
   "🙎‍♂️": [
     "man_pouting",
     "male",
     "boy",
-    "man"
+    "man",
+    "gesture",
+    "men"
   ],
   "🙎‍♀️": [
     "woman_pouting",
     "female",
     "girl",
-    "woman"
+    "woman",
+    "gesture",
+    "women"
   ],
   "🙅": [
     "person_gesturing_no",
-    "decline"
+    "decline",
+    "arms",
+    "deal",
+    "denied",
+    "face",
+    "forbidden",
+    "gesture",
+    "good",
+    "halt",
+    "hand",
+    "not",
+    "ok",
+    "prohibited",
+    "stop",
+    "x"
   ],
   "🙅‍♂️": [
     "man_gesturing_no",
     "male",
     "boy",
     "man",
-    "nope"
+    "nope",
+    "denied",
+    "forbidden",
+    "gesture",
+    "good",
+    "halt",
+    "hand",
+    "men",
+    "ng",
+    "not",
+    "ok",
+    "prohibited",
+    "stop"
   ],
   "🙅‍♀️": [
     "woman_gesturing_no",
     "female",
     "girl",
     "woman",
-    "nope"
+    "nope",
+    "denied",
+    "forbidden",
+    "gesture",
+    "good",
+    "halt",
+    "hand",
+    "ng",
+    "not",
+    "ok",
+    "prohibited",
+    "stop",
+    "women"
   ],
   "🙆": [
     "person_gesturing_ok",
-    "agree"
+    "agree",
+    "ballerina",
+    "face",
+    "gesture",
+    "hand",
+    "hands",
+    "head"
   ],
   "🙆‍♂️": [
     "man_gesturing_ok",
@@ -1683,7 +2685,9 @@
     "male",
     "blue",
     "human",
-    "man"
+    "man",
+    "gesture",
+    "hand"
   ],
   "🙆‍♀️": [
     "woman_gesturing_ok",
@@ -1692,11 +2696,25 @@
     "female",
     "pink",
     "human",
-    "woman"
+    "woman",
+    "gesture",
+    "hand"
   ],
   "💁": [
     "person_tipping_hand",
-    "information"
+    "information",
+    "attendant",
+    "bellhop",
+    "concierge",
+    "desk",
+    "female",
+    "flick",
+    "girl",
+    "hair",
+    "help",
+    "sassy",
+    "woman",
+    "women"
   ],
   "💁‍♂️": [
     "man_tipping_hand",
@@ -1704,7 +2722,11 @@
     "boy",
     "man",
     "human",
-    "information"
+    "information",
+    "desk",
+    "help",
+    "men",
+    "sassy"
   ],
   "💁‍♀️": [
     "woman_tipping_hand",
@@ -1712,73 +2734,154 @@
     "girl",
     "woman",
     "human",
-    "information"
+    "information",
+    "desk",
+    "help",
+    "sassy",
+    "women"
   ],
   "🙋": [
     "person_raising_hand",
-    "question"
+    "question",
+    "answering",
+    "gesture",
+    "happy",
+    "one",
+    "raised",
+    "up"
   ],
   "🙋‍♂️": [
     "man_raising_hand",
     "male",
     "boy",
-    "man"
+    "man",
+    "gesture",
+    "happy",
+    "men",
+    "one",
+    "raised"
   ],
   "🙋‍♀️": [
     "woman_raising_hand",
     "female",
     "girl",
-    "woman"
+    "woman",
+    "gesture",
+    "happy",
+    "one",
+    "raised",
+    "women"
   ],
   "🧏": [
     "deaf_person",
-    "accessibility"
+    "accessibility",
+    "ear",
+    "hear"
   ],
   "🧏‍♂️": [
     "deaf_man",
-    "accessibility"
+    "accessibility",
+    "male",
+    "men"
   ],
   "🧏‍♀️": [
     "deaf_woman",
-    "accessibility"
+    "accessibility",
+    "female",
+    "women"
   ],
   "🙇": [
     "person_bowing",
-    "respectiful"
+    "respectiful",
+    "apology",
+    "bow",
+    "boy",
+    "cute",
+    "deeply",
+    "dogeza",
+    "gesture",
+    "man",
+    "massage",
+    "respect",
+    "sorry",
+    "thanks"
   ],
   "🙇‍♂️": [
     "man_bowing",
     "man",
     "male",
-    "boy"
+    "boy",
+    "apology",
+    "bow",
+    "deeply",
+    "favor",
+    "gesture",
+    "men",
+    "respect",
+    "sorry",
+    "thanks"
   ],
   "🙇‍♀️": [
     "woman_bowing",
     "woman",
     "female",
-    "girl"
+    "girl",
+    "apology",
+    "bow",
+    "deeply",
+    "favor",
+    "gesture",
+    "respect",
+    "sorry",
+    "thanks",
+    "women"
   ],
   "🤦": [
     "person_facepalming",
-    "disappointed"
+    "disappointed",
+    "disbelief",
+    "exasperation",
+    "face",
+    "facepalm",
+    "head",
+    "hitting",
+    "palm",
+    "picard",
+    "smh"
   ],
   "🤦‍♂️": [
     "man_facepalming",
     "man",
     "male",
     "boy",
-    "disbelief"
+    "disbelief",
+    "exasperation",
+    "face",
+    "facepalm",
+    "men",
+    "palm"
   ],
   "🤦‍♀️": [
     "woman_facepalming",
     "woman",
     "female",
     "girl",
-    "disbelief"
+    "disbelief",
+    "exasperation",
+    "face",
+    "facepalm",
+    "palm",
+    "women"
   ],
   "🤷": [
     "person_shrugging",
-    "regardless"
+    "regardless",
+    "doubt",
+    "ignorance",
+    "indifference",
+    "shrug",
+    "shruggie",
+    "¯\\"
   ],
   "🤷‍♂️": [
     "man_shrugging",
@@ -1787,7 +2890,11 @@
     "boy",
     "confused",
     "indifferent",
-    "doubt"
+    "doubt",
+    "ignorance",
+    "indifference",
+    "men",
+    "shrug"
   ],
   "🤷‍♀️": [
     "woman_shrugging",
@@ -1796,11 +2903,23 @@
     "girl",
     "confused",
     "indifferent",
-    "doubt"
+    "doubt",
+    "ignorance",
+    "indifference",
+    "shrug",
+    "women"
   ],
   "🧑‍⚕️": [
     "health_worker",
-    "hospital"
+    "hospital",
+    "dentist",
+    "doctor",
+    "healthcare",
+    "md",
+    "nurse",
+    "physician",
+    "professional",
+    "therapist"
   ],
   "👨‍⚕️": [
     "man_health_worker",
@@ -1809,7 +2928,13 @@
     "therapist",
     "healthcare",
     "man",
-    "human"
+    "human",
+    "dentist",
+    "male",
+    "md",
+    "men",
+    "physician",
+    "professional"
   ],
   "👩‍⚕️": [
     "woman_health_worker",
@@ -1818,154 +2943,288 @@
     "therapist",
     "healthcare",
     "woman",
-    "human"
+    "human",
+    "dentist",
+    "female",
+    "md",
+    "physician",
+    "professional",
+    "women"
   ],
   "🧑‍🎓": [
     "student",
-    "learn"
+    "learn",
+    "education",
+    "graduate",
+    "pupil",
+    "school"
   ],
   "👨‍🎓": [
     "man_student",
     "graduate",
     "man",
-    "human"
+    "human",
+    "education",
+    "graduation",
+    "male",
+    "men",
+    "pupil",
+    "school"
   ],
   "👩‍🎓": [
     "woman_student",
     "graduate",
     "woman",
-    "human"
+    "human",
+    "education",
+    "female",
+    "graduation",
+    "pupil",
+    "school",
+    "women"
   ],
   "🧑‍🏫": [
     "teacher",
-    "professor"
+    "professor",
+    "education",
+    "educator",
+    "instructor"
   ],
   "👨‍🏫": [
     "man_teacher",
     "instructor",
     "professor",
     "man",
-    "human"
+    "human",
+    "education",
+    "educator",
+    "male",
+    "men",
+    "school"
   ],
   "👩‍🏫": [
     "woman_teacher",
     "instructor",
     "professor",
     "woman",
-    "human"
+    "human",
+    "education",
+    "educator",
+    "female",
+    "school",
+    "women"
   ],
   "🧑‍⚖️": [
     "judge",
-    "law"
+    "law",
+    "court",
+    "justice",
+    "scales"
   ],
   "👨‍⚖️": [
     "man_judge",
     "justice",
     "court",
     "man",
-    "human"
+    "human",
+    "law",
+    "male",
+    "men",
+    "scales"
   ],
   "👩‍⚖️": [
     "woman_judge",
     "justice",
     "court",
     "woman",
-    "human"
+    "human",
+    "female",
+    "law",
+    "scales",
+    "women"
   ],
   "🧑‍🌾": [
     "farmer",
-    "crops"
+    "crops",
+    "farm",
+    "farming",
+    "gardener",
+    "rancher",
+    "worker"
   ],
   "👨‍🌾": [
     "man_farmer",
     "rancher",
     "gardener",
     "man",
-    "human"
+    "human",
+    "farm",
+    "farming",
+    "male",
+    "men",
+    "worker"
   ],
   "👩‍🌾": [
     "woman_farmer",
     "rancher",
     "gardener",
     "woman",
-    "human"
+    "human",
+    "farm",
+    "farming",
+    "female",
+    "women",
+    "worker"
   ],
   "🧑‍🍳": [
     "cook",
     "food",
     "kitchen",
-    "culinary"
+    "culinary",
+    "chef",
+    "cooking",
+    "service"
   ],
   "👨‍🍳": [
     "man_cook",
     "chef",
     "man",
-    "human"
+    "human",
+    "cooking",
+    "food",
+    "male",
+    "men",
+    "service"
   ],
   "👩‍🍳": [
     "woman_cook",
     "chef",
     "woman",
-    "human"
+    "human",
+    "cooking",
+    "female",
+    "food",
+    "service",
+    "women"
   ],
   "🧑‍🔧": [
     "mechanic",
     "worker",
-    "technician"
+    "technician",
+    "electrician",
+    "person",
+    "plumber",
+    "repair",
+    "tradesperson"
   ],
   "👨‍🔧": [
     "man_mechanic",
     "plumber",
     "man",
     "human",
-    "wrench"
+    "wrench",
+    "electrician",
+    "male",
+    "men",
+    "person",
+    "repair",
+    "tradesperson"
   ],
   "👩‍🔧": [
     "woman_mechanic",
     "plumber",
     "woman",
     "human",
-    "wrench"
+    "wrench",
+    "electrician",
+    "female",
+    "person",
+    "repair",
+    "tradesperson",
+    "women"
   ],
   "🧑‍🏭": [
     "factory_worker",
-    "labor"
+    "labor",
+    "assembly",
+    "industrial",
+    "welder"
   ],
   "👨‍🏭": [
     "man_factory_worker",
     "assembly",
     "industrial",
     "man",
-    "human"
+    "human",
+    "male",
+    "men",
+    "welder"
   ],
   "👩‍🏭": [
     "woman_factory_worker",
     "assembly",
     "industrial",
     "woman",
-    "human"
+    "human",
+    "female",
+    "welder",
+    "women"
   ],
   "🧑‍💼": [
     "office_worker",
-    "business"
+    "business",
+    "accountant",
+    "adviser",
+    "analyst",
+    "architect",
+    "banker",
+    "clerk",
+    "manager"
   ],
   "👨‍💼": [
     "man_office_worker",
     "business",
     "manager",
     "man",
-    "human"
+    "human",
+    "accountant",
+    "adviser",
+    "analyst",
+    "architect",
+    "banker",
+    "businessman",
+    "ceo",
+    "clerk",
+    "male",
+    "men"
   ],
   "👩‍💼": [
     "woman_office_worker",
     "business",
     "manager",
     "woman",
-    "human"
+    "human",
+    "accountant",
+    "adviser",
+    "analyst",
+    "architect",
+    "banker",
+    "businesswoman",
+    "ceo",
+    "clerk",
+    "female",
+    "women"
   ],
   "🧑‍🔬": [
     "scientist",
-    "chemistry"
+    "chemistry",
+    "biologist",
+    "chemist",
+    "engineer",
+    "lab",
+    "mathematician",
+    "physicist",
+    "technician"
   ],
   "👨‍🔬": [
     "man_scientist",
@@ -1974,7 +3233,13 @@
     "engineer",
     "physicist",
     "man",
-    "human"
+    "human",
+    "lab",
+    "male",
+    "mathematician",
+    "men",
+    "research",
+    "technician"
   ],
   "👩‍🔬": [
     "woman_scientist",
@@ -1983,11 +3248,22 @@
     "engineer",
     "physicist",
     "woman",
-    "human"
+    "human",
+    "female",
+    "lab",
+    "mathematician",
+    "research",
+    "technician",
+    "women"
   ],
   "🧑‍💻": [
     "technologist",
-    "computer"
+    "computer",
+    "coder",
+    "engineer",
+    "laptop",
+    "software",
+    "technology"
   ],
   "👨‍💻": [
     "man_technologist",
@@ -1999,7 +3275,11 @@
     "man",
     "human",
     "laptop",
-    "computer"
+    "computer",
+    "blogger",
+    "male",
+    "men",
+    "technology"
   ],
   "👩‍💻": [
     "woman_technologist",
@@ -2011,103 +3291,187 @@
     "woman",
     "human",
     "laptop",
-    "computer"
+    "computer",
+    "blogger",
+    "female",
+    "technology",
+    "women"
   ],
   "🧑‍🎤": [
     "singer",
     "song",
     "artist",
-    "performer"
+    "performer",
+    "actor",
+    "entertainer",
+    "music",
+    "musician",
+    "rock",
+    "rocker",
+    "rockstar",
+    "star"
   ],
   "👨‍🎤": [
     "man_singer",
     "rockstar",
     "entertainer",
     "man",
-    "human"
+    "human",
+    "actor",
+    "aladdin",
+    "bowie",
+    "male",
+    "men",
+    "music",
+    "musician",
+    "rock",
+    "rocker",
+    "sane",
+    "star"
   ],
   "👩‍🎤": [
     "woman_singer",
     "rockstar",
     "entertainer",
     "woman",
-    "human"
+    "human",
+    "actor",
+    "female",
+    "music",
+    "musician",
+    "rock",
+    "rocker",
+    "star",
+    "women"
   ],
   "🧑‍🎨": [
     "artist",
     "painting",
     "draw",
-    "creativity"
+    "creativity",
+    "art",
+    "paint",
+    "painter",
+    "palette"
   ],
   "👨‍🎨": [
     "man_artist",
     "painter",
     "man",
-    "human"
+    "human",
+    "art",
+    "male",
+    "men",
+    "paint",
+    "palette"
   ],
   "👩‍🎨": [
     "woman_artist",
     "painter",
     "woman",
-    "human"
+    "human",
+    "art",
+    "female",
+    "paint",
+    "palette",
+    "women"
   ],
   "🧑‍✈️": [
     "pilot",
     "fly",
     "plane",
-    "airplane"
+    "airplane",
+    "aviation",
+    "aviator"
   ],
   "👨‍✈️": [
     "man_pilot",
     "aviator",
     "plane",
     "man",
-    "human"
+    "human",
+    "airplane",
+    "aviation",
+    "male",
+    "men"
   ],
   "👩‍✈️": [
     "woman_pilot",
     "aviator",
     "plane",
     "woman",
-    "human"
+    "human",
+    "airplane",
+    "aviation",
+    "female",
+    "women"
   ],
   "🧑‍🚀": [
     "astronaut",
-    "outerspace"
+    "outerspace",
+    "moon",
+    "planets",
+    "rocket",
+    "space",
+    "stars"
   ],
   "👨‍🚀": [
     "man_astronaut",
     "space",
     "rocket",
     "man",
-    "human"
+    "human",
+    "cosmonaut",
+    "male",
+    "men",
+    "moon",
+    "planets",
+    "stars"
   ],
   "👩‍🚀": [
     "woman_astronaut",
     "space",
     "rocket",
     "woman",
-    "human"
+    "human",
+    "cosmonaut",
+    "female",
+    "moon",
+    "planets",
+    "stars",
+    "women"
   ],
   "🧑‍🚒": [
     "firefighter",
-    "fire"
+    "fire",
+    "firetruck"
   ],
   "👨‍🚒": [
     "man_firefighter",
     "fireman",
     "man",
-    "human"
+    "human",
+    "fire",
+    "firetruck",
+    "male",
+    "men"
   ],
   "👩‍🚒": [
     "woman_firefighter",
     "fireman",
     "woman",
-    "human"
+    "human",
+    "female",
+    "fire",
+    "firetruck",
+    "women"
   ],
   "👮": [
     "police_officer",
-    "cop"
+    "cop",
+    "law",
+    "policeman",
+    "policewoman"
   ],
   "👮‍♂️": [
     "man_police_officer",
@@ -2117,7 +3481,11 @@
     "legal",
     "enforcement",
     "arrest",
-    "911"
+    "911",
+    "cop",
+    "male",
+    "men",
+    "policeman"
   ],
   "👮‍♀️": [
     "woman_police_officer",
@@ -2128,16 +3496,27 @@
     "enforcement",
     "arrest",
     "911",
-    "female"
+    "female",
+    "cop",
+    "policewoman",
+    "women"
   ],
   "🕵️": [
     "detective",
     "human",
-    "spy"
+    "spy",
+    "eye",
+    "or",
+    "private",
+    "sleuth"
   ],
   "🕵️‍♂️": [
     "man_detective",
-    "crime"
+    "crime",
+    "male",
+    "men",
+    "sleuth",
+    "spy"
   ],
   "🕵️‍♀️": [
     "woman_detective",
@@ -2145,11 +3524,16 @@
     "spy",
     "detective",
     "female",
-    "woman"
+    "woman",
+    "sleuth",
+    "women"
   ],
   "💂": [
     "guard",
-    "protect"
+    "protect",
+    "british",
+    "foot",
+    "guardsman"
   ],
   "💂‍♂️": [
     "man_guard",
@@ -2158,7 +3542,9 @@
     "british",
     "male",
     "guy",
-    "royal"
+    "royal",
+    "guardsman",
+    "men"
   ],
   "💂‍♀️": [
     "woman_guard",
@@ -2167,12 +3553,21 @@
     "british",
     "female",
     "royal",
-    "woman"
+    "woman",
+    "guardsman",
+    "guardswoman",
+    "women"
   ],
   "👷": [
     "construction_worker",
     "labor",
-    "build"
+    "build",
+    "builder",
+    "face",
+    "hard",
+    "hat",
+    "helmet",
+    "safety"
   ],
   "👷‍♂️": [
     "man_construction_worker",
@@ -2183,7 +3578,9 @@
     "build",
     "construction",
     "worker",
-    "labor"
+    "labor",
+    "helmet",
+    "men"
   ],
   "👷‍♀️": [
     "woman_construction_worker",
@@ -2194,7 +3591,9 @@
     "construction",
     "worker",
     "labor",
-    "woman"
+    "woman",
+    "helmet",
+    "women"
   ],
   "🤴": [
     "prince",
@@ -2203,7 +3602,11 @@
     "male",
     "crown",
     "royal",
-    "king"
+    "king",
+    "fairy",
+    "fantasy",
+    "men",
+    "tale"
   ],
   "👸": [
     "princess",
@@ -2213,18 +3616,29 @@
     "blond",
     "crown",
     "royal",
-    "queen"
+    "queen",
+    "blonde",
+    "fairy",
+    "fantasy",
+    "tale",
+    "tiara",
+    "women"
   ],
   "👳": [
     "person_wearing_turban",
-    "headdress"
+    "headdress",
+    "arab",
+    "man",
+    "muslim",
+    "sikh"
   ],
   "👳‍♂️": [
     "man_wearing_turban",
     "male",
     "indian",
     "hinduism",
-    "arabs"
+    "arabs",
+    "men"
   ],
   "👳‍♀️": [
     "woman_wearing_turban",
@@ -2232,13 +3646,21 @@
     "indian",
     "hinduism",
     "arabs",
-    "woman"
+    "woman",
+    "women"
   ],
   "👲": [
     "man_with_skullcap",
     "male",
     "boy",
-    "chinese"
+    "chinese",
+    "asian",
+    "cap",
+    "gua",
+    "hat",
+    "mao",
+    "person",
+    "pi"
   ],
   "🧕": [
     "woman_with_headscarf",
@@ -2252,7 +3674,11 @@
     "couple",
     "marriage",
     "wedding",
-    "groom"
+    "groom",
+    "male",
+    "men",
+    "person",
+    "suit"
   ],
   "👰": [
     "bride_with_veil",
@@ -2260,22 +3686,42 @@
     "marriage",
     "wedding",
     "woman",
-    "bride"
+    "bride",
+    "person"
   ],
   "🤰": [
     "pregnant_woman",
-    "baby"
+    "baby",
+    "female",
+    "pregnancy",
+    "pregnant lady",
+    "women"
   ],
   "🤱": [
     "breast_feeding",
     "nursing",
-    "baby"
+    "baby",
+    "breastfeeding",
+    "child",
+    "female",
+    "infant",
+    "milk",
+    "mother",
+    "woman",
+    "women"
   ],
   "👼": [
     "baby_angel",
     "heaven",
     "wings",
-    "halo"
+    "halo",
+    "cherub",
+    "cupid",
+    "face",
+    "fairy",
+    "fantasy",
+    "putto",
+    "tale"
   ],
   "🎅": [
     "santa_claus",
@@ -2283,18 +3729,35 @@
     "man",
     "male",
     "xmas",
-    "father christmas"
+    "father christmas",
+    "activity",
+    "celebration",
+    "men",
+    "nicholas",
+    "saint",
+    "sinterklaas"
   ],
   "🤶": [
     "mrs_claus",
     "woman",
     "female",
     "xmas",
-    "mother christmas"
+    "mother christmas",
+    "activity",
+    "celebration",
+    "mrs.",
+    "santa",
+    "women"
   ],
   "🦸": [
     "superhero",
-    "marvel"
+    "marvel",
+    "fantasy",
+    "good",
+    "hero",
+    "heroine",
+    "superpower",
+    "superpowers"
   ],
   "🦸‍♂️": [
     "man_superhero",
@@ -2302,7 +3765,10 @@
     "male",
     "good",
     "hero",
-    "superpowers"
+    "superpowers",
+    "fantasy",
+    "men",
+    "superpower"
   ],
   "🦸‍♀️": [
     "woman_superhero",
@@ -2310,11 +3776,22 @@
     "female",
     "good",
     "heroine",
-    "superpowers"
+    "superpowers",
+    "fantasy",
+    "hero",
+    "superpower",
+    "women"
   ],
   "🦹": [
     "supervillain",
-    "marvel"
+    "marvel",
+    "bad",
+    "criminal",
+    "evil",
+    "fantasy",
+    "superpower",
+    "superpowers",
+    "villain"
   ],
   "🦹‍♂️": [
     "man_supervillain",
@@ -2324,7 +3801,11 @@
     "bad",
     "criminal",
     "hero",
-    "superpowers"
+    "superpowers",
+    "fantasy",
+    "men",
+    "superpower",
+    "villain"
   ],
   "🦹‍♀️": [
     "woman_supervillain",
@@ -2334,106 +3815,182 @@
     "bad",
     "criminal",
     "heroine",
-    "superpowers"
+    "superpowers",
+    "fantasy",
+    "superpower",
+    "villain",
+    "women"
   ],
   "🧙": [
     "mage",
-    "magic"
+    "magic",
+    "fantasy",
+    "sorcerer",
+    "sorceress",
+    "witch",
+    "wizard"
   ],
   "🧙‍♂️": [
     "man_mage",
     "man",
     "male",
     "mage",
-    "sorcerer"
+    "sorcerer",
+    "fantasy",
+    "men",
+    "wizard"
   ],
   "🧙‍♀️": [
     "woman_mage",
     "woman",
     "female",
     "mage",
-    "witch"
+    "witch",
+    "fantasy",
+    "sorceress",
+    "wizard",
+    "women"
   ],
   "🧚": [
     "fairy",
     "wings",
-    "magical"
+    "magical",
+    "fantasy",
+    "oberon",
+    "puck",
+    "titania"
   ],
   "🧚‍♂️": [
     "man_fairy",
     "man",
-    "male"
+    "male",
+    "fantasy",
+    "men",
+    "oberon",
+    "puck"
   ],
   "🧚‍♀️": [
     "woman_fairy",
     "woman",
-    "female"
+    "female",
+    "fantasy",
+    "titania",
+    "wings",
+    "women"
   ],
   "🧛": [
     "vampire",
     "blood",
-    "twilight"
+    "twilight",
+    "dracula",
+    "fantasy",
+    "undead"
   ],
   "🧛‍♂️": [
     "man_vampire",
     "man",
     "male",
-    "dracula"
+    "dracula",
+    "fantasy",
+    "men",
+    "undead"
   ],
   "🧛‍♀️": [
     "woman_vampire",
     "woman",
-    "female"
+    "female",
+    "fantasy",
+    "undead",
+    "unded",
+    "women"
   ],
   "🧜": [
     "merperson",
-    "sea"
+    "sea",
+    "fantasy",
+    "merboy",
+    "mergirl",
+    "mermaid",
+    "merman",
+    "merwoman"
   ],
   "🧜‍♂️": [
     "merman",
     "man",
     "male",
-    "triton"
+    "triton",
+    "fantasy",
+    "men",
+    "mermaid"
   ],
   "🧜‍♀️": [
     "mermaid",
     "woman",
     "female",
     "merwoman",
-    "ariel"
+    "ariel",
+    "fantasy",
+    "women"
   ],
   "🧝": [
     "elf",
-    "magical"
+    "magical",
+    "ears",
+    "fantasy",
+    "legolas",
+    "pointed"
   ],
   "🧝‍♂️": [
     "man_elf",
     "man",
-    "male"
+    "male",
+    "ears",
+    "fantasy",
+    "magical",
+    "men",
+    "pointed"
   ],
   "🧝‍♀️": [
     "woman_elf",
     "woman",
-    "female"
+    "female",
+    "ears",
+    "fantasy",
+    "magical",
+    "pointed",
+    "women"
   ],
   "🧞": [
     "genie",
     "magical",
-    "wishes"
+    "wishes",
+    "djinn",
+    "djinni",
+    "fantasy",
+    "jinni"
   ],
   "🧞‍♂️": [
     "man_genie",
     "man",
-    "male"
+    "male",
+    "djinn",
+    "fantasy",
+    "men"
   ],
   "🧞‍♀️": [
     "woman_genie",
     "woman",
-    "female"
+    "female",
+    "djinn",
+    "fantasy",
+    "women"
   ],
   "🧟": [
     "zombie",
-    "dead"
+    "dead",
+    "fantasy",
+    "undead",
+    "walking"
   ],
   "🧟‍♂️": [
     "man_zombie",
@@ -2441,58 +3998,98 @@
     "male",
     "dracula",
     "undead",
-    "walking dead"
+    "walking dead",
+    "fantasy",
+    "men"
   ],
   "🧟‍♀️": [
     "woman_zombie",
     "woman",
     "female",
     "undead",
-    "walking dead"
+    "walking dead",
+    "fantasy",
+    "women"
   ],
   "💆": [
     "person_getting_massage",
-    "relax"
+    "relax",
+    "face",
+    "head",
+    "massaging",
+    "salon",
+    "spa"
   ],
   "💆‍♂️": [
     "man_getting_massage",
     "male",
     "boy",
     "man",
-    "head"
+    "head",
+    "face",
+    "men",
+    "salon",
+    "spa"
   ],
   "💆‍♀️": [
     "woman_getting_massage",
     "female",
     "girl",
     "woman",
-    "head"
+    "head",
+    "face",
+    "salon",
+    "spa",
+    "women"
   ],
   "💇": [
     "person_getting_haircut",
-    "hairstyle"
+    "hairstyle",
+    "barber",
+    "beauty",
+    "cutting",
+    "hair",
+    "hairdresser",
+    "parlor"
   ],
   "💇‍♂️": [
     "man_getting_haircut",
     "male",
     "boy",
-    "man"
+    "man",
+    "barber",
+    "beauty",
+    "men",
+    "parlor"
   ],
   "💇‍♀️": [
     "woman_getting_haircut",
     "female",
     "girl",
-    "woman"
+    "woman",
+    "barber",
+    "beauty",
+    "parlor",
+    "women"
   ],
   "🚶": [
     "person_walking",
-    "move"
+    "move",
+    "hike",
+    "pedestrian",
+    "walk",
+    "walker"
   ],
   "🚶‍♂️": [
     "man_walking",
     "human",
     "feet",
-    "steps"
+    "steps",
+    "hike",
+    "male",
+    "men",
+    "pedestrian",
+    "walk"
   ],
   "🚶‍♀️": [
     "woman_walking",
@@ -2500,46 +4097,74 @@
     "feet",
     "steps",
     "woman",
-    "female"
+    "female",
+    "hike",
+    "pedestrian",
+    "walk",
+    "women"
   ],
   "🧍": [
     "person_standing",
-    "still"
+    "still",
+    "stand"
   ],
   "🧍‍♂️": [
     "man_standing",
-    "still"
+    "still",
+    "male",
+    "men",
+    "stand"
   ],
   "🧍‍♀️": [
     "woman_standing",
-    "still"
+    "still",
+    "female",
+    "stand",
+    "women"
   ],
   "🧎": [
     "person_kneeling",
     "pray",
-    "respectful"
+    "respectful",
+    "kneel"
   ],
   "🧎‍♂️": [
     "man_kneeling",
     "pray",
-    "respectful"
+    "respectful",
+    "kneel",
+    "male",
+    "men"
   ],
   "🧎‍♀️": [
     "woman_kneeling",
     "respectful",
-    "pray"
+    "pray",
+    "female",
+    "kneel",
+    "women"
   ],
   "🧑‍🦯": [
     "person_with_probing_cane",
-    "blind"
+    "blind",
+    "accessibility",
+    "white"
   ],
   "👨‍🦯": [
     "man_with_probing_cane",
-    "blind"
+    "blind",
+    "accessibility",
+    "male",
+    "men",
+    "white"
   ],
   "👩‍🦯": [
     "woman_with_probing_cane",
-    "blind"
+    "blind",
+    "accessibility",
+    "female",
+    "white",
+    "women"
   ],
   "🧑‍🦼": [
     "person_in_motorized_wheelchair",
@@ -2549,12 +4174,16 @@
   "👨‍🦼": [
     "man_in_motorized_wheelchair",
     "disability",
-    "accessibility"
+    "accessibility",
+    "male",
+    "men"
   ],
   "👩‍🦼": [
     "woman_in_motorized_wheelchair",
     "disability",
-    "accessibility"
+    "accessibility",
+    "female",
+    "women"
   ],
   "🧑‍🦽": [
     "person_in_manual_wheelchair",
@@ -2564,16 +4193,26 @@
   "👨‍🦽": [
     "man_in_manual_wheelchair",
     "disability",
-    "accessibility"
+    "accessibility",
+    "male",
+    "men"
   ],
   "👩‍🦽": [
     "woman_in_manual_wheelchair",
     "disability",
-    "accessibility"
+    "accessibility",
+    "female",
+    "women"
   ],
   "🏃": [
     "person_running",
-    "move"
+    "move",
+    "exercise",
+    "jogging",
+    "marathon",
+    "run",
+    "runner",
+    "workout"
   ],
   "🏃‍♂️": [
     "man_running",
@@ -2581,7 +4220,13 @@
     "walking",
     "exercise",
     "race",
-    "running"
+    "running",
+    "male",
+    "marathon",
+    "men",
+    "racing",
+    "runner",
+    "workout"
   ],
   "🏃‍♀️": [
     "woman_running",
@@ -2590,21 +4235,36 @@
     "exercise",
     "race",
     "running",
-    "female"
+    "female",
+    "boy",
+    "marathon",
+    "racing",
+    "runner",
+    "women",
+    "workout"
   ],
   "💃": [
     "woman_dancing",
     "female",
     "girl",
     "woman",
-    "fun"
+    "fun",
+    "dance",
+    "dancer",
+    "dress",
+    "red",
+    "salsa",
+    "women"
   ],
   "🕺": [
     "man_dancing",
     "male",
     "boy",
     "fun",
-    "dancer"
+    "dancer",
+    "dance",
+    "disco",
+    "men"
   ],
   "🕴️": [
     "man_in_suit_levitating",
@@ -2612,31 +4272,61 @@
     "business",
     "levitate",
     "hover",
-    "jump"
+    "jump",
+    "boy",
+    "hovering",
+    "jabsco",
+    "male",
+    "men",
+    "person",
+    "rude",
+    "walt"
   ],
   "👯": [
     "people_with_bunny_ears",
     "perform",
-    "costume"
+    "costume",
+    "dancer",
+    "dancing",
+    "ear",
+    "partying",
+    "wearing",
+    "women"
   ],
   "👯‍♂️": [
     "men_with_bunny_ears",
     "male",
     "bunny",
     "men",
-    "boys"
+    "boys",
+    "dancer",
+    "dancing",
+    "ear",
+    "man",
+    "partying",
+    "wearing"
   ],
   "👯‍♀️": [
     "women_with_bunny_ears",
     "female",
     "bunny",
     "women",
-    "girls"
+    "girls",
+    "dancer",
+    "dancing",
+    "ear",
+    "partying",
+    "people",
+    "wearing"
   ],
   "🧖": [
     "person_in_steamy_room",
     "relax",
-    "spa"
+    "spa",
+    "hamam",
+    "sauna",
+    "steam",
+    "steambath"
   ],
   "🧖‍♂️": [
     "man_in_steamy_room",
@@ -2644,7 +4334,11 @@
     "man",
     "spa",
     "steamroom",
-    "sauna"
+    "sauna",
+    "hamam",
+    "men",
+    "steam",
+    "steambath"
   ],
   "🧖‍♀️": [
     "woman_in_steamy_room",
@@ -2652,11 +4346,18 @@
     "woman",
     "spa",
     "steamroom",
-    "sauna"
+    "sauna",
+    "hamam",
+    "steam",
+    "steambath",
+    "women"
   ],
   "🧗": [
     "person_climbing",
-    "sport"
+    "sport",
+    "bouldering",
+    "climber",
+    "rock"
   ],
   "🧗‍♂️": [
     "man_climbing",
@@ -2664,7 +4365,10 @@
     "hobby",
     "man",
     "male",
-    "rock"
+    "rock",
+    "bouldering",
+    "climber",
+    "men"
   ],
   "🧗‍♀️": [
     "woman_climbing",
@@ -2672,13 +4376,17 @@
     "hobby",
     "woman",
     "female",
-    "rock"
+    "rock",
+    "bouldering",
+    "climber",
+    "women"
   ],
   "🤺": [
     "person_fencing",
     "sports",
     "fencing",
-    "sword"
+    "sword",
+    "fencer"
   ],
   "🏇": [
     "horse_racing",
@@ -2686,39 +4394,62 @@
     "betting",
     "competition",
     "gambling",
-    "luck"
+    "luck",
+    "jockey",
+    "race",
+    "racehorse"
   ],
   "⛷️": [
     "skier",
     "sports",
     "winter",
-    "snow"
+    "snow",
+    "ski"
   ],
   "🏂": [
     "snowboarder",
     "sports",
-    "winter"
+    "winter",
+    "ski",
+    "snow",
+    "snowboard",
+    "snowboarding"
   ],
   "🏌️": [
     "person_golfing",
     "sports",
-    "business"
+    "business",
+    "ball",
+    "club",
+    "golf",
+    "golfer"
   ],
   "🏌️‍♂️": [
     "man_golfing",
-    "sport"
+    "sport",
+    "ball",
+    "golf",
+    "golfer",
+    "male",
+    "men"
   ],
   "🏌️‍♀️": [
     "woman_golfing",
     "sports",
     "business",
     "woman",
-    "female"
+    "female",
+    "ball",
+    "golf",
+    "golfer",
+    "women"
   ],
   "🏄": [
     "person_surfing",
     "sport",
-    "sea"
+    "sea",
+    "surf",
+    "surfer"
   ],
   "🏄‍♂️": [
     "man_surfing",
@@ -2726,7 +4457,10 @@
     "ocean",
     "sea",
     "summer",
-    "beach"
+    "beach",
+    "male",
+    "men",
+    "surfer"
   ],
   "🏄‍♀️": [
     "woman_surfing",
@@ -2736,19 +4470,28 @@
     "summer",
     "beach",
     "woman",
-    "female"
+    "female",
+    "surfer",
+    "women"
   ],
   "🚣": [
     "person_rowing_boat",
     "sport",
-    "move"
+    "move",
+    "paddles",
+    "rowboat",
+    "vehicle"
   ],
   "🚣‍♂️": [
     "man_rowing_boat",
     "sports",
     "hobby",
     "water",
-    "ship"
+    "ship",
+    "male",
+    "men",
+    "rowboat",
+    "vehicle"
   ],
   "🚣‍♀️": [
     "woman_rowing_boat",
@@ -2757,12 +4500,17 @@
     "water",
     "ship",
     "woman",
-    "female"
+    "female",
+    "rowboat",
+    "vehicle",
+    "women"
   ],
   "🏊": [
     "person_swimming",
     "sport",
-    "pool"
+    "pool",
+    "swim",
+    "swimmer"
   ],
   "🏊‍♂️": [
     "man_swimming",
@@ -2771,7 +4519,11 @@
     "human",
     "athlete",
     "water",
-    "summer"
+    "summer",
+    "male",
+    "men",
+    "swim",
+    "swimmer"
   ],
   "🏊‍♀️": [
     "woman_swimming",
@@ -2782,33 +4534,58 @@
     "water",
     "summer",
     "woman",
-    "female"
+    "female",
+    "swim",
+    "swimmer",
+    "women"
   ],
   "⛹️": [
     "person_bouncing_ball",
     "sports",
-    "human"
+    "human",
+    "basketball",
+    "player"
   ],
   "⛹️‍♂️": [
     "man_bouncing_ball",
-    "sport"
+    "sport",
+    "basketball",
+    "male",
+    "men",
+    "player"
   ],
   "⛹️‍♀️": [
     "woman_bouncing_ball",
     "sports",
     "human",
     "woman",
-    "female"
+    "female",
+    "basketball",
+    "player",
+    "women"
   ],
   "🏋️": [
     "person_lifting_weights",
     "sports",
     "training",
-    "exercise"
+    "exercise",
+    "bodybuilder",
+    "gym",
+    "lifter",
+    "weight",
+    "weightlifter",
+    "workout"
   ],
   "🏋️‍♂️": [
     "man_lifting_weights",
-    "sport"
+    "sport",
+    "gym",
+    "lifter",
+    "male",
+    "men",
+    "weight",
+    "weightlifter",
+    "workout"
   ],
   "🏋️‍♀️": [
     "woman_lifting_weights",
@@ -2816,7 +4593,13 @@
     "training",
     "exercise",
     "woman",
-    "female"
+    "female",
+    "gym",
+    "lifter",
+    "weight",
+    "weightlifter",
+    "women",
+    "workout"
   ],
   "🚴": [
     "person_biking",
@@ -2824,7 +4607,8 @@
     "bike",
     "cyclist",
     "sport",
-    "move"
+    "move",
+    "bicyclist"
   ],
   "🚴‍♂️": [
     "man_biking",
@@ -2833,7 +4617,10 @@
     "cyclist",
     "sports",
     "exercise",
-    "hipster"
+    "hipster",
+    "bicyclist",
+    "male",
+    "men"
   ],
   "🚴‍♀️": [
     "woman_biking",
@@ -2844,7 +4631,9 @@
     "exercise",
     "hipster",
     "woman",
-    "female"
+    "female",
+    "bicyclist",
+    "women"
   ],
   "🚵": [
     "person_mountain_biking",
@@ -2852,7 +4641,9 @@
     "bike",
     "cyclist",
     "sport",
-    "move"
+    "move",
+    "bicyclist",
+    "biker"
   ],
   "🚵‍♂️": [
     "man_mountain_biking",
@@ -2862,7 +4653,11 @@
     "transportation",
     "sports",
     "human",
-    "race"
+    "race",
+    "bicyclist",
+    "biker",
+    "male",
+    "men"
   ],
   "🚵‍♀️": [
     "woman_mountain_biking",
@@ -2874,34 +4669,60 @@
     "human",
     "race",
     "woman",
-    "female"
+    "female",
+    "bicyclist",
+    "biker",
+    "women"
   ],
   "🤸": [
     "person_cartwheeling",
     "sport",
-    "gymnastic"
+    "gymnastic",
+    "cartwheel",
+    "doing",
+    "gymnast",
+    "gymnastics"
   ],
   "🤸‍♂️": [
     "man_cartwheeling",
-    "gymnastics"
+    "gymnastics",
+    "cartwheel",
+    "doing",
+    "male",
+    "men"
   ],
   "🤸‍♀️": [
     "woman_cartwheeling",
-    "gymnastics"
+    "gymnastics",
+    "cartwheel",
+    "doing",
+    "female",
+    "women"
   ],
   "🤼": [
     "people_wrestling",
-    "sport"
+    "sport",
+    "wrestle",
+    "wrestler",
+    "wrestlers"
   ],
   "🤼‍♂️": [
     "men_wrestling",
     "sports",
-    "wrestlers"
+    "wrestlers",
+    "male",
+    "man",
+    "wrestle",
+    "wrestler"
   ],
   "🤼‍♀️": [
     "women_wrestling",
     "sports",
-    "wrestlers"
+    "wrestlers",
+    "female",
+    "woman",
+    "wrestle",
+    "wrestler"
   ],
   "🤽": [
     "person_playing_water_polo",
@@ -2910,47 +4731,71 @@
   "🤽‍♂️": [
     "man_playing_water_polo",
     "sports",
-    "pool"
+    "pool",
+    "male",
+    "men"
   ],
   "🤽‍♀️": [
     "woman_playing_water_polo",
     "sports",
-    "pool"
+    "pool",
+    "female",
+    "women"
   ],
   "🤾": [
     "person_playing_handball",
-    "sport"
+    "sport",
+    "ball"
   ],
   "🤾‍♂️": [
     "man_playing_handball",
-    "sports"
+    "sports",
+    "ball",
+    "male",
+    "men"
   ],
   "🤾‍♀️": [
     "woman_playing_handball",
-    "sports"
+    "sports",
+    "ball",
+    "female",
+    "women"
   ],
   "🤹": [
     "person_juggling",
     "performance",
-    "balance"
+    "balance",
+    "juggle",
+    "juggler",
+    "multitask",
+    "skill"
   ],
   "🤹‍♂️": [
     "man_juggling",
     "juggle",
     "balance",
     "skill",
-    "multitask"
+    "multitask",
+    "juggler",
+    "male",
+    "men"
   ],
   "🤹‍♀️": [
     "woman_juggling",
     "juggle",
     "balance",
     "skill",
-    "multitask"
+    "multitask",
+    "female",
+    "juggler",
+    "women"
   ],
   "🧘": [
     "person_in_lotus_position",
-    "meditate"
+    "meditate",
+    "meditation",
+    "serenity",
+    "yoga"
   ],
   "🧘‍♂️": [
     "man_in_lotus_position",
@@ -2960,7 +4805,8 @@
     "yoga",
     "serenity",
     "zen",
-    "mindfulness"
+    "mindfulness",
+    "men"
   ],
   "🧘‍♀️": [
     "woman_in_lotus_position",
@@ -2970,22 +4816,38 @@
     "yoga",
     "serenity",
     "zen",
-    "mindfulness"
+    "mindfulness",
+    "women"
   ],
   "🛀": [
     "person_taking_bath",
     "clean",
     "shower",
-    "bathroom"
+    "bathroom",
+    "bathing",
+    "bathtub",
+    "hot"
   ],
   "🛌": [
     "person_in_bed",
     "bed",
-    "rest"
+    "rest",
+    "accommodation",
+    "hotel",
+    "sleep",
+    "sleeping"
   ],
   "🧑‍🤝‍🧑": [
     "people_holding_hands",
-    "friendship"
+    "friendship",
+    "couple",
+    "date",
+    "gender",
+    "hand",
+    "hold",
+    "inclusive",
+    "neutral",
+    "nonconforming"
   ],
   "👭": [
     "women_holding_hands",
@@ -2996,7 +4858,15 @@
     "like",
     "female",
     "people",
-    "human"
+    "human",
+    "date",
+    "hand",
+    "hold",
+    "lesbian",
+    "lgbt",
+    "pride",
+    "two",
+    "woman"
   ],
   "👫": [
     "woman_and_man_holding_hands",
@@ -3009,7 +4879,16 @@
     "like",
     "affection",
     "valentines",
-    "marriage"
+    "marriage",
+    "couple",
+    "female",
+    "hand",
+    "heterosexual",
+    "hold",
+    "male",
+    "men",
+    "straight",
+    "women"
   ],
   "👬": [
     "men_holding_hands",
@@ -3020,7 +4899,16 @@
     "bromance",
     "friendship",
     "people",
-    "human"
+    "human",
+    "date",
+    "gay",
+    "hand",
+    "hold",
+    "lgbt",
+    "male",
+    "man",
+    "pride",
+    "two"
   ],
   "💏": [
     "kiss",
@@ -3029,11 +4917,33 @@
     "love",
     "like",
     "dating",
-    "marriage"
+    "marriage",
+    "couple",
+    "couplekiss",
+    "female",
+    "gender",
+    "heart",
+    "kissing",
+    "male",
+    "man",
+    "men",
+    "neutral",
+    "romance",
+    "woman",
+    "women"
   ],
   "👩‍❤️‍💋‍👨": [
     "kiss_woman_man",
-    "love"
+    "love",
+    "couple",
+    "couplekiss",
+    "female",
+    "heart",
+    "kissing",
+    "male",
+    "men",
+    "romance",
+    "women"
   ],
   "👨‍❤️‍💋‍👨": [
     "kiss_man_man",
@@ -3042,7 +4952,18 @@
     "love",
     "like",
     "dating",
-    "marriage"
+    "marriage",
+    "couple",
+    "couplekiss",
+    "gay",
+    "heart",
+    "kissing",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "romance",
+    "two"
   ],
   "👩‍❤️‍💋‍👩": [
     "kiss_woman_woman",
@@ -3051,7 +4972,18 @@
     "love",
     "like",
     "dating",
-    "marriage"
+    "marriage",
+    "couple",
+    "couplekiss",
+    "female",
+    "heart",
+    "kissing",
+    "lesbian",
+    "lgbt",
+    "pride",
+    "romance",
+    "two",
+    "women"
   ],
   "💑": [
     "couple_with_heart",
@@ -3062,11 +4994,26 @@
     "human",
     "dating",
     "valentines",
-    "marriage"
+    "marriage",
+    "female",
+    "gender",
+    "loving",
+    "male",
+    "man",
+    "men",
+    "neutral",
+    "romance",
+    "woman",
+    "women"
   ],
   "👩‍❤️‍👨": [
     "couple_with_heart_woman_man",
-    "love"
+    "love",
+    "female",
+    "male",
+    "men",
+    "romance",
+    "women"
   ],
   "👨‍❤️‍👨": [
     "couple_with_heart_man_man",
@@ -3077,7 +5024,14 @@
     "human",
     "dating",
     "valentines",
-    "marriage"
+    "marriage",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "romance",
+    "two"
   ],
   "👩‍❤️‍👩": [
     "couple_with_heart_woman_woman",
@@ -3088,7 +5042,14 @@
     "human",
     "dating",
     "valentines",
-    "marriage"
+    "marriage",
+    "female",
+    "lesbian",
+    "lgbt",
+    "pride",
+    "romance",
+    "two",
+    "women"
   ],
   "👪": [
     "family",
@@ -3100,11 +5061,21 @@
     "father",
     "mother",
     "people",
-    "human"
+    "human",
+    "boy",
+    "female",
+    "male",
+    "man",
+    "men",
+    "woman",
+    "women"
   ],
   "👨‍👩‍👦": [
     "family_man_woman_boy",
-    "love"
+    "love",
+    "father",
+    "mother",
+    "son"
   ],
   "👨‍👩‍👧": [
     "family_man_woman_girl",
@@ -3112,7 +5083,14 @@
     "parents",
     "people",
     "human",
-    "child"
+    "child",
+    "daughter",
+    "father",
+    "female",
+    "male",
+    "men",
+    "mother",
+    "women"
   ],
   "👨‍👩‍👧‍👦": [
     "family_man_woman_girl_boy",
@@ -3120,7 +5098,16 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "father",
+    "female",
+    "male",
+    "men",
+    "mother",
+    "son",
+    "women"
   ],
   "👨‍👩‍👦‍👦": [
     "family_man_woman_boy_boy",
@@ -3128,7 +5115,16 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "father",
+    "female",
+    "male",
+    "men",
+    "mother",
+    "sons",
+    "two",
+    "women"
   ],
   "👨‍👩‍👧‍👧": [
     "family_man_woman_girl_girl",
@@ -3136,7 +5132,16 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughters",
+    "father",
+    "female",
+    "male",
+    "men",
+    "mother",
+    "two",
+    "women"
   ],
   "👨‍👨‍👦": [
     "family_man_man_boy",
@@ -3144,7 +5149,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "father",
+    "fathers",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "son",
+    "two"
   ],
   "👨‍👨‍👧": [
     "family_man_man_girl",
@@ -3152,7 +5167,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "father",
+    "fathers",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "two"
   ],
   "👨‍👨‍👧‍👦": [
     "family_man_man_girl_boy",
@@ -3160,7 +5185,18 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "father",
+    "fathers",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "son",
+    "two"
   ],
   "👨‍👨‍👦‍👦": [
     "family_man_man_boy_boy",
@@ -3168,7 +5204,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "father",
+    "fathers",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "sons",
+    "two"
   ],
   "👨‍👨‍👧‍👧": [
     "family_man_man_girl_girl",
@@ -3176,7 +5222,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughters",
+    "father",
+    "fathers",
+    "gay",
+    "lgbt",
+    "male",
+    "men",
+    "pride",
+    "two"
   ],
   "👩‍👩‍👦": [
     "family_woman_woman_boy",
@@ -3184,7 +5240,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "female",
+    "lesbian",
+    "lgbt",
+    "mother",
+    "mothers",
+    "pride",
+    "son",
+    "two",
+    "women"
   ],
   "👩‍👩‍👧": [
     "family_woman_woman_girl",
@@ -3192,7 +5258,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "female",
+    "lesbian",
+    "lgbt",
+    "mother",
+    "mothers",
+    "pride",
+    "two",
+    "women"
   ],
   "👩‍👩‍👧‍👦": [
     "family_woman_woman_girl_boy",
@@ -3200,7 +5276,18 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "female",
+    "lesbian",
+    "lgbt",
+    "mother",
+    "mothers",
+    "pride",
+    "son",
+    "two",
+    "women"
   ],
   "👩‍👩‍👦‍👦": [
     "family_woman_woman_boy_boy",
@@ -3208,7 +5295,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "female",
+    "lesbian",
+    "lgbt",
+    "mother",
+    "mothers",
+    "pride",
+    "sons",
+    "two",
+    "women"
   ],
   "👩‍👩‍👧‍👧": [
     "family_woman_woman_girl_girl",
@@ -3216,7 +5313,17 @@
     "parents",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughters",
+    "female",
+    "lesbian",
+    "lgbt",
+    "mother",
+    "mothers",
+    "pride",
+    "two",
+    "women"
   ],
   "👨‍👦": [
     "family_man_boy",
@@ -3224,7 +5331,11 @@
     "parent",
     "people",
     "human",
-    "child"
+    "child",
+    "father",
+    "male",
+    "men",
+    "son"
   ],
   "👨‍👦‍👦": [
     "family_man_boy_boy",
@@ -3232,7 +5343,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "father",
+    "male",
+    "men",
+    "sons",
+    "two"
   ],
   "👨‍👧": [
     "family_man_girl",
@@ -3240,7 +5357,11 @@
     "parent",
     "people",
     "human",
-    "child"
+    "child",
+    "daughter",
+    "father",
+    "female",
+    "male"
   ],
   "👨‍👧‍👦": [
     "family_man_girl_boy",
@@ -3248,7 +5369,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "father",
+    "male",
+    "men",
+    "son"
   ],
   "👨‍👧‍👧": [
     "family_man_girl_girl",
@@ -3256,7 +5383,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughters",
+    "father",
+    "female",
+    "male",
+    "two"
   ],
   "👩‍👦": [
     "family_woman_boy",
@@ -3264,7 +5397,11 @@
     "parent",
     "people",
     "human",
-    "child"
+    "child",
+    "female",
+    "mother",
+    "son",
+    "women"
   ],
   "👩‍👦‍👦": [
     "family_woman_boy_boy",
@@ -3272,7 +5409,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "female",
+    "mother",
+    "sons",
+    "two",
+    "women"
   ],
   "👩‍👧": [
     "family_woman_girl",
@@ -3280,7 +5423,11 @@
     "parent",
     "people",
     "human",
-    "child"
+    "child",
+    "daughter",
+    "female",
+    "mother",
+    "women"
   ],
   "👩‍👧‍👦": [
     "family_woman_girl_boy",
@@ -3288,7 +5435,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughter",
+    "female",
+    "male",
+    "mother",
+    "son"
   ],
   "👩‍👧‍👧": [
     "family_woman_girl_girl",
@@ -3296,7 +5449,13 @@
     "parent",
     "people",
     "human",
-    "children"
+    "children",
+    "child",
+    "daughters",
+    "female",
+    "mother",
+    "two",
+    "women"
   ],
   "🗣️": [
     "speaking_head",
@@ -3305,13 +5464,20 @@
     "human",
     "sing",
     "say",
-    "talk"
+    "talk",
+    "face",
+    "mansplaining",
+    "shout",
+    "shouting",
+    "silhouette",
+    "speak"
   ],
   "👤": [
     "bust_in_silhouette",
     "user",
     "person",
-    "human"
+    "human",
+    "shadow"
   ],
   "👥": [
     "busts_in_silhouette",
@@ -3319,27 +5485,41 @@
     "person",
     "human",
     "group",
-    "team"
+    "team",
+    "bust",
+    "people",
+    "shadows",
+    "silhouettes",
+    "two",
+    "users"
   ],
   "👣": [
     "footprints",
     "feet",
     "tracking",
     "walking",
-    "beach"
+    "beach",
+    "body",
+    "clothing",
+    "footprint",
+    "footsteps",
+    "print",
+    "tracks"
   ],
   "🐵": [
     "monkey_face",
     "animal",
     "nature",
-    "circus"
+    "circus",
+    "head"
   ],
   "🐒": [
     "monkey",
     "animal",
     "nature",
     "banana",
-    "circus"
+    "circus",
+    "cheeky"
   ],
   "🦍": [
     "gorilla",
@@ -3349,7 +5529,8 @@
   ],
   "🦧": [
     "orangutan",
-    "animal"
+    "animal",
+    "ape"
   ],
   "🐶": [
     "dog_face",
@@ -3368,17 +5549,24 @@
     "friend",
     "doge",
     "pet",
-    "faithful"
+    "faithful",
+    "dog2",
+    "doggo"
   ],
   "🦮": [
     "guide_dog",
     "animal",
-    "blind"
+    "blind",
+    "accessibility",
+    "eye",
+    "seeing"
   ],
   "🐕‍🦺": [
     "service_dog",
     "blind",
-    "animal"
+    "animal",
+    "accessibility",
+    "assistance"
   ],
   "🐩": [
     "poodle",
@@ -3386,13 +5574,17 @@
     "animal",
     "101",
     "nature",
-    "pet"
+    "pet",
+    "miniature",
+    "standard",
+    "toy"
   ],
   "🐺": [
     "wolf",
     "animal",
     "nature",
-    "wild"
+    "wild",
+    "face"
   ],
   "🦊": [
     "fox",
@@ -3403,7 +5595,10 @@
   "🦝": [
     "raccoon",
     "animal",
-    "nature"
+    "nature",
+    "curious",
+    "face",
+    "sly"
   ],
   "🐱": [
     "cat_face",
@@ -3411,19 +5606,27 @@
     "meow",
     "nature",
     "pet",
-    "kitten"
+    "kitten",
+    "kitty"
   ],
   "🐈": [
     "cat",
     "animal",
     "meow",
     "pet",
-    "cats"
+    "cats",
+    "cat2",
+    "domestic",
+    "feline",
+    "housecat"
   ],
   "🦁": [
     "lion",
     "animal",
-    "nature"
+    "nature",
+    "face",
+    "leo",
+    "zodiac"
   ],
   "🐯": [
     "tiger_face",
@@ -3432,50 +5635,67 @@
     "danger",
     "wild",
     "nature",
-    "roar"
+    "roar",
+    "cute"
   ],
   "🐅": [
     "tiger",
     "animal",
     "nature",
-    "roar"
+    "roar",
+    "bengal",
+    "tiger2"
   ],
   "🐆": [
     "leopard",
     "animal",
-    "nature"
+    "nature",
+    "african",
+    "jaguar"
   ],
   "🐴": [
     "horse_face",
     "animal",
     "brown",
-    "nature"
+    "nature",
+    "head"
   ],
   "🐎": [
     "horse",
     "animal",
     "gamble",
-    "luck"
+    "luck",
+    "equestrian",
+    "galloping",
+    "racehorse",
+    "racing",
+    "speed"
   ],
   "🦄": [
     "unicorn",
     "animal",
     "nature",
-    "mystical"
+    "mystical",
+    "face"
   ],
   "🦓": [
     "zebra",
     "animal",
     "nature",
     "stripes",
-    "safari"
+    "safari",
+    "face",
+    "stripe"
   ],
   "🦌": [
     "deer",
     "animal",
     "nature",
     "horns",
-    "venison"
+    "venison",
+    "buck",
+    "reindeer",
+    "stag"
   ],
   "🐮": [
     "cow_face",
@@ -3484,20 +5704,28 @@
     "animal",
     "nature",
     "moo",
-    "milk"
+    "milk",
+    "happy"
   ],
   "🐂": [
     "ox",
     "animal",
     "cow",
-    "beef"
+    "beef",
+    "bull",
+    "bullock",
+    "oxen",
+    "steer",
+    "taurus",
+    "zodiac"
   ],
   "🐃": [
     "water_buffalo",
     "animal",
     "nature",
     "ox",
-    "cow"
+    "cow",
+    "domestic"
   ],
   "🐄": [
     "cow",
@@ -3506,53 +5734,76 @@
     "animal",
     "nature",
     "moo",
-    "milk"
+    "milk",
+    "cow2",
+    "dairy"
   ],
   "🐷": [
     "pig_face",
     "animal",
     "oink",
-    "nature"
+    "nature",
+    "head"
   ],
   "🐖": [
     "pig",
     "animal",
-    "nature"
+    "nature",
+    "hog",
+    "pig2",
+    "sow"
   ],
   "🐗": [
     "boar",
     "animal",
-    "nature"
+    "nature",
+    "pig",
+    "warthog",
+    "wild"
   ],
   "🐽": [
     "pig_nose",
     "animal",
-    "oink"
+    "oink",
+    "face",
+    "snout"
   ],
   "🐏": [
     "ram",
     "animal",
     "sheep",
-    "nature"
+    "nature",
+    "aries",
+    "male",
+    "zodiac"
   ],
   "🐑": [
     "ewe",
     "animal",
     "nature",
     "wool",
-    "shipit"
+    "shipit",
+    "female",
+    "lamb",
+    "sheep"
   ],
   "🐐": [
     "goat",
     "animal",
-    "nature"
+    "nature",
+    "capricorn",
+    "zodiac"
   ],
   "🐪": [
     "camel",
     "animal",
     "hot",
     "desert",
-    "hump"
+    "hump",
+    "arabian",
+    "bump",
+    "dromedary",
+    "one"
   ],
   "🐫": [
     "two_hump_camel",
@@ -3560,20 +5811,27 @@
     "nature",
     "hot",
     "desert",
-    "hump"
+    "hump",
+    "asian",
+    "bactrian",
+    "bump"
   ],
   "🦙": [
     "llama",
     "animal",
     "nature",
-    "alpaca"
+    "alpaca",
+    "guanaco",
+    "vicuña",
+    "wool"
   ],
   "🦒": [
     "giraffe",
     "animal",
     "nature",
     "spots",
-    "safari"
+    "safari",
+    "face"
   ],
   "🐘": [
     "elephant",
@@ -3587,12 +5845,14 @@
     "rhinoceros",
     "animal",
     "nature",
-    "horn"
+    "horn",
+    "rhino"
   ],
   "🦛": [
     "hippopotamus",
     "animal",
-    "nature"
+    "nature",
+    "hippo"
   ],
   "🐭": [
     "mouse_face",
@@ -3605,7 +5865,10 @@
     "mouse",
     "animal",
     "nature",
-    "rodent"
+    "rodent",
+    "dormouse",
+    "mice",
+    "mouse2"
   ],
   "🐀": [
     "rat",
@@ -3616,7 +5879,9 @@
   "🐹": [
     "hamster",
     "animal",
-    "nature"
+    "nature",
+    "face",
+    "pet"
   ],
   "🐰": [
     "rabbit_face",
@@ -3625,7 +5890,8 @@
     "pet",
     "spring",
     "magic",
-    "bunny"
+    "bunny",
+    "easter"
   ],
   "🐇": [
     "rabbit",
@@ -3633,7 +5899,9 @@
     "nature",
     "pet",
     "magic",
-    "spring"
+    "spring",
+    "bunny",
+    "rabbit2"
   ],
   "🐿️": [
     "chipmunk",
@@ -3646,42 +5914,56 @@
     "hedgehog",
     "animal",
     "nature",
-    "spiny"
+    "spiny",
+    "face"
   ],
   "🦇": [
     "bat",
     "animal",
     "nature",
     "blind",
-    "vampire"
+    "vampire",
+    "batman"
   ],
   "🐻": [
     "bear",
     "animal",
     "nature",
-    "wild"
+    "wild",
+    "face",
+    "teddy"
   ],
   "🐨": [
     "koala",
     "animal",
-    "nature"
+    "nature",
+    "bear",
+    "face",
+    "marsupial"
   ],
   "🐼": [
     "panda",
     "animal",
-    "nature"
+    "nature",
+    "face"
   ],
   "🦥": [
     "sloth",
-    "animal"
+    "animal",
+    "lazy",
+    "slow"
   ],
   "🦦": [
     "otter",
-    "animal"
+    "animal",
+    "fishing",
+    "playful"
   ],
   "🦨": [
     "skunk",
-    "animal"
+    "animal",
+    "smelly",
+    "stink"
   ],
   "🦘": [
     "kangaroo",
@@ -3690,13 +5972,16 @@
     "australia",
     "joey",
     "hop",
-    "marsupial"
+    "marsupial",
+    "jump",
+    "roo"
   ],
   "🦡": [
     "badger",
     "animal",
     "nature",
-    "honey"
+    "honey",
+    "pester"
   ],
   "🐾": [
     "paw_prints",
@@ -3706,25 +5991,34 @@
     "dog",
     "cat",
     "pet",
-    "feet"
+    "feet",
+    "kitten",
+    "print",
+    "puppy"
   ],
   "🦃": [
     "turkey",
     "animal",
-    "bird"
+    "bird",
+    "thanksgiving",
+    "wild"
   ],
   "🐔": [
     "chicken",
     "animal",
     "cluck",
     "nature",
-    "bird"
+    "bird",
+    "hen"
   ],
   "🐓": [
     "rooster",
     "animal",
     "nature",
-    "chicken"
+    "chicken",
+    "bird",
+    "cock",
+    "cockerel"
   ],
   "🐣": [
     "hatching_chick",
@@ -3739,14 +6033,17 @@
     "baby_chick",
     "animal",
     "chicken",
-    "bird"
+    "bird",
+    "yellow"
   ],
   "🐥": [
     "front_facing_baby_chick",
     "animal",
     "chicken",
     "baby",
-    "bird"
+    "bird",
+    "hatched",
+    "standing"
   ],
   "🐦": [
     "bird",
@@ -3759,18 +6056,22 @@
   "🐧": [
     "penguin",
     "animal",
-    "nature"
+    "nature",
+    "bird"
   ],
   "🕊️": [
     "dove",
     "animal",
-    "bird"
+    "bird",
+    "fly",
+    "peace"
   ],
   "🦅": [
     "eagle",
     "animal",
     "nature",
-    "bird"
+    "bird",
+    "bald"
   ],
   "🦆": [
     "duck",
@@ -3783,25 +6084,33 @@
     "swan",
     "animal",
     "nature",
-    "bird"
+    "bird",
+    "cygnet",
+    "duckling",
+    "ugly"
   ],
   "🦉": [
     "owl",
     "animal",
     "nature",
     "bird",
-    "hoot"
+    "hoot",
+    "wise"
   ],
   "🦩": [
     "flamingo",
-    "animal"
+    "animal",
+    "flamboyant",
+    "tropical"
   ],
   "🦚": [
     "peacock",
     "animal",
     "nature",
     "peahen",
-    "bird"
+    "bird",
+    "ostentatious",
+    "proud"
   ],
   "🦜": [
     "parrot",
@@ -3816,7 +6125,8 @@
     "animal",
     "nature",
     "croak",
-    "toad"
+    "toad",
+    "face"
   ],
   "🐊": [
     "crocodile",
@@ -3824,20 +6134,23 @@
     "nature",
     "reptile",
     "lizard",
-    "alligator"
+    "alligator",
+    "croc"
   ],
   "🐢": [
     "turtle",
     "animal",
     "slow",
     "nature",
-    "tortoise"
+    "tortoise",
+    "terrapin"
   ],
   "🦎": [
     "lizard",
     "animal",
     "nature",
-    "reptile"
+    "reptile",
+    "gecko"
   ],
   "🐍": [
     "snake",
@@ -3845,7 +6158,11 @@
     "evil",
     "nature",
     "hiss",
-    "python"
+    "python",
+    "bearer",
+    "ophiuchus",
+    "serpent",
+    "zodiac"
   ],
   "🐲": [
     "dragon_face",
@@ -3853,7 +6170,10 @@
     "myth",
     "nature",
     "chinese",
-    "green"
+    "green",
+    "fairy",
+    "head",
+    "tale"
   ],
   "🐉": [
     "dragon",
@@ -3861,7 +6181,9 @@
     "myth",
     "nature",
     "chinese",
-    "green"
+    "green",
+    "fairy",
+    "tale"
   ],
   "🦕": [
     "sauropod",
@@ -3879,21 +6201,25 @@
     "nature",
     "dinosaur",
     "tyrannosaurus",
-    "extinct"
+    "extinct",
+    "trex"
   ],
   "🐳": [
     "spouting_whale",
     "animal",
     "nature",
     "sea",
-    "ocean"
+    "ocean",
+    "cute",
+    "face"
   ],
   "🐋": [
     "whale",
     "animal",
     "nature",
     "sea",
-    "ocean"
+    "ocean",
+    "whale2"
   ],
   "🐬": [
     "dolphin",
@@ -3910,7 +6236,10 @@
     "fish",
     "animal",
     "food",
-    "nature"
+    "nature",
+    "freshwater",
+    "pisces",
+    "zodiac"
   ],
   "🐠": [
     "tropical_fish",
@@ -3918,7 +6247,9 @@
     "swim",
     "ocean",
     "beach",
-    "nemo"
+    "nemo",
+    "blue",
+    "yellow"
   ],
   "🐡": [
     "blowfish",
@@ -3926,7 +6257,10 @@
     "nature",
     "food",
     "sea",
-    "ocean"
+    "ocean",
+    "fish",
+    "fugu",
+    "pufferfish"
   ],
   "🦈": [
     "shark",
@@ -3937,7 +6271,9 @@
     "ocean",
     "jaws",
     "fins",
-    "beach"
+    "beach",
+    "great",
+    "white"
   ],
   "🐙": [
     "octopus",
@@ -3952,27 +6288,32 @@
     "spiral_shell",
     "nature",
     "sea",
-    "beach"
+    "beach",
+    "seashell"
   ],
   "🐌": [
     "snail",
     "slow",
     "animal",
-    "shell"
+    "shell",
+    "garden",
+    "slug"
   ],
   "🦋": [
     "butterfly",
     "animal",
     "insect",
     "nature",
-    "caterpillar"
+    "caterpillar",
+    "pretty"
   ],
   "🐛": [
     "bug",
     "animal",
     "insect",
     "nature",
-    "worm"
+    "worm",
+    "caterpillar"
   ],
   "🐜": [
     "ant",
@@ -3988,43 +6329,60 @@
     "nature",
     "bug",
     "spring",
-    "honey"
+    "honey",
+    "bee",
+    "bumblebee"
   ],
   "🐞": [
     "lady_beetle",
     "animal",
     "insect",
     "nature",
-    "ladybug"
+    "ladybug",
+    "bug",
+    "ladybird"
   ],
   "🦗": [
     "cricket",
     "animal",
-    "chirp"
+    "chirp",
+    "grasshopper",
+    "insect",
+    "orthoptera"
   ],
   "🕷️": [
     "spider",
     "animal",
-    "arachnid"
+    "arachnid",
+    "insect"
   ],
   "🕸️": [
     "spider_web",
     "animal",
     "insect",
     "arachnid",
-    "silk"
+    "silk",
+    "cobweb",
+    "spiderweb"
   ],
   "🦂": [
     "scorpion",
     "animal",
-    "arachnid"
+    "arachnid",
+    "scorpio",
+    "scorpius",
+    "zodiac"
   ],
   "🦟": [
     "mosquito",
     "animal",
     "nature",
     "insect",
-    "malaria"
+    "malaria",
+    "disease",
+    "fever",
+    "pest",
+    "virus"
   ],
   "🦠": [
     "microbe",
@@ -4032,64 +6390,94 @@
     "bacteria",
     "germs",
     "virus",
-    "covid"
+    "covid",
+    "cell",
+    "coronavirus",
+    "germ",
+    "microorganism"
   ],
   "💐": [
     "bouquet",
     "flowers",
     "nature",
-    "spring"
+    "spring",
+    "flower",
+    "plant",
+    "romance"
   ],
   "🌸": [
     "cherry_blossom",
     "nature",
     "plant",
     "spring",
-    "flower"
+    "flower",
+    "pink",
+    "sakura"
   ],
   "💮": [
     "white_flower",
     "japanese",
-    "spring"
+    "spring",
+    "blossom",
+    "cherry",
+    "doily",
+    "done",
+    "paper",
+    "stamp",
+    "well"
   ],
   "🏵️": [
     "rosette",
     "flower",
     "decoration",
-    "military"
+    "military",
+    "plant"
   ],
   "🌹": [
     "rose",
     "flowers",
     "valentines",
     "love",
-    "spring"
+    "spring",
+    "flower",
+    "plant",
+    "red"
   ],
   "🥀": [
     "wilted_flower",
     "plant",
     "nature",
     "flower",
-    "rose"
+    "rose",
+    "dead",
+    "drooping"
   ],
   "🌺": [
     "hibiscus",
     "plant",
     "vegetable",
     "flowers",
-    "beach"
+    "beach",
+    "flower"
   ],
   "🌻": [
     "sunflower",
     "nature",
     "plant",
-    "fall"
+    "fall",
+    "flower",
+    "sun",
+    "yellow"
   ],
   "🌼": [
     "blossom",
     "nature",
     "flowers",
-    "yellow"
+    "yellow",
+    "blossoming flower",
+    "daisy",
+    "flower",
+    "plant"
   ],
   "🌷": [
     "tulip",
@@ -4097,7 +6485,8 @@
     "plant",
     "nature",
     "summer",
-    "spring"
+    "spring",
+    "flower"
   ],
   "🌱": [
     "seedling",
@@ -4105,17 +6494,26 @@
     "nature",
     "grass",
     "lawn",
-    "spring"
+    "spring",
+    "sprout",
+    "sprouting",
+    "young"
   ],
   "🌲": [
     "evergreen_tree",
     "plant",
-    "nature"
+    "nature",
+    "fir",
+    "pine",
+    "wood"
   ],
   "🌳": [
     "deciduous_tree",
     "plant",
-    "nature"
+    "nature",
+    "rounded",
+    "shedding",
+    "wood"
   ],
   "🌴": [
     "palm_tree",
@@ -4125,18 +6523,25 @@
     "summer",
     "beach",
     "mojito",
-    "tropical"
+    "tropical",
+    "coconut"
   ],
   "🌵": [
     "cactus",
     "vegetable",
     "plant",
-    "nature"
+    "nature",
+    "desert"
   ],
   "🌾": [
     "sheaf_of_rice",
     "nature",
-    "plant"
+    "plant",
+    "crop",
+    "ear",
+    "farming",
+    "grain",
+    "wheat"
   ],
   "🌿": [
     "herb",
@@ -4145,7 +6550,9 @@
     "medicine",
     "weed",
     "grass",
-    "lawn"
+    "lawn",
+    "crop",
+    "leaf"
   ],
   "☘️": [
     "shamrock",
@@ -4153,7 +6560,8 @@
     "plant",
     "nature",
     "irish",
-    "clover"
+    "clover",
+    "trefoil"
   ],
   "🍀": [
     "four_leaf_clover",
@@ -4161,7 +6569,9 @@
     "plant",
     "nature",
     "lucky",
-    "irish"
+    "irish",
+    "ireland",
+    "luck"
   ],
   "🍁": [
     "maple_leaf",
@@ -4169,14 +6579,21 @@
     "plant",
     "vegetable",
     "ca",
-    "fall"
+    "fall",
+    "canada",
+    "canadian",
+    "falling"
   ],
   "🍂": [
     "fallen_leaf",
     "nature",
     "plant",
     "vegetable",
-    "leaves"
+    "leaves",
+    "autumn",
+    "brown",
+    "fall",
+    "falling"
   ],
   "🍃": [
     "leaf_fluttering_in_wind",
@@ -4186,50 +6603,69 @@
     "vegetable",
     "grass",
     "lawn",
-    "spring"
+    "spring",
+    "blow",
+    "flutter",
+    "green",
+    "leaves"
   ],
   "🍇": [
     "grapes",
     "fruit",
     "food",
-    "wine"
+    "wine",
+    "grape",
+    "plant"
   ],
   "🍈": [
     "melon",
     "fruit",
     "nature",
-    "food"
+    "food",
+    "cantaloupe",
+    "honeydew",
+    "muskmelon",
+    "plant"
   ],
   "🍉": [
     "watermelon",
     "fruit",
     "food",
     "picnic",
-    "summer"
+    "summer",
+    "plant"
   ],
   "🍊": [
     "tangerine",
     "food",
     "fruit",
     "nature",
-    "orange"
+    "orange",
+    "mandarin",
+    "plant"
   ],
   "🍋": [
     "lemon",
     "fruit",
-    "nature"
+    "nature",
+    "citrus",
+    "lemonade",
+    "plant"
   ],
   "🍌": [
     "banana",
     "fruit",
     "food",
-    "monkey"
+    "monkey",
+    "plant",
+    "plantain"
   ],
   "🍍": [
     "pineapple",
     "fruit",
     "nature",
-    "food"
+    "food",
+    "plant"
   ],
   "🥭": [
     "mango",
@@ -4241,54 +6677,79 @@
     "red_apple",
     "fruit",
     "mac",
-    "school"
+    "school",
+    "delicious",
+    "plant"
   ],
   "🍏": [
     "green_apple",
     "fruit",
-    "nature"
+    "nature",
+    "delicious",
+    "golden",
+    "granny",
+    "plant",
+    "smith"
   ],
   "🍐": [
     "pear",
     "fruit",
     "nature",
-    "food"
+    "food",
+    "plant"
   ],
   "🍑": [
     "peach",
     "fruit",
     "nature",
-    "food"
+    "food",
+    "bottom",
+    "butt",
+    "plant"
   ],
   "🍒": [
     "cherries",
     "food",
-    "fruit"
+    "fruit",
+    "berries",
+    "cherry",
+    "plant",
+    "red",
+    "wild"
   ],
   "🍓": [
     "strawberry",
     "fruit",
     "food",
-    "nature"
+    "nature",
+    "berry",
+    "plant"
   ],
   "🥝": [
     "kiwi_fruit",
     "fruit",
-    "food"
+    "food",
+    "chinese",
+    "gooseberry",
+    "kiwifruit"
   ],
   "🍅": [
     "tomato",
     "fruit",
     "vegetable",
     "nature",
-    "food"
+    "food",
+    "plant"
   ],
   "🥥": [
     "coconut",
     "fruit",
     "nature",
     "food",
-    "palm"
+    "palm",
+    "cocoanut",
+    "colada",
+    "piña"
   ],
   "🥑": [
     "avocado",
@@ -4300,14 +6761,20 @@
     "vegetable",
     "nature",
     "food",
-    "aubergine"
+    "aubergine",
+    "phallic",
+    "plant",
+    "purple"
   ],
   "🥔": [
     "potato",
     "food",
     "tuber",
     "vegatable",
-    "starch"
+    "starch",
+    "baked",
+    "idaho",
+    "vegetable"
   ],
   "🥕": [
     "carrot",
@@ -4319,20 +6786,26 @@
     "ear_of_corn",
     "food",
     "vegetable",
-    "plant"
+    "plant",
+    "cob",
+    "maize",
+    "maze"
   ],
   "🌶️": [
     "hot_pepper",
     "food",
     "spicy",
     "chilli",
-    "chili"
+    "chili",
+    "plant"
   ],
   "🥒": [
     "cucumber",
     "fruit",
     "food",
-    "pickle"
+    "pickle",
+    "gherkin",
+    "vegetable"
   ],
   "🥬": [
     "leafy_green",
@@ -4342,53 +6815,78 @@
     "bok choy",
     "cabbage",
     "kale",
-    "lettuce"
+    "lettuce",
+    "chinese",
+    "cos",
+    "greens",
+    "romaine"
   ],
   "🥦": [
     "broccoli",
     "fruit",
     "food",
-    "vegetable"
+    "vegetable",
+    "cabbage",
+    "wild"
   ],
   "🧄": [
     "garlic",
     "food",
     "spice",
-    "cook"
+    "cook",
+    "flavoring",
+    "plant",
+    "vegetable"
   ],
   "🧅": [
     "onion",
     "cook",
     "food",
-    "spice"
+    "spice",
+    "flavoring",
+    "plant",
+    "vegetable"
   ],
   "🍄": [
     "mushroom",
     "plant",
-    "vegetable"
+    "vegetable",
+    "fungus",
+    "shroom",
+    "toadstool"
   ],
   "🥜": [
     "peanuts",
     "food",
-    "nut"
+    "nut",
+    "nuts",
+    "peanut",
+    "vegetable"
   ],
   "🌰": [
     "chestnut",
     "food",
-    "squirrel"
+    "squirrel",
+    "acorn",
+    "nut",
+    "plant"
   ],
   "🍞": [
     "bread",
     "food",
     "wheat",
     "breakfast",
-    "toast"
+    "toast",
+    "loaf"
   ],
   "🥐": [
     "croissant",
     "food",
     "bread",
-    "french"
+    "french",
+    "breakfast",
+    "crescent",
+    "roll"
   ],
   "🥖": [
     "baguette_bread",
@@ -4404,7 +6902,9 @@
     "bread",
     "twisted",
     "germany",
-    "bakery"
+    "bakery",
+    "soft",
+    "twist"
   ],
   "🥯": [
     "bagel",
@@ -4412,7 +6912,10 @@
     "bread",
     "bakery",
     "schmear",
-    "jewish_bakery"
+    "jewish_bakery",
+    "breakfast",
+    "cheese",
+    "cream"
   ],
   "🥞": [
     "pancakes",
@@ -4420,13 +6923,19 @@
     "breakfast",
     "flapjacks",
     "hotcakes",
-    "brunch"
+    "brunch",
+    "crêpe",
+    "crêpes",
+    "hotcake",
+    "pancake"
   ],
   "🧇": [
     "waffle",
     "food",
     "breakfast",
-    "brunch"
+    "brunch",
+    "indecisive",
+    "iron"
   ],
   "🧀": [
     "cheese_wedge",
@@ -4438,7 +6947,10 @@
     "meat_on_bone",
     "good",
     "food",
-    "drumstick"
+    "drumstick",
+    "barbecue",
+    "bbq",
+    "manga"
   ],
   "🍗": [
     "poultry_leg",
@@ -4447,7 +6959,8 @@
     "drumstick",
     "bird",
     "chicken",
-    "turkey"
+    "turkey",
+    "bone"
   ],
   "🥩": [
     "cut_of_meat",
@@ -4457,7 +6970,8 @@
     "cut",
     "chop",
     "lambchop",
-    "porkchop"
+    "porkchop",
+    "steak"
   ],
   "🥓": [
     "bacon",
@@ -4466,7 +6980,8 @@
     "pork",
     "pig",
     "meat",
-    "brunch"
+    "brunch",
+    "rashers"
   ],
   "🍔": [
     "hamburger",
@@ -4482,19 +6997,27 @@
     "chips",
     "snack",
     "fast food",
-    "potato"
+    "potato",
+    "mcdonald's"
   ],
   "🍕": [
     "pizza",
     "food",
     "party",
-    "italy"
+    "italy",
+    "cheese",
+    "pepperoni",
+    "slice"
   ],
   "🌭": [
     "hot_dog",
     "food",
     "frankfurter",
-    "america"
+    "america",
+    "hotdog",
+    "redhot",
+    "sausage",
+    "wiener"
   ],
   "🥪": [
     "sandwich",
@@ -4502,7 +7025,11 @@
     "lunch",
     "bread",
     "toast",
-    "bakery"
+    "bakery",
+    "cheese",
+    "deli",
+    "meat",
+    "vegetables"
   ],
   "🌮": [
     "taco",
@@ -4512,7 +7039,8 @@
   "🌯": [
     "burrito",
     "food",
-    "mexican"
+    "mexican",
+    "wrap"
   ],
   "🥙": [
     "stuffed_flatbread",
@@ -4520,12 +7048,21 @@
     "flatbread",
     "stuffed",
     "gyro",
-    "mediterranean"
+    "mediterranean",
+    "doner",
+    "falafel",
+    "kebab",
+    "pita",
+    "sandwich",
+    "shawarma"
   ],
   "🧆": [
     "falafel",
     "food",
-    "mediterranean"
+    "mediterranean",
+    "chickpea",
+    "falfel",
+    "meatball"
   ],
   "🥚": [
     "egg",
@@ -4539,7 +7076,10 @@
     "breakfast",
     "kitchen",
     "egg",
-    "skillet"
+    "skillet",
+    "fried",
+    "frying",
+    "pan"
   ],
   "🥘": [
     "shallow_pan_of_food",
@@ -4547,14 +7087,17 @@
     "cooking",
     "casserole",
     "paella",
-    "skillet"
+    "skillet",
+    "curry"
   ],
   "🍲": [
     "pot_of_food",
     "food",
     "meat",
     "soup",
-    "hot pot"
+    "hot pot",
+    "bowl",
+    "stew"
   ],
   "🥣": [
     "bowl_with_spoon",
@@ -4562,7 +7105,9 @@
     "breakfast",
     "cereal",
     "oatmeal",
-    "porridge"
+    "porridge",
+    "congee",
+    "tableware"
   ],
   "🥗": [
     "green_salad",
@@ -4577,12 +7122,15 @@
     "movie theater",
     "films",
     "snack",
-    "drama"
+    "drama",
+    "corn",
+    "popping"
   ],
   "🧈": [
     "butter",
     "food",
-    "cook"
+    "cook",
+    "dairy"
   ],
   "🧂": [
     "salt",
@@ -4593,7 +7141,11 @@
     "canned_food",
     "food",
     "soup",
-    "tomatoes"
+    "tomatoes",
+    "can",
+    "preserve",
+    "tin",
+    "tinned"
   ],
   "🍱": [
     "bento_box",
@@ -4619,7 +7171,10 @@
   "🍚": [
     "cooked_rice",
     "food",
-    "asian"
+    "asian",
+    "boiled",
+    "bowl",
+    "steamed"
   ],
   "🍛": [
     "curry_rice",
@@ -4634,7 +7189,9 @@
     "japanese",
     "noodle",
     "chopsticks",
-    "ramen"
+    "ramen",
+    "noodles",
+    "soup"
   ],
   "🍝": [
     "spaghetti",
@@ -4647,27 +7204,36 @@
     "roasted_sweet_potato",
     "food",
     "nature",
-    "plant"
+    "plant",
+    "goguma",
+    "yam"
   ],
   "🍢": [
     "oden",
     "skewer",
     "food",
-    "japanese"
+    "japanese",
+    "kebab",
+    "seafood",
+    "stick"
   ],
   "🍣": [
     "sushi",
     "food",
     "fish",
     "japanese",
-    "rice"
+    "rice",
+    "sashimi",
+    "seafood"
   ],
   "🍤": [
     "fried_shrimp",
     "food",
     "animal",
     "appetizer",
-    "summer"
+    "summer",
+    "prawn",
+    "tempura"
   ],
   "🍥": [
     "fish_cake_with_swirl",
@@ -4680,13 +7246,19 @@
     "swirl",
     "kamaboko",
     "surimi",
-    "ramen"
+    "ramen",
+    "design",
+    "fishcake",
+    "pastry"
   ],
   "🥮": [
     "moon_cake",
     "food",
     "autumn",
-    "dessert"
+    "dessert",
+    "festival",
+    "mooncake",
+    "yuèbǐng"
   ],
   "🍡": [
     "dango",
@@ -4695,7 +7267,13 @@
     "sweet",
     "japanese",
     "barbecue",
-    "meat"
+    "meat",
+    "balls",
+    "green",
+    "pink",
+    "skewer",
+    "stick",
+    "white"
   ],
   "🥟": [
     "dumpling",
@@ -4703,7 +7281,9 @@
     "empanada",
     "pierogi",
     "potsticker",
-    "gyoza"
+    "gyoza",
+    "gyōza",
+    "jiaozi"
   ],
   "🥠": [
     "fortune_cookie",
@@ -4714,12 +7294,20 @@
   "🥡": [
     "takeout_box",
     "food",
-    "leftovers"
+    "leftovers",
+    "chinese",
+    "container",
+    "out",
+    "oyster",
+    "pail",
+    "take"
   ],
   "🦀": [
     "crab",
     "animal",
-    "crustacean"
+    "crustacean",
+    "cancer",
+    "zodiac"
   ],
   "🦞": [
     "lobster",
@@ -4734,37 +7322,55 @@
     "animal",
     "ocean",
     "nature",
-    "seafood"
+    "seafood",
+    "food",
+    "prawn",
+    "shellfish",
+    "small"
   ],
   "🦑": [
     "squid",
     "animal",
     "nature",
     "ocean",
-    "sea"
+    "sea",
+    "food",
+    "molusc"
   ],
   "🦪": [
     "oyster",
-    "food"
+    "food",
+    "diving",
+    "pearl"
   ],
   "🍦": [
     "soft_ice_cream",
     "food",
     "hot",
     "dessert",
-    "summer"
+    "summer",
+    "icecream",
+    "mr.",
+    "serve",
+    "sweet",
+    "whippy"
   ],
   "🍧": [
     "shaved_ice",
     "hot",
     "dessert",
-    "summer"
+    "summer",
+    "cone",
+    "snow",
+    "sweet"
   ],
   "🍨": [
     "ice_cream",
     "food",
     "hot",
-    "dessert"
+    "dessert",
+    "bowl",
+    "sweet"
   ],
   "🍩": [
     "doughnut",
@@ -4772,7 +7378,8 @@
     "dessert",
     "snack",
     "sweet",
-    "donut"
+    "donut",
+    "breakfast"
   ],
   "🍪": [
     "cookie",
@@ -4781,38 +7388,57 @@
     "oreo",
     "chocolate",
     "sweet",
-    "dessert"
+    "dessert",
+    "biscuit",
+    "chip"
   ],
   "🎂": [
     "birthday_cake",
     "food",
     "dessert",
-    "cake"
+    "cake",
+    "candles",
+    "celebration",
+    "party",
+    "pastry",
+    "sweet"
   ],
   "🍰": [
     "shortcake",
     "food",
-    "dessert"
+    "dessert",
+    "cake",
+    "pastry",
+    "piece",
+    "slice",
+    "strawberry",
+    "sweet"
   ],
   "🧁": [
     "cupcake",
     "food",
     "dessert",
     "bakery",
-    "sweet"
+    "sweet",
+    "cake",
+    "fairy",
+    "pastry"
   ],
   "🥧": [
     "pie",
     "food",
     "dessert",
-    "pastry"
+    "pastry",
+    "filling",
+    "sweet"
   ],
   "🍫": [
     "chocolate_bar",
     "food",
     "snack",
     "dessert",
-    "sweet"
+    "sweet",
+    "candy"
   ],
   "🍬": [
     "candy",
@@ -4826,26 +7452,35 @@
     "food",
     "snack",
     "candy",
-    "sweet"
+    "sweet",
+    "dessert",
+    "lollypop",
+    "sucker"
   ],
   "🍮": [
     "custard",
     "dessert",
     "food",
     "pudding",
-    "flan"
+    "flan",
+    "caramel",
+    "creme",
+    "sweet"
   ],
   "🍯": [
     "honey_pot",
     "bees",
     "sweet",
-    "kitchen"
+    "kitchen",
+    "honeypot"
   ],
   "🍼": [
     "baby_bottle",
     "food",
     "container",
-    "milk"
+    "milk",
+    "drink",
+    "feeding"
   ],
   "🥛": [
     "glass_of_milk",
@@ -4860,7 +7495,12 @@
     "latte",
     "espresso",
     "coffee",
-    "mug"
+    "mug",
+    "cafe",
+    "chocolate",
+    "drink",
+    "steaming",
+    "tea"
   ],
   "🍵": [
     "teacup_without_handle",
@@ -4868,7 +7508,11 @@
     "bowl",
     "breakfast",
     "green",
-    "british"
+    "british",
+    "beverage",
+    "cup",
+    "matcha",
+    "tea"
   ],
   "🍶": [
     "sake",
@@ -4878,14 +7522,23 @@
     "beverage",
     "japanese",
     "alcohol",
-    "booze"
+    "booze",
+    "bar",
+    "bottle",
+    "cup",
+    "rice"
   ],
   "🍾": [
     "bottle_with_popping_cork",
     "drink",
     "wine",
     "bottle",
-    "celebration"
+    "celebration",
+    "bar",
+    "bubbly",
+    "champagne",
+    "party",
+    "sparkling"
   ],
   "🍷": [
     "wine_glass",
@@ -4893,7 +7546,9 @@
     "beverage",
     "drunk",
     "alcohol",
-    "booze"
+    "booze",
+    "bar",
+    "red"
   ],
   "🍸": [
     "cocktail_glass",
@@ -4902,7 +7557,9 @@
     "alcohol",
     "beverage",
     "booze",
-    "mojito"
+    "mojito",
+    "bar",
+    "martini"
   ],
   "🍹": [
     "tropical_drink",
@@ -4912,7 +7569,12 @@
     "beach",
     "alcohol",
     "booze",
-    "mojito"
+    "mojito",
+    "bar",
+    "fruit",
+    "punch",
+    "tiki",
+    "vacation"
   ],
   "🍺": [
     "beer_mug",
@@ -4924,7 +7586,9 @@
     "pub",
     "summer",
     "alcohol",
-    "booze"
+    "booze",
+    "bar",
+    "stein"
   ],
   "🍻": [
     "clinking_beer_mugs",
@@ -4936,7 +7600,13 @@
     "pub",
     "summer",
     "alcohol",
-    "booze"
+    "booze",
+    "bar",
+    "beers",
+    "cheers",
+    "clink",
+    "drinks",
+    "mug"
   ],
   "🥂": [
     "clinking_glasses",
@@ -4948,7 +7618,10 @@
     "cheers",
     "wine",
     "champagne",
-    "toast"
+    "toast",
+    "celebration",
+    "clink",
+    "glass"
   ],
   "🥃": [
     "tumbler_glass",
@@ -4962,31 +7635,55 @@
     "scotch",
     "whisky",
     "glass",
-    "shot"
+    "shot",
+    "rum",
+    "whiskey"
   ],
   "🥤": [
     "cup_with_straw",
     "drink",
-    "soda"
+    "soda",
+    "go",
+    "juice",
+    "malt",
+    "milkshake",
+    "pop",
+    "smoothie",
+    "soft",
+    "tableware",
+    "water"
   ],
   "🧃": [
     "beverage_box",
-    "drink"
+    "drink",
+    "juice",
+    "straw",
+    "sweet"
   ],
   "🧉": [
     "mate",
     "drink",
     "tea",
-    "beverage"
+    "beverage",
+    "bombilla",
+    "chimarrão",
+    "cimarrón",
+    "maté",
+    "yerba"
   ],
   "🧊": [
     "ice",
     "water",
-    "cold"
+    "cold",
+    "cube",
+    "iceberg"
   ],
   "🥢": [
     "chopsticks",
-    "food"
+    "food",
+    "hashi",
+    "jeotgarak",
+    "kuaizi"
   ],
   "🍽️": [
     "fork_and_knife_with_plate",
@@ -4995,12 +7692,19 @@
     "meal",
     "lunch",
     "dinner",
-    "restaurant"
+    "restaurant",
+    "cooking",
+    "cutlery",
+    "dining",
+    "tableware"
   ],
   "🍴": [
     "fork_and_knife",
     "cutlery",
-    "kitchen"
+    "kitchen",
+    "cooking",
+    "silverware",
+    "tableware"
   ],
   "🥄": [
     "spoon",
@@ -5014,19 +7718,32 @@
     "blade",
     "cutlery",
     "kitchen",
-    "weapon"
+    "weapon",
+    "butchers",
+    "chop",
+    "cooking",
+    "cut",
+    "hocho",
+    "tool"
   ],
   "🏺": [
     "amphora",
     "vase",
-    "jar"
+    "jar",
+    "aquarius",
+    "cooking",
+    "drink",
+    "jug",
+    "tool",
+    "zodiac"
   ],
   "🌍": [
     "globe_showing_europe_africa",
     "globe",
     "world",
     "earth",
-    "international"
+    "international",
+    "planet"
   ],
   "🌎": [
     "globe_showing_americas",
@@ -5034,7 +7751,8 @@
     "world",
     "USA",
     "earth",
-    "international"
+    "international",
+    "planet"
   ],
   "🌏": [
     "globe_showing_asia_australia",
@@ -5042,7 +7760,8 @@
     "world",
     "east",
     "earth",
-    "international"
+    "international",
+    "planet"
   ],
   "🌐": [
     "globe_with_meridians",
@@ -5051,19 +7770,25 @@
     "world",
     "internet",
     "interweb",
-    "i18n"
+    "i18n",
+    "global",
+    "web",
+    "wide",
+    "www"
   ],
   "🗺️": [
     "world_map",
     "location",
-    "direction"
+    "direction",
+    "travel"
   ],
   "🗾": [
     "map_of_japan",
     "nation",
     "country",
     "japanese",
-    "asia"
+    "asia",
+    "silhouette"
   ],
   "🧭": [
     "compass",
@@ -5089,20 +7814,27 @@
     "volcano",
     "photo",
     "nature",
-    "disaster"
+    "disaster",
+    "eruption",
+    "mountain",
+    "weather"
   ],
   "🗻": [
     "mount_fuji",
     "photo",
     "mountain",
     "nature",
-    "japanese"
+    "japanese",
+    "capped",
+    "san",
+    "snow"
   ],
   "🏕️": [
     "camping",
     "photo",
     "outdoors",
-    "tent"
+    "tent",
+    "campsite"
   ],
   "🏖️": [
     "beach_with_umbrella",
@@ -5136,7 +7868,9 @@
     "place",
     "sports",
     "concert",
-    "venue"
+    "venue",
+    "grandstand",
+    "sport"
   ],
   "🏛️": [
     "classical_building",
@@ -5148,23 +7882,34 @@
     "building_construction",
     "wip",
     "working",
-    "progress"
+    "progress",
+    "crane"
   ],
   "🧱": [
     "brick",
-    "bricks"
+    "bricks",
+    "clay",
+    "construction",
+    "mortar",
+    "wall"
   ],
   "🏘️": [
     "houses",
     "buildings",
-    "photo"
+    "photo",
+    "building",
+    "group",
+    "house"
   ],
   "🏚️": [
     "derelict_house",
     "abandon",
     "evict",
     "broken",
-    "building"
+    "building",
+    "abandoned",
+    "haunted",
+    "old"
   ],
   "🏠": [
     "house",
@@ -5175,31 +7920,46 @@
     "house_with_garden",
     "home",
     "plant",
-    "nature"
+    "nature",
+    "building",
+    "tree"
   ],
   "🏢": [
     "office_building",
     "building",
     "bureau",
-    "work"
+    "work",
+    "city",
+    "high",
+    "rise"
   ],
   "🏣": [
     "japanese_post_office",
     "building",
     "envelope",
-    "communication"
+    "communication",
+    "japan",
+    "mark",
+    "postal"
   ],
   "🏤": [
     "post_office",
     "building",
-    "email"
+    "email",
+    "european"
   ],
   "🏥": [
     "hospital",
     "building",
     "health",
     "surgery",
-    "doctor"
+    "doctor",
+    "cross",
+    "emergency",
+    "medical",
+    "medicine",
+    "red",
+    "room"
   ],
   "🏦": [
     "bank",
@@ -5208,25 +7968,40 @@
     "sales",
     "cash",
     "business",
-    "enterprise"
+    "enterprise",
+    "bakkureru",
+    "bk",
+    "branch"
   ],
   "🏨": [
     "hotel",
     "building",
     "accomodation",
-    "checkin"
+    "checkin",
+    "accommodation",
+    "h"
   ],
   "🏩": [
     "love_hotel",
     "like",
     "affection",
-    "dating"
+    "dating",
+    "building",
+    "heart",
+    "hospital"
   ],
   "🏪": [
     "convenience_store",
     "building",
     "shopping",
-    "groceries"
+    "groceries",
+    "corner",
+    "e",
+    "eleven®",
+    "hour",
+    "kwik",
+    "mart",
+    "shop"
   ],
   "🏫": [
     "school",
@@ -5234,31 +8009,43 @@
     "student",
     "education",
     "learn",
-    "teach"
+    "teach",
+    "clock",
+    "elementary",
+    "high",
+    "middle",
+    "tower"
   ],
   "🏬": [
     "department_store",
     "building",
     "shopping",
-    "mall"
+    "mall",
+    "center",
+    "shops"
   ],
   "🏭": [
     "factory",
     "building",
     "industry",
     "pollution",
-    "smoke"
+    "smoke",
+    "industrial",
+    "smog"
   ],
   "🏯": [
     "japanese_castle",
     "photo",
-    "building"
+    "building",
+    "fortress"
   ],
   "🏰": [
     "castle",
     "building",
     "royalty",
-    "history"
+    "history",
+    "european",
+    "turrets"
   ],
   "💒": [
     "wedding",
@@ -5268,29 +8055,44 @@
     "couple",
     "marriage",
     "bride",
-    "groom"
+    "groom",
+    "activity",
+    "chapel",
+    "church",
+    "heart",
+    "romance"
   ],
   "🗼": [
     "tokyo_tower",
     "photo",
-    "japanese"
+    "japanese",
+    "eiffel",
+    "red"
   ],
   "🗽": [
     "statue_of_liberty",
     "american",
-    "newyork"
+    "newyork",
+    "new",
+    "york"
   ],
   "⛪": [
     "church",
     "building",
     "religion",
-    "christ"
+    "christ",
+    "christian",
+    "cross"
   ],
   "🕌": [
     "mosque",
     "islam",
     "worship",
-    "minaret"
+    "minaret",
+    "domed",
+    "muslim",
+    "religion",
+    "roof"
   ],
   "🛕": [
     "hindu_temple",
@@ -5301,26 +8103,37 @@
     "judaism",
     "worship",
     "temple",
-    "jewish"
+    "jewish",
+    "jew",
+    "religion",
+    "synagog"
   ],
   "⛩️": [
     "shinto_shrine",
     "temple",
     "japan",
-    "kyoto"
+    "kyoto",
+    "kami",
+    "michi",
+    "no",
+    "religion"
   ],
   "🕋": [
     "kaaba",
     "mecca",
     "mosque",
-    "islam"
+    "islam",
+    "muslim",
+    "religion"
   ],
   "⛲": [
     "fountain",
     "photo",
     "summer",
     "water",
-    "fresh"
+    "fresh",
+    "feature",
+    "park"
   ],
   "⛺": [
     "tent",
@@ -5331,102 +8144,187 @@
   "🌁": [
     "foggy",
     "photo",
-    "mountain"
+    "mountain",
+    "bridge",
+    "city",
+    "fog",
+    "fog bridge",
+    "karl",
+    "under",
+    "weather"
   ],
   "🌃": [
     "night_with_stars",
     "evening",
     "city",
-    "downtown"
+    "downtown",
+    "star",
+    "starry",
+    "weather"
   ],
   "🏙️": [
     "cityscape",
     "photo",
     "night life",
-    "urban"
+    "urban",
+    "building",
+    "city",
+    "skyline"
   ],
   "🌄": [
     "sunrise_over_mountains",
     "view",
     "vacation",
-    "photo"
+    "photo",
+    "morning",
+    "mountain",
+    "sun",
+    "weather"
   ],
   "🌅": [
     "sunrise",
     "morning",
     "view",
     "vacation",
-    "photo"
+    "photo",
+    "sun",
+    "sunset",
+    "weather"
   ],
   "🌆": [
     "cityscape_at_dusk",
     "photo",
     "evening",
     "sky",
-    "buildings"
+    "buildings",
+    "building",
+    "city",
+    "landscape",
+    "orange",
+    "sun",
+    "sunset",
+    "weather"
   ],
   "🌇": [
     "sunset",
     "photo",
     "good morning",
-    "dawn"
+    "dawn",
+    "building",
+    "buildings",
+    "city",
+    "dusk",
+    "over",
+    "sun",
+    "sunrise",
+    "weather"
   ],
   "🌉": [
     "bridge_at_night",
     "photo",
-    "sanfrancisco"
+    "sanfrancisco",
+    "gate",
+    "golden",
+    "weather"
   ],
   "♨️": [
     "hot_springs",
     "bath",
     "warm",
-    "relax"
+    "relax",
+    "hotsprings",
+    "onsen",
+    "steam",
+    "steaming"
   ],
   "🎠": [
     "carousel_horse",
     "photo",
-    "carnival"
+    "carnival",
+    "activity",
+    "entertainment",
+    "fairground",
+    "go",
+    "merry",
+    "round"
   ],
   "🎡": [
     "ferris_wheel",
     "photo",
     "carnival",
-    "londoneye"
+    "londoneye",
+    "activity",
+    "amusement",
+    "big",
+    "entertainment",
+    "fairground",
+    "observation",
+    "park"
   ],
   "🎢": [
     "roller_coaster",
     "carnival",
     "playground",
     "photo",
-    "fun"
+    "fun",
+    "activity",
+    "amusement",
+    "entertainment",
+    "park",
+    "rollercoaster",
+    "theme"
   ],
   "💈": [
     "barber_pole",
     "hair",
     "salon",
-    "style"
+    "style",
+    "barber's",
+    "haircut",
+    "hairdresser",
+    "shop",
+    "stripes"
   ],
   "🎪": [
     "circus_tent",
     "festival",
     "carnival",
-    "party"
+    "party",
+    "activity",
+    "big",
+    "entertainment",
+    "top"
   ],
   "🚂": [
     "locomotive",
     "transportation",
     "vehicle",
-    "train"
+    "train",
+    "engine",
+    "railway",
+    "steam"
   ],
   "🚃": [
     "railway_car",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "carriage",
+    "electric",
+    "railcar",
+    "railroad",
+    "train",
+    "tram",
+    "trolleybus",
+    "wagon"
   ],
   "🚄": [
     "high_speed_train",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "bullettrain",
+    "railway",
+    "shinkansen",
+    "side"
   ],
   "🚅": [
     "bullet_train",
@@ -5435,12 +8333,24 @@
     "speed",
     "fast",
     "public",
-    "travel"
+    "travel",
+    "bullettrain",
+    "front",
+    "high",
+    "nose",
+    "railway",
+    "shinkansen"
   ],
   "🚆": [
     "train",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "diesel",
+    "electric",
+    "passenger",
+    "railway",
+    "regular",
+    "train2"
   ],
   "🚇": [
     "metro",
@@ -5448,23 +8358,31 @@
     "blue-square",
     "mrt",
     "underground",
-    "tube"
+    "tube",
+    "subway",
+    "train",
+    "vehicle"
   ],
   "🚈": [
     "light_rail",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "railway"
   ],
   "🚉": [
     "station",
     "transportation",
     "vehicle",
-    "public"
+    "public",
+    "platform",
+    "railway",
+    "train"
   ],
   "🚊": [
     "tram",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "trolleybus"
   ],
   "🚝": [
     "monorail",
@@ -5474,7 +8392,10 @@
   "🚞": [
     "mountain_railway",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "car",
+    "funicular",
+    "train"
   ],
   "🚋": [
     "tram_car",
@@ -5482,42 +8403,57 @@
     "vehicle",
     "carriage",
     "public",
-    "travel"
+    "travel",
+    "train",
+    "trolleybus"
   ],
   "🚌": [
     "bus",
     "car",
     "vehicle",
-    "transportation"
+    "transportation",
+    "school"
   ],
   "🚍": [
     "oncoming_bus",
     "vehicle",
-    "transportation"
+    "transportation",
+    "front"
   ],
   "🚎": [
     "trolleybus",
     "bart",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "bus",
+    "electric bus",
+    "tram",
+    "trolley"
   ],
   "🚐": [
     "minibus",
     "vehicle",
     "car",
-    "transportation"
+    "transportation",
+    "bus",
+    "minivan",
+    "mover",
+    "people"
   ],
   "🚑": [
     "ambulance",
     "health",
     "911",
-    "hospital"
+    "hospital",
+    "vehicle"
   ],
   "🚒": [
     "fire_engine",
     "transportation",
     "cars",
-    "vehicle"
+    "vehicle",
+    "department",
+    "truck"
   ],
   "🚓": [
     "police_car",
@@ -5526,7 +8462,10 @@
     "transportation",
     "law",
     "legal",
-    "enforcement"
+    "enforcement",
+    "cop",
+    "patrol",
+    "side"
   ],
   "🚔": [
     "oncoming_police_car",
@@ -5534,56 +8473,78 @@
     "law",
     "legal",
     "enforcement",
-    "911"
+    "911",
+    "front of",
+    "🚓 cop"
   ],
   "🚕": [
     "taxi",
     "uber",
     "vehicle",
     "cars",
-    "transportation"
+    "transportation",
+    "new",
+    "side",
+    "taxicab",
+    "york"
   ],
   "🚖": [
     "oncoming_taxi",
     "vehicle",
     "cars",
-    "uber"
+    "uber",
+    "front",
+    "taxicab"
   ],
   "🚗": [
     "automobile",
     "red",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "car",
+    "side"
   ],
   "🚘": [
     "oncoming_automobile",
     "car",
     "vehicle",
-    "transportation"
+    "transportation",
+    "front"
   ],
   "🚙": [
     "sport_utility_vehicle",
     "transportation",
-    "vehicle"
+    "vehicle",
+    "blue",
+    "campervan",
+    "car",
+    "motorhome",
+    "recreational",
+    "rv"
   ],
   "🚚": [
     "delivery_truck",
     "cars",
-    "transportation"
+    "transportation",
+    "vehicle"
   ],
   "🚛": [
     "articulated_lorry",
     "vehicle",
     "cars",
     "transportation",
-    "express"
+    "express",
+    "green",
+    "semi",
+    "truck"
   ],
   "🚜": [
     "tractor",
     "vehicle",
     "car",
     "farming",
-    "agriculture"
+    "agriculture",
+    "farm"
   ],
   "🏎️": [
     "racing_car",
@@ -5591,19 +8552,24 @@
     "race",
     "fast",
     "formula",
-    "f1"
+    "f1",
+    "one"
   ],
   "🏍️": [
     "motorcycle",
     "race",
     "sports",
-    "fast"
+    "fast",
+    "motorbike",
+    "racing"
   ],
   "🛵": [
     "motor_scooter",
     "vehicle",
     "vespa",
-    "sasha"
+    "sasha",
+    "bike",
+    "cycle"
   ],
   "🦽": [
     "manual_wheelchair",
@@ -5616,14 +8582,17 @@
   "🛺": [
     "auto_rickshaw",
     "move",
-    "transportation"
+    "transportation",
+    "tuk"
   ],
   "🚲": [
     "bicycle",
     "bike",
     "sports",
     "exercise",
-    "hipster"
+    "hipster",
+    "push",
+    "vehicle"
   ],
   "🛴": [
     "kick_scooter",
@@ -5633,12 +8602,14 @@
   ],
   "🛹": [
     "skateboard",
-    "board"
+    "board",
+    "skate"
   ],
   "🚏": [
     "bus_stop",
     "transportation",
-    "wait"
+    "wait",
+    "busstop"
   ],
   "🛣️": [
     "motorway",
@@ -5659,7 +8630,10 @@
   "⛽": [
     "fuel_pump",
     "gas station",
-    "petroleum"
+    "petroleum",
+    "diesel",
+    "fuelpump",
+    "petrol"
   ],
   "🚨": [
     "police_car_light",
@@ -5671,7 +8645,16 @@
     "error",
     "pinged",
     "law",
-    "legal"
+    "legal",
+    "beacon",
+    "cars",
+    "car’s",
+    "emergency light",
+    "flashing",
+    "revolving",
+    "rotating",
+    "siren",
+    "vehicle"
   ],
   "🚥": [
     "horizontal_traffic_light",
@@ -5681,25 +8664,38 @@
   "🚦": [
     "vertical_traffic_light",
     "transportation",
-    "driving"
+    "driving",
+    "semaphore",
+    "signal"
   ],
   "🛑": [
     "stop_sign",
-    "stop"
+    "stop",
+    "octagonal"
   ],
   "🚧": [
     "construction",
     "wip",
     "progress",
     "caution",
-    "warning"
+    "warning",
+    "barrier",
+    "black",
+    "roadwork",
+    "sign",
+    "striped",
+    "yellow"
   ],
   "⚓": [
     "anchor",
     "ship",
     "ferry",
     "sea",
-    "boat"
+    "boat",
+    "admiralty",
+    "fisherman",
+    "pattern",
+    "tool"
   ],
   "⛵": [
     "sailboat",
@@ -5707,7 +8703,13 @@
     "summer",
     "transportation",
     "water",
-    "sailing"
+    "sailing",
+    "boat",
+    "dinghy",
+    "resort",
+    "sea",
+    "vehicle",
+    "yacht"
   ],
   "🛶": [
     "canoe",
@@ -5721,60 +8723,90 @@
     "ship",
     "transportation",
     "vehicle",
-    "summer"
+    "summer",
+    "boat",
+    "motorboat",
+    "powerboat"
   ],
   "🛳️": [
     "passenger_ship",
     "yacht",
     "cruise",
-    "ferry"
+    "ferry",
+    "vehicle"
   ],
   "⛴️": [
     "ferry",
     "boat",
     "ship",
-    "yacht"
+    "yacht",
+    "passenger"
   ],
   "🛥️": [
     "motor_boat",
-    "ship"
+    "ship",
+    "motorboat",
+    "vehicle"
   ],
   "🚢": [
     "ship",
     "transportation",
     "titanic",
-    "deploy"
+    "deploy",
+    "boat",
+    "cruise",
+    "passenger",
+    "vehicle"
   ],
   "✈️": [
     "airplane",
     "vehicle",
     "transportation",
     "flight",
-    "fly"
+    "fly",
+    "aeroplane",
+    "plane"
   ],
   "🛩️": [
     "small_airplane",
     "flight",
     "transportation",
     "fly",
-    "vehicle"
+    "vehicle",
+    "aeroplane",
+    "plane"
   ],
   "🛫": [
     "airplane_departure",
     "airport",
     "flight",
-    "landing"
+    "landing",
+    "aeroplane",
+    "departures",
+    "off",
+    "plane",
+    "taking",
+    "vehicle"
   ],
   "🛬": [
     "airplane_arrival",
     "airport",
     "flight",
-    "boarding"
+    "boarding",
+    "aeroplane",
+    "arrivals",
+    "arriving",
+    "landing",
+    "plane",
+    "vehicle"
   ],
   "🪂": [
     "parachute",
     "fly",
-    "glide"
+    "glide",
+    "hang",
+    "parasail",
+    "skydive"
   ],
   "💺": [
     "seat",
@@ -5783,7 +8815,10 @@
     "transport",
     "bus",
     "flight",
-    "fly"
+    "fly",
+    "aeroplane",
+    "chair",
+    "train"
   ],
   "🚁": [
     "helicopter",
@@ -5800,13 +8835,19 @@
     "mountain_cableway",
     "transportation",
     "vehicle",
-    "ski"
+    "ski",
+    "cable",
+    "gondola"
   ],
   "🚡": [
     "aerial_tramway",
     "transportation",
     "vehicle",
-    "ski"
+    "ski",
+    "cable",
+    "car",
+    "gondola",
+    "ropeway"
   ],
   "🛰️": [
     "satellite",
@@ -5815,7 +8856,10 @@
     "orbit",
     "spaceflight",
     "NASA",
-    "ISS"
+    "ISS",
+    "artificial",
+    "space",
+    "vehicle"
   ],
   "🚀": [
     "rocket",
@@ -5825,22 +8869,30 @@
     "NASA",
     "outer space",
     "outer_space",
-    "fly"
+    "fly",
+    "shuttle",
+    "vehicle"
   ],
   "🛸": [
     "flying_saucer",
     "transportation",
     "vehicle",
-    "ufo"
+    "ufo",
+    "alien",
+    "extraterrestrial",
+    "fantasy",
+    "space"
   ],
   "🛎️": [
     "bellhop_bell",
-    "service"
+    "service",
+    "hotel"
   ],
   "🧳": [
     "luggage",
     "packing",
-    "travel"
+    "travel",
+    "suitcase"
   ],
   "⌛": [
     "hourglass_done",
@@ -5850,28 +8902,40 @@
     "limit",
     "exam",
     "quiz",
-    "test"
+    "test",
+    "sand",
+    "timer"
   ],
   "⏳": [
     "hourglass_not_done",
     "oldschool",
     "time",
-    "countdown"
+    "countdown",
+    "flowing",
+    "sand",
+    "timer"
   ],
   "⌚": [
     "watch",
     "time",
-    "accessories"
+    "accessories",
+    "apple",
+    "clock",
+    "timepiece",
+    "wrist",
+    "wristwatch"
   ],
   "⏰": [
     "alarm_clock",
     "time",
-    "wake"
+    "wake",
+    "morning"
   ],
   "⏱️": [
     "stopwatch",
     "time",
-    "deadline"
+    "deadline",
+    "clock"
   ],
   "⏲️": [
     "timer_clock",
@@ -5894,7 +8958,11 @@
     "midday",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock12",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕧": [
     "twelve_thirty",
@@ -5905,7 +8973,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock1230",
+    "face"
   ],
   "🕐": [
     "one_o_clock",
@@ -5917,7 +8988,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock1",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕜": [
     "one_thirty",
@@ -5928,7 +9003,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock130",
+    "face"
   ],
   "🕑": [
     "two_o_clock",
@@ -5940,7 +9018,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock2",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕝": [
     "two_thirty",
@@ -5951,7 +9033,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock230",
+    "face"
   ],
   "🕒": [
     "three_o_clock",
@@ -5963,7 +9048,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock3",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕞": [
     "three_thirty",
@@ -5974,7 +9063,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock330",
+    "face"
   ],
   "🕓": [
     "four_o_clock",
@@ -5986,7 +9078,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock4",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕟": [
     "four_thirty",
@@ -5997,7 +9093,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock430",
+    "face"
   ],
   "🕔": [
     "five_o_clock",
@@ -6009,7 +9108,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock5",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕠": [
     "five_thirty",
@@ -6020,7 +9123,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock530",
+    "face"
   ],
   "🕕": [
     "six_o_clock",
@@ -6034,7 +9140,11 @@
     "early",
     "schedule",
     "dawn",
-    "dusk"
+    "dusk",
+    "clock6",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕡": [
     "six_thirty",
@@ -6045,7 +9155,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock630",
+    "face"
   ],
   "🕖": [
     "seven_o_clock",
@@ -6057,7 +9170,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock7",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕢": [
     "seven_thirty",
@@ -6068,7 +9185,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock730",
+    "face"
   ],
   "🕗": [
     "eight_o_clock",
@@ -6080,7 +9200,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock8",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕣": [
     "eight_thirty",
@@ -6091,7 +9215,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock830",
+    "face"
   ],
   "🕘": [
     "nine_o_clock",
@@ -6103,7 +9230,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock9",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕤": [
     "nine_thirty",
@@ -6114,7 +9245,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock930",
+    "face"
   ],
   "🕙": [
     "ten_o_clock",
@@ -6126,7 +9260,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock10",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕥": [
     "ten_thirty",
@@ -6137,7 +9275,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock1030",
+    "face"
   ],
   "🕚": [
     "eleven_o_clock",
@@ -6149,7 +9290,11 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock11",
+    "face",
+    "oclock",
+    "o’clock"
   ],
   "🕦": [
     "eleven_thirty",
@@ -6160,7 +9305,10 @@
     "time",
     "late",
     "early",
-    "schedule"
+    "schedule",
+    "clock",
+    "clock1130",
+    "face"
   ],
   "🌑": [
     "new_moon",
@@ -6170,7 +9318,13 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "dark",
+    "eclipse",
+    "shadow moon",
+    "solar",
+    "symbol",
+    "weather"
   ],
   "🌒": [
     "waxing_crescent_moon",
@@ -6180,7 +9334,9 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌓": [
     "first_quarter_moon",
@@ -6190,7 +9346,9 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌔": [
     "waxing_gibbous_moon",
@@ -6202,7 +9360,9 @@
     "planet",
     "space",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌕": [
     "full_moon",
@@ -6213,7 +9373,9 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌖": [
     "waning_gibbous_moon",
@@ -6224,7 +9386,9 @@
     "night",
     "evening",
     "sleep",
-    "waxing_gibbous_moon"
+    "waxing_gibbous_moon",
+    "symbol",
+    "weather"
   ],
   "🌗": [
     "last_quarter_moon",
@@ -6234,7 +9398,9 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌘": [
     "waning_crescent_moon",
@@ -6244,7 +9410,9 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "symbol",
+    "weather"
   ],
   "🌙": [
     "crescent_moon",
@@ -6252,7 +9420,9 @@
     "sleep",
     "sky",
     "evening",
-    "magic"
+    "magic",
+    "space",
+    "weather"
   ],
   "🌚": [
     "new_moon_face",
@@ -6262,7 +9432,11 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "creepy",
+    "dark",
+    "molester",
+    "weather"
   ],
   "🌛": [
     "first_quarter_moon_face",
@@ -6272,7 +9446,8 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "weather"
   ],
   "🌜": [
     "last_quarter_moon_face",
@@ -6282,7 +9457,8 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "weather"
   ],
   "🌡️": [
     "thermometer",
@@ -6298,7 +9474,13 @@
     "brightness",
     "summer",
     "beach",
-    "spring"
+    "spring",
+    "black",
+    "bright",
+    "rays",
+    "space",
+    "sunny",
+    "sunshine"
   ],
   "🌝": [
     "full_moon_face",
@@ -6308,22 +9490,41 @@
     "space",
     "night",
     "evening",
-    "sleep"
+    "sleep",
+    "bright",
+    "moonface",
+    "smiley",
+    "smiling",
+    "weather"
   ],
   "🌞": [
     "sun_with_face",
     "nature",
     "morning",
-    "sky"
+    "sky",
+    "bright",
+    "smiley",
+    "smiling",
+    "space",
+    "summer",
+    "sunface",
+    "weather"
   ],
   "🪐": [
     "ringed_planet",
-    "outerspace"
+    "outerspace",
+    "planets",
+    "saturn",
+    "saturnine",
+    "space"
   ],
   "⭐": [
     "star",
     "night",
-    "yellow"
+    "yellow",
+    "gold",
+    "medium",
+    "white"
   ],
   "🌟": [
     "glowing_star",
@@ -6331,23 +9532,43 @@
     "sparkle",
     "awesome",
     "good",
-    "magic"
+    "magic",
+    "glittery",
+    "glow",
+    "shining",
+    "star2"
   ],
   "🌠": [
     "shooting_star",
     "night",
-    "photo"
+    "photo",
+    "activity",
+    "falling",
+    "meteoroid",
+    "space",
+    "stars",
+    "upon",
+    "when",
+    "wish",
+    "you"
   ],
   "🌌": [
     "milky_way",
     "photo",
     "space",
-    "stars"
+    "stars",
+    "galaxy",
+    "night",
+    "sky",
+    "universe",
+    "weather"
   ],
   "☁️": [
     "cloud",
     "weather",
-    "sky"
+    "sky",
+    "cloudy",
+    "overcast"
   ],
   "⛅": [
     "sun_behind_cloud",
@@ -6356,24 +9577,30 @@
     "cloudy",
     "morning",
     "fall",
-    "spring"
+    "spring",
+    "partly",
+    "sunny"
   ],
   "⛈️": [
     "cloud_with_lightning_and_rain",
     "weather",
-    "lightning"
+    "lightning",
+    "thunder"
   ],
   "🌤️": [
     "sun_behind_small_cloud",
-    "weather"
+    "weather",
+    "white"
   ],
   "🌥️": [
     "sun_behind_large_cloud",
-    "weather"
+    "weather",
+    "white"
   ],
   "🌦️": [
     "sun_behind_rain_cloud",
-    "weather"
+    "weather",
+    "white"
   ],
   "🌧️": [
     "cloud_with_rain",
@@ -6381,7 +9608,8 @@
   ],
   "🌨️": [
     "cloud_with_snow",
-    "weather"
+    "weather",
+    "cold"
   ],
   "🌩️": [
     "cloud_with_lightning",
@@ -6392,16 +9620,25 @@
     "tornado",
     "weather",
     "cyclone",
-    "twister"
+    "twister",
+    "cloud",
+    "whirlwind"
   ],
   "🌫️": [
     "fog",
-    "weather"
+    "weather",
+    "cloud"
   ],
   "🌬️": [
     "wind_face",
     "gust",
-    "air"
+    "air",
+    "blow",
+    "blowing",
+    "cloud",
+    "mother",
+    "nature",
+    "weather"
   ],
   "🌀": [
     "cyclone",
@@ -6415,7 +9652,9 @@
     "spin",
     "tornado",
     "hurricane",
-    "typhoon"
+    "typhoon",
+    "dizzy",
+    "twister"
   ],
   "🌈": [
     "rainbow",
@@ -6424,29 +9663,48 @@
     "unicorn_face",
     "photo",
     "sky",
-    "spring"
+    "spring",
+    "gay",
+    "lgbt",
+    "pride",
+    "primary",
+    "rain",
+    "weather"
   ],
   "🌂": [
     "closed_umbrella",
     "weather",
     "rain",
-    "drizzle"
+    "drizzle",
+    "clothing",
+    "collapsed umbrella",
+    "pink"
   ],
   "☂️": [
     "umbrella",
     "weather",
-    "spring"
+    "spring",
+    "clothing",
+    "open",
+    "rain"
   ],
   "☔": [
     "umbrella_with_rain_drops",
     "rainy",
     "weather",
-    "spring"
+    "spring",
+    "clothing",
+    "drop",
+    "raining"
   ],
   "⛱️": [
     "umbrella_on_ground",
     "weather",
-    "summer"
+    "summer",
+    "beach",
+    "parasol",
+    "rain",
+    "sun"
   ],
   "⚡": [
     "high_voltage",
@@ -6454,7 +9712,12 @@
     "weather",
     "lightning bolt",
     "fast",
-    "zap"
+    "zap",
+    "danger",
+    "electric",
+    "electricity",
+    "sign",
+    "thunderbolt"
   ],
   "❄️": [
     "snowflake",
@@ -6463,7 +9726,9 @@
     "cold",
     "weather",
     "christmas",
-    "xmas"
+    "xmas",
+    "snow",
+    "snowing"
   ],
   "☃️": [
     "snowman",
@@ -6473,7 +9738,10 @@
     "weather",
     "christmas",
     "xmas",
-    "frozen"
+    "frozen",
+    "snow",
+    "snowflakes",
+    "snowing"
   ],
   "⛄": [
     "snowman_without_snow",
@@ -6484,7 +9752,9 @@
     "christmas",
     "xmas",
     "frozen",
-    "without_snow"
+    "without_snow",
+    "frosty",
+    "olaf"
   ],
   "☄️": [
     "comet",
@@ -6494,14 +9764,23 @@
     "fire",
     "hot",
     "cook",
-    "flame"
+    "flame",
+    "burn",
+    "lit",
+    "snapstreak",
+    "tool"
   ],
   "💧": [
     "droplet",
     "water",
     "drip",
     "faucet",
-    "spring"
+    "spring",
+    "cold",
+    "comic",
+    "drop",
+    "sweat",
+    "weather"
   ],
   "🌊": [
     "water_wave",
@@ -6510,7 +9789,11 @@
     "wave",
     "nature",
     "tsunami",
-    "disaster"
+    "disaster",
+    "beach",
+    "ocean",
+    "waves",
+    "weather"
   ],
   "🎃": [
     "jack_o_lantern",
@@ -6518,7 +9801,11 @@
     "light",
     "pumpkin",
     "creepy",
-    "fall"
+    "fall",
+    "activity",
+    "celebration",
+    "entertainment",
+    "gourd"
   ],
   "🎄": [
     "christmas_tree",
@@ -6526,20 +9813,35 @@
     "vacation",
     "december",
     "xmas",
-    "celebration"
+    "celebration",
+    "activity",
+    "entertainment",
+    "xmas tree"
   ],
   "🎆": [
     "fireworks",
     "photo",
     "festival",
     "carnival",
-    "congratulations"
+    "congratulations",
+    "activity",
+    "celebration",
+    "entertainment",
+    "explosion"
   ],
   "🎇": [
     "sparkler",
     "stars",
     "night",
-    "shine"
+    "shine",
+    "activity",
+    "celebration",
+    "entertainment",
+    "firework",
+    "fireworks",
+    "hanabi",
+    "senko",
+    "sparkle"
   ],
   "🧨": [
     "firecracker",
@@ -6547,7 +9849,8 @@
     "boom",
     "explode",
     "explosion",
-    "explosive"
+    "explosive",
+    "fireworks"
   ],
   "✨": [
     "sparkles",
@@ -6557,14 +9860,21 @@
     "cool",
     "awesome",
     "good",
-    "magic"
+    "magic",
+    "entertainment",
+    "glitter",
+    "sparkle",
+    "star"
   ],
   "🎈": [
     "balloon",
     "party",
     "celebration",
     "birthday",
-    "circus"
+    "circus",
+    "activity",
+    "entertainment",
+    "red"
   ],
   "🎉": [
     "party_popper",
@@ -6574,14 +9884,21 @@
     "magic",
     "circus",
     "celebration",
-    "tada"
+    "tada",
+    "activity",
+    "entertainment",
+    "hat",
+    "hooray"
   ],
   "🎊": [
     "confetti_ball",
     "festival",
     "party",
     "birthday",
-    "circus"
+    "circus",
+    "activity",
+    "celebration",
+    "entertainment"
   ],
   "🎋": [
     "tanabata_tree",
@@ -6592,7 +9909,12 @@
     "bamboo",
     "wish",
     "star_festival",
-    "tanzaku"
+    "tanzaku",
+    "activity",
+    "banner",
+    "celebration",
+    "entertainment",
+    "japanese"
   ],
   "🎍": [
     "pine_decoration",
@@ -6602,13 +9924,24 @@
     "vegetable",
     "panda",
     "new_years",
-    "bamboo"
+    "bamboo",
+    "activity",
+    "celebration",
+    "kadomatsu",
+    "year"
   ],
   "🎎": [
     "japanese_dolls",
     "japanese",
     "toy",
-    "kimono"
+    "kimono",
+    "activity",
+    "celebration",
+    "doll",
+    "entertainment",
+    "festival",
+    "hinamatsuri",
+    "imperial"
   ],
   "🎏": [
     "carp_streamer",
@@ -6616,64 +9949,113 @@
     "japanese",
     "koinobori",
     "carp",
-    "banner"
+    "banner",
+    "activity",
+    "celebration",
+    "entertainment",
+    "flag",
+    "flags",
+    "socks",
+    "wind"
   ],
   "🎐": [
     "wind_chime",
     "nature",
     "ding",
     "spring",
-    "bell"
+    "bell",
+    "activity",
+    "celebration",
+    "entertainment",
+    "furin",
+    "jellyfish"
   ],
   "🎑": [
     "moon_viewing_ceremony",
     "photo",
     "japan",
     "asia",
-    "tsukimi"
+    "tsukimi",
+    "activity",
+    "autumn",
+    "celebration",
+    "dumplings",
+    "entertainment",
+    "festival",
+    "grass",
+    "harvest",
+    "mid",
+    "rice",
+    "scene"
   ],
   "🧧": [
     "red_envelope",
-    "gift"
+    "gift",
+    "ang",
+    "good",
+    "hóngbāo",
+    "lai",
+    "luck",
+    "money",
+    "packet",
+    "pao",
+    "see"
   ],
   "🎀": [
     "ribbon",
     "decoration",
     "pink",
     "girl",
-    "bowtie"
+    "bowtie",
+    "bow",
+    "celebration"
   ],
   "🎁": [
     "wrapped_gift",
     "present",
     "birthday",
     "christmas",
-    "xmas"
+    "xmas",
+    "box",
+    "celebration",
+    "entertainment"
   ],
   "🎗️": [
     "reminder_ribbon",
     "sports",
     "cause",
     "support",
-    "awareness"
+    "awareness",
+    "celebration"
   ],
   "🎟️": [
     "admission_tickets",
     "sports",
     "concert",
-    "entrance"
+    "entrance",
+    "entertainment",
+    "ticket"
   ],
   "🎫": [
     "ticket",
     "event",
     "concert",
-    "pass"
+    "pass",
+    "activity",
+    "admission",
+    "entertainment",
+    "stub",
+    "tour",
+    "world"
   ],
   "🎖️": [
     "military_medal",
     "award",
     "winning",
-    "army"
+    "army",
+    "celebration",
+    "decoration",
+    "medallion"
   ],
   "🏆": [
     "trophy",
@@ -6682,28 +10064,37 @@
     "contest",
     "place",
     "ftw",
-    "ceremony"
+    "ceremony",
+    "championship",
+    "prize",
+    "winner",
+    "winners"
   ],
   "🏅": [
     "sports_medal",
     "award",
-    "winning"
+    "winning",
+    "gold",
+    "winner"
   ],
   "🥇": [
     "1st_place_medal",
     "award",
     "winning",
-    "first"
+    "first",
+    "gold"
   ],
   "🥈": [
     "2nd_place_medal",
     "award",
-    "second"
+    "second",
+    "silver"
   ],
   "🥉": [
     "3rd_place_medal",
     "award",
-    "third"
+    "third",
+    "bronze"
   ],
   "⚽": [
     "soccer_ball",
@@ -6713,79 +10104,131 @@
   "⚾": [
     "baseball",
     "sports",
-    "balls"
+    "balls",
+    "ball",
+    "softball"
   ],
   "🥎": [
     "softball",
     "sports",
-    "balls"
+    "balls",
+    "ball",
+    "game",
+    "glove",
+    "sport",
+    "underarm"
   ],
   "🏀": [
     "basketball",
     "sports",
     "balls",
-    "NBA"
+    "NBA",
+    "ball",
+    "hoop",
+    "orange"
   ],
   "🏐": [
     "volleyball",
     "sports",
-    "balls"
+    "balls",
+    "ball",
+    "game"
   ],
   "🏈": [
     "american_football",
     "sports",
     "balls",
-    "NFL"
+    "NFL",
+    "ball",
+    "gridiron",
+    "superbowl"
   ],
   "🏉": [
     "rugby_football",
     "sports",
-    "team"
+    "team",
+    "ball",
+    "league",
+    "union"
   ],
   "🎾": [
     "tennis",
     "sports",
     "balls",
-    "green"
+    "green",
+    "ball",
+    "racket",
+    "racquet"
   ],
   "🥏": [
     "flying_disc",
     "sports",
     "frisbee",
-    "ultimate"
+    "ultimate",
+    "game",
+    "golf",
+    "sport"
   ],
   "🎳": [
     "bowling",
     "sports",
     "fun",
-    "play"
+    "play",
+    "ball",
+    "game",
+    "pin",
+    "pins",
+    "skittles",
+    "ten"
   ],
   "🏏": [
     "cricket_game",
-    "sports"
+    "sports",
+    "ball",
+    "bat",
+    "field"
   ],
   "🏑": [
     "field_hockey",
-    "sports"
+    "sports",
+    "ball",
+    "game",
+    "stick"
   ],
   "🏒": [
     "ice_hockey",
-    "sports"
+    "sports",
+    "game",
+    "puck",
+    "stick"
   ],
   "🥍": [
     "lacrosse",
     "sports",
     "ball",
-    "stick"
+    "stick",
+    "game",
+    "goal",
+    "sport"
   ],
   "🏓": [
     "ping_pong",
     "sports",
-    "pingpong"
+    "pingpong",
+    "ball",
+    "bat",
+    "game",
+    "paddle",
+    "table",
+    "tennis"
   ],
   "🏸": [
     "badminton",
-    "sports"
+    "sports",
+    "birdie",
+    "game",
+    "racquet",
+    "shuttlecock"
   ],
   "🥊": [
     "boxing_glove",
@@ -6808,44 +10251,61 @@
     "business",
     "flag",
     "hole",
-    "summer"
+    "summer",
+    "golf"
   ],
   "⛸️": [
     "ice_skate",
-    "sports"
+    "sports",
+    "skating"
   ],
   "🎣": [
     "fishing_pole",
     "food",
     "hobby",
-    "summer"
+    "summer",
+    "entertainment",
+    "fish",
+    "rod"
   ],
   "🤿": [
     "diving_mask",
     "sport",
-    "ocean"
+    "ocean",
+    "scuba",
+    "snorkeling"
   ],
   "🎽": [
     "running_shirt",
     "play",
-    "pageant"
+    "pageant",
+    "athletics",
+    "marathon",
+    "sash",
+    "singlet"
   ],
   "🎿": [
     "skis",
     "sports",
     "winter",
     "cold",
-    "snow"
+    "snow",
+    "boot",
+    "ski",
+    "skiing"
   ],
   "🛷": [
     "sled",
     "sleigh",
     "luge",
-    "toboggan"
+    "toboggan",
+    "sledge"
   ],
   "🥌": [
     "curling_stone",
-    "sports"
+    "sports",
+    "game",
+    "rock"
   ],
   "🎯": [
     "direct_hit",
@@ -6853,16 +10313,27 @@
     "play",
     "bar",
     "target",
-    "bullseye"
+    "bullseye",
+    "activity",
+    "archery",
+    "bull",
+    "dart",
+    "darts",
+    "entertainment",
+    "eye"
   ],
   "🪀": [
     "yo_yo",
-    "toy"
+    "toy",
+    "fluctuate",
+    "yoyo"
   ],
   "🪁": [
     "kite",
     "wind",
-    "fly"
+    "fly",
+    "soar",
+    "toy"
   ],
   "🎱": [
     "pool_8_ball",
@@ -6870,7 +10341,13 @@
     "hobby",
     "game",
     "luck",
-    "magic"
+    "magic",
+    "8ball",
+    "billiard",
+    "billiards",
+    "cue",
+    "eight",
+    "snooker"
   ],
   "🔮": [
     "crystal_ball",
@@ -6878,24 +10355,43 @@
     "party",
     "magic",
     "circus",
-    "fortune_teller"
+    "fortune_teller",
+    "clairvoyant",
+    "fairy",
+    "fantasy",
+    "psychic",
+    "purple",
+    "tale",
+    "tool"
   ],
   "🧿": [
     "nazar_amulet",
     "bead",
-    "charm"
+    "charm",
+    "boncuğu",
+    "evil",
+    "eye",
+    "talisman"
   ],
   "🎮": [
     "video_game",
     "play",
     "console",
     "PS4",
-    "controller"
+    "controller",
+    "entertainment",
+    "gamepad",
+    "playstation",
+    "u",
+    "wii",
+    "xbox"
   ],
   "🕹️": [
     "joystick",
     "game",
-    "play"
+    "play",
+    "entertainment",
+    "video"
   ],
   "🎰": [
     "slot_machine",
@@ -6904,7 +10400,11 @@
     "vegas",
     "fruit machine",
     "luck",
-    "casino"
+    "casino",
+    "activity",
+    "gambling",
+    "game",
+    "poker"
   ],
   "🎲": [
     "game_die",
@@ -6912,50 +10412,76 @@
     "random",
     "tabletop",
     "play",
-    "luck"
+    "luck",
+    "entertainment",
+    "gambling"
   ],
   "🧩": [
     "puzzle_piece",
     "interlocking",
     "puzzle",
-    "piece"
+    "piece",
+    "clue",
+    "jigsaw"
   ],
   "🧸": [
     "teddy_bear",
     "plush",
-    "stuffed"
+    "stuffed",
+    "plaything",
+    "toy"
   ],
   "♠️": [
     "spade_suit",
     "poker",
     "cards",
     "suits",
-    "magic"
+    "magic",
+    "black",
+    "card",
+    "game",
+    "spades"
   ],
   "♥️": [
     "heart_suit",
     "poker",
     "cards",
     "magic",
-    "suits"
+    "suits",
+    "black",
+    "card",
+    "game",
+    "hearts"
   ],
   "♦️": [
     "diamond_suit",
     "poker",
     "cards",
     "magic",
-    "suits"
+    "suits",
+    "black",
+    "card",
+    "diamonds",
+    "game"
   ],
   "♣️": [
     "club_suit",
     "poker",
     "cards",
     "magic",
-    "suits"
+    "suits",
+    "black",
+    "card",
+    "clubs",
+    "game"
   ],
   "♟️": [
     "chess_pawn",
-    "expendable"
+    "expendable",
+    "black",
+    "dupe",
+    "game",
+    "piece"
   ],
   "🃏": [
     "joker",
@@ -6963,50 +10489,86 @@
     "cards",
     "game",
     "play",
-    "magic"
+    "magic",
+    "black",
+    "card",
+    "entertainment",
+    "playing",
+    "wildcard"
   ],
   "🀄": [
     "mahjong_red_dragon",
     "game",
     "play",
     "chinese",
-    "kanji"
+    "kanji",
+    "tile"
   ],
   "🎴": [
     "flower_playing_cards",
     "game",
     "sunset",
-    "red"
+    "red",
+    "activity",
+    "card",
+    "deck",
+    "entertainment",
+    "hanafuda",
+    "hwatu",
+    "japanese",
+    "of cards"
   ],
   "🎭": [
     "performing_arts",
     "acting",
     "theater",
-    "drama"
+    "drama",
+    "activity",
+    "art",
+    "comedy",
+    "entertainment",
+    "greek",
+    "logo",
+    "mask",
+    "masks",
+    "theatre",
+    "theatre masks",
+    "tragedy"
   ],
   "🖼️": [
     "framed_picture",
-    "photography"
+    "photography",
+    "art",
+    "frame",
+    "museum",
+    "painting"
   ],
   "🎨": [
     "artist_palette",
     "design",
     "paint",
     "draw",
-    "colors"
+    "colors",
+    "activity",
+    "art",
+    "entertainment",
+    "museum",
+    "painting"
   ],
   "🧵": [
     "thread",
     "needle",
     "sewing",
     "spool",
-    "string"
+    "string",
+    "crafts"
   ],
   "🧶": [
     "yarn",
     "ball",
     "crochet",
-    "knit"
+    "knit",
+    "crafts"
   ],
   "👓": [
     "glasses",
@@ -7015,30 +10577,44 @@
     "eyesight",
     "nerdy",
     "dork",
-    "geek"
+    "geek",
+    "clothing",
+    "eye",
+    "eyeglasses",
+    "eyewear"
   ],
   "🕶️": [
     "sunglasses",
     "face",
     "cool",
-    "accessories"
+    "accessories",
+    "dark",
+    "eye",
+    "eyewear",
+    "glasses"
   ],
   "🥽": [
     "goggles",
     "eyes",
     "protection",
-    "safety"
+    "safety",
+    "clothing",
+    "eye",
+    "swimming",
+    "welding"
   ],
   "🥼": [
     "lab_coat",
     "doctor",
     "experiment",
     "scientist",
-    "chemist"
+    "chemist",
+    "clothing"
   ],
   "🦺": [
     "safety_vest",
-    "protection"
+    "protection",
+    "emergency"
   ],
   "👔": [
     "necktie",
@@ -7047,7 +10623,9 @@
     "formal",
     "fashion",
     "cloth",
-    "business"
+    "business",
+    "clothing",
+    "tie"
   ],
   "👕": [
     "t_shirt",
@@ -7055,39 +10633,56 @@
     "cloth",
     "casual",
     "shirt",
-    "tee"
+    "tee",
+    "clothing",
+    "polo",
+    "tshirt"
   ],
   "👖": [
     "jeans",
     "fashion",
-    "shopping"
+    "shopping",
+    "clothing",
+    "denim",
+    "pants",
+    "trousers"
   ],
   "🧣": [
     "scarf",
     "neck",
     "winter",
-    "clothes"
+    "clothes",
+    "clothing"
   ],
   "🧤": [
     "gloves",
     "hands",
     "winter",
-    "clothes"
+    "clothes",
+    "clothing",
+    "hand"
   ],
   "🧥": [
     "coat",
-    "jacket"
+    "jacket",
+    "clothing"
   ],
   "🧦": [
     "socks",
     "stockings",
-    "clothes"
+    "clothes",
+    "clothing",
+    "pair",
+    "stocking"
   ],
   "👗": [
     "dress",
     "clothes",
     "fashion",
-    "shopping"
+    "shopping",
+    "clothing",
+    "gown",
+    "skirt"
   ],
   "👘": [
     "kimono",
@@ -7095,23 +10690,45 @@
     "fashion",
     "women",
     "female",
-    "japanese"
+    "japanese",
+    "clothing",
+    "dressing",
+    "gown"
   ],
   "🥻": [
     "sari",
-    "dress"
+    "dress",
+    "clothing",
+    "saree",
+    "shari"
   ],
   "🩱": [
     "one_piece_swimsuit",
-    "fashion"
+    "fashion",
+    "bathing",
+    "clothing",
+    "suit",
+    "swim"
   ],
   "🩲": [
     "briefs",
-    "clothing"
+    "clothing",
+    "bathing",
+    "brief",
+    "suit",
+    "swim",
+    "swimsuit",
+    "underwear"
   ],
   "🩳": [
     "shorts",
-    "clothing"
+    "clothing",
+    "bathing",
+    "pants",
+    "suit",
+    "swim",
+    "swimsuit",
+    "underwear"
   ],
   "👙": [
     "bikini",
@@ -7121,13 +10738,23 @@
     "girl",
     "fashion",
     "beach",
-    "summer"
+    "summer",
+    "bathers",
+    "clothing",
+    "swim",
+    "swimsuit"
   ],
   "👚": [
     "woman_s_clothes",
     "fashion",
     "shopping_bags",
-    "female"
+    "female",
+    "blouse",
+    "clothing",
+    "pink",
+    "shirt",
+    "womans",
+    "woman’s"
   ],
   "👛": [
     "purse",
@@ -7135,55 +10762,86 @@
     "accessories",
     "money",
     "sales",
-    "shopping"
+    "shopping",
+    "clothing",
+    "coin",
+    "wallet"
   ],
   "👜": [
     "handbag",
     "fashion",
     "accessory",
     "accessories",
-    "shopping"
+    "shopping",
+    "bag",
+    "clothing",
+    "purse",
+    "women’s"
   ],
   "👝": [
     "clutch_bag",
     "bag",
     "accessories",
-    "shopping"
+    "shopping",
+    "clothing",
+    "pouch",
+    "small"
   ],
   "🛍️": [
     "shopping_bags",
     "mall",
     "buy",
-    "purchase"
+    "purchase",
+    "bag",
+    "hotel"
   ],
   "🎒": [
     "backpack",
     "student",
     "education",
-    "bag"
+    "bag",
+    "activity",
+    "rucksack",
+    "satchel",
+    "school"
   ],
   "👞": [
     "man_s_shoe",
     "fashion",
-    "male"
+    "male",
+    "brown",
+    "clothing",
+    "dress",
+    "mans",
+    "man’s"
   ],
   "👟": [
     "running_shoe",
     "shoes",
     "sports",
-    "sneakers"
+    "sneakers",
+    "athletic",
+    "clothing",
+    "runner",
+    "sneaker",
+    "sport",
+    "tennis",
+    "trainer"
   ],
   "🥾": [
     "hiking_boot",
     "backpacking",
     "camping",
-    "hiking"
+    "hiking",
+    "clothing"
   ],
   "🥿": [
     "flat_shoe",
     "ballet",
     "slip-on",
-    "slipper"
+    "slipper",
+    "clothing",
+    "woman’s"
   ],
   "👠": [
     "high_heeled_shoe",
@@ -7191,22 +10849,44 @@
     "shoes",
     "female",
     "pumps",
-    "stiletto"
+    "stiletto",
+    "clothing",
+    "heel",
+    "heels",
+    "woman"
   ],
   "👡": [
     "woman_s_sandal",
     "shoes",
     "fashion",
-    "flip flops"
+    "flip flops",
+    "clothing",
+    "heeled",
+    "sandals",
+    "shoe",
+    "womans",
+    "woman’s"
   ],
   "🩰": [
     "ballet_shoes",
-    "dance"
+    "dance",
+    "clothing",
+    "pointe",
+    "shoe"
   ],
   "👢": [
     "woman_s_boot",
     "shoes",
-    "fashion"
+    "fashion",
+    "boots",
+    "clothing",
+    "cowgirl",
+    "heeled",
+    "high",
+    "knee",
+    "shoe",
+    "womans",
+    "woman’s"
   ],
   "👑": [
     "crown",
@@ -7214,7 +10894,10 @@
     "kod",
     "leader",
     "royalty",
-    "lord"
+    "lord",
+    "clothing",
+    "queen",
+    "royal"
   ],
   "👒": [
     "woman_s_hat",
@@ -7222,14 +10905,26 @@
     "accessories",
     "female",
     "lady",
-    "spring"
+    "spring",
+    "bow",
+    "clothing",
+    "ladies",
+    "womans",
+    "woman’s"
   ],
   "🎩": [
     "top_hat",
     "magic",
     "gentleman",
     "classy",
-    "circus"
+    "circus",
+    "activity",
+    "clothing",
+    "entertainment",
+    "formal",
+    "groom",
+    "tophat",
+    "wear"
   ],
   "🎓": [
     "graduation_cap",
@@ -7242,29 +10937,53 @@
     "hat",
     "legal",
     "learn",
-    "education"
+    "education",
+    "academic",
+    "activity",
+    "board",
+    "celebration",
+    "clothing",
+    "graduate",
+    "mortar",
+    "square"
   ],
   "🧢": [
     "billed_cap",
     "cap",
-    "baseball"
+    "baseball",
+    "clothing",
+    "hat"
   ],
   "⛑️": [
     "rescue_worker_s_helmet",
     "construction",
-    "build"
+    "build",
+    "aid",
+    "cross",
+    "face",
+    "hat",
+    "white",
+    "worker’s"
   ],
   "📿": [
     "prayer_beads",
     "dhikr",
-    "religious"
+    "religious",
+    "clothing",
+    "necklace",
+    "religion",
+    "rosary"
   ],
   "💄": [
     "lipstick",
     "female",
     "girl",
     "fashion",
-    "woman"
+    "woman",
+    "cosmetics",
+    "gloss",
+    "lip",
+    "makeup"
   ],
   "💍": [
     "ring",
@@ -7276,34 +10995,50 @@
     "fashion",
     "jewelry",
     "gem",
-    "engagement"
+    "engagement",
+    "engaged",
+    "romance"
   ],
   "💎": [
     "gem_stone",
     "blue",
     "ruby",
     "diamond",
-    "jewelry"
+    "jewelry",
+    "gemstone",
+    "jewel",
+    "romance"
   ],
   "🔇": [
     "muted_speaker",
     "sound",
     "volume",
     "silence",
-    "quiet"
+    "quiet",
+    "cancellation",
+    "mute",
+    "off",
+    "silent",
+    "stroke"
   ],
   "🔈": [
     "speaker_low_volume",
     "sound",
     "volume",
     "silence",
-    "broadcast"
+    "broadcast",
+    "soft"
   ],
   "🔉": [
     "speaker_medium_volume",
     "volume",
     "speaker",
-    "broadcast"
+    "broadcast",
+    "low",
+    "one",
+    "reduce",
+    "sound",
+    "wave"
   ],
   "🔊": [
     "speaker_high_volume",
@@ -7311,23 +11046,47 @@
     "noise",
     "noisy",
     "speaker",
-    "broadcast"
+    "broadcast",
+    "entertainment",
+    "increase",
+    "loud",
+    "sound",
+    "three",
+    "waves"
   ],
   "📢": [
     "loudspeaker",
     "volume",
-    "sound"
+    "sound",
+    "address",
+    "announcement",
+    "bullhorn",
+    "communication",
+    "loud",
+    "megaphone",
+    "pa",
+    "public",
+    "system"
   ],
   "📣": [
     "megaphone",
     "sound",
     "speaker",
-    "volume"
+    "volume",
+    "bullhorn",
+    "cheering",
+    "communication",
+    "mega"
   ],
   "📯": [
     "postal_horn",
     "instrument",
-    "music"
+    "music",
+    "bugle",
+    "communication",
+    "entertainment",
+    "french",
+    "post"
   ],
   "🔔": [
     "bell",
@@ -7335,7 +11094,10 @@
     "notification",
     "christmas",
     "xmas",
-    "chime"
+    "chime",
+    "liberty",
+    "ringer",
+    "wedding"
   ],
   "🔕": [
     "bell_with_slash",
@@ -7343,39 +11105,72 @@
     "volume",
     "mute",
     "quiet",
-    "silent"
+    "silent",
+    "cancellation",
+    "disabled",
+    "forbidden",
+    "muted",
+    "no",
+    "not",
+    "notifications",
+    "off",
+    "prohibited",
+    "ringer",
+    "stroke"
   ],
   "🎼": [
     "musical_score",
     "treble",
     "clef",
-    "compose"
+    "compose",
+    "activity",
+    "entertainment",
+    "music",
+    "sheet"
   ],
   "🎵": [
     "musical_note",
     "score",
     "tone",
-    "sound"
+    "sound",
+    "activity",
+    "beamed",
+    "eighth",
+    "entertainment",
+    "music",
+    "notes",
+    "pair",
+    "quavers"
   ],
   "🎶": [
     "musical_notes",
     "music",
-    "score"
+    "score",
+    "activity",
+    "entertainment",
+    "multiple",
+    "note",
+    "singing"
   ],
   "🎙️": [
     "studio_microphone",
     "sing",
     "recording",
     "artist",
-    "talkshow"
+    "talkshow",
+    "mic",
+    "music",
+    "podcast"
   ],
   "🎚️": [
     "level_slider",
-    "scale"
+    "scale",
+    "music"
   ],
   "🎛️": [
     "control_knobs",
-    "dial"
+    "dial",
+    "music"
   ],
   "🎤": [
     "microphone",
@@ -7383,55 +11178,98 @@
     "music",
     "PA",
     "sing",
-    "talkshow"
+    "talkshow",
+    "activity",
+    "entertainment",
+    "karaoke",
+    "mic",
+    "singing"
   ],
   "🎧": [
     "headphone",
     "music",
     "score",
-    "gadgets"
+    "gadgets",
+    "activity",
+    "earbud",
+    "earphone",
+    "earphones",
+    "entertainment",
+    "headphones",
+    "ipod"
   ],
   "📻": [
     "radio",
     "communication",
     "music",
     "podcast",
-    "program"
+    "program",
+    "digital",
+    "entertainment",
+    "video",
+    "wireless"
   ],
   "🎷": [
     "saxophone",
     "music",
     "instrument",
     "jazz",
-    "blues"
+    "blues",
+    "activity",
+    "entertainment",
+    "sax"
   ],
   "🎸": [
     "guitar",
     "music",
-    "instrument"
+    "instrument",
+    "acoustic guitar",
+    "activity",
+    "bass",
+    "electric",
+    "entertainment",
+    "rock"
   ],
   "🎹": [
     "musical_keyboard",
     "piano",
     "instrument",
-    "compose"
+    "compose",
+    "activity",
+    "entertainment",
+    "music"
   ],
   "🎺": [
     "trumpet",
     "music",
-    "brass"
+    "brass",
+    "activity",
+    "entertainment",
+    "horn",
+    "instrument",
+    "jazz"
   ],
   "🎻": [
     "violin",
     "music",
     "instrument",
     "orchestra",
-    "symphony"
+    "symphony",
+    "activity",
+    "entertainment",
+    "quartet",
+    "smallest",
+    "string",
+    "world’s"
   ],
   "🪕": [
     "banjo",
     "music",
-    "instructment"
+    "instructment",
+    "activity",
+    "entertainment",
+    "instrument",
+    "stringed"
   ],
   "🥁": [
     "drum",
@@ -7445,64 +11283,101 @@
     "technology",
     "apple",
     "gadgets",
-    "dial"
+    "dial",
+    "cell",
+    "communication",
+    "iphone",
+    "smartphone",
+    "telephone"
   ],
   "📲": [
     "mobile_phone_with_arrow",
     "iphone",
-    "incoming"
+    "incoming",
+    "call",
+    "calling",
+    "cell",
+    "communication",
+    "left",
+    "pointing",
+    "receive",
+    "rightwards",
+    "telephone"
   ],
   "☎️": [
     "telephone",
     "technology",
     "communication",
-    "dial"
+    "dial",
+    "black",
+    "phone",
+    "rotary"
   ],
   "📞": [
     "telephone_receiver",
     "technology",
     "communication",
-    "dial"
+    "dial",
+    "call",
+    "handset",
+    "phone"
   ],
   "📟": [
     "pager",
     "bbcall",
     "oldschool",
-    "90s"
+    "90s",
+    "beeper",
+    "bleeper",
+    "communication"
   ],
   "📠": [
     "fax_machine",
     "communication",
-    "technology"
+    "technology",
+    "facsimile"
   ],
   "🔋": [
     "battery",
     "power",
     "energy",
-    "sustain"
+    "sustain",
+    "aa",
+    "phone"
   ],
   "🔌": [
     "electric_plug",
     "charger",
-    "power"
+    "power",
+    "ac",
+    "adaptor",
+    "cable",
+    "electricity"
   ],
   "💻": [
     "laptop",
     "technology",
     "screen",
     "display",
-    "monitor"
+    "monitor",
+    "computer",
+    "desktop",
+    "notebook",
+    "pc",
+    "personal"
   ],
   "🖥️": [
     "desktop_computer",
     "technology",
     "computing",
-    "screen"
+    "screen",
+    "imac"
   ],
   "🖨️": [
     "printer",
     "paper",
-    "ink"
+    "ink",
+    "computer"
   ],
   "⌨️": [
     "keyboard",
@@ -7514,12 +11389,15 @@
   ],
   "🖱️": [
     "computer_mouse",
-    "click"
+    "click",
+    "button",
+    "three"
   ],
   "🖲️": [
     "trackball",
     "technology",
-    "trackpad"
+    "trackpad",
+    "computer"
   ],
   "💽": [
     "computer_disk",
@@ -7527,7 +11405,11 @@
     "record",
     "data",
     "disk",
-    "90s"
+    "90s",
+    "entertainment",
+    "minidisc",
+    "minidisk",
+    "optical"
   ],
   "💾": [
     "floppy_disk",
@@ -7535,7 +11417,8 @@
     "technology",
     "save",
     "90s",
-    "80s"
+    "80s",
+    "computer"
   ],
   "💿": [
     "optical_disk",
@@ -7543,61 +11426,100 @@
     "dvd",
     "disk",
     "disc",
-    "90s"
+    "90s",
+    "cd",
+    "compact",
+    "computer",
+    "rom"
   ],
   "📀": [
     "dvd",
     "cd",
     "disk",
-    "disc"
+    "disc",
+    "computer",
+    "entertainment",
+    "optical",
+    "rom",
+    "video"
   ],
   "🧮": [
     "abacus",
-    "calculation"
+    "calculation",
+    "count",
+    "counting",
+    "frame",
+    "math"
   ],
   "🎥": [
     "movie_camera",
     "film",
-    "record"
+    "record",
+    "activity",
+    "cinema",
+    "entertainment",
+    "hollywood",
+    "video"
   ],
   "🎞️": [
     "film_frames",
-    "movie"
+    "movie",
+    "cinema",
+    "entertainment",
+    "strip"
   ],
   "📽️": [
     "film_projector",
     "video",
     "tape",
     "record",
-    "movie"
+    "movie",
+    "cinema",
+    "entertainment"
   ],
   "🎬": [
     "clapper_board",
     "movie",
     "film",
-    "record"
+    "record",
+    "activity",
+    "clapboard",
+    "director",
+    "entertainment",
+    "slate"
   ],
   "📺": [
     "television",
     "technology",
     "program",
     "oldschool",
-    "show"
+    "show",
+    "entertainment",
+    "tv",
+    "video"
   ],
   "📷": [
     "camera",
     "gadgets",
-    "photography"
+    "photography",
+    "digital",
+    "entertainment",
+    "photo",
+    "video"
   ],
   "📸": [
     "camera_with_flash",
     "photography",
-    "gadgets"
+    "gadgets",
+    "photo",
+    "video"
   ],
   "📹": [
     "video_camera",
     "film",
-    "record"
+    "record",
+    "camcorder",
+    "entertainment"
   ],
   "📼": [
     "videocassette",
@@ -7605,50 +11527,76 @@
     "video",
     "oldschool",
     "90s",
-    "80s"
+    "80s",
+    "entertainment",
+    "tape",
+    "vcr",
+    "vhs"
   ],
   "🔍": [
     "magnifying_glass_tilted_left",
     "search",
     "zoom",
     "find",
-    "detective"
+    "detective",
+    "icon",
+    "mag",
+    "magnifier",
+    "pointing",
+    "tool"
   ],
   "🔎": [
     "magnifying_glass_tilted_right",
     "search",
     "zoom",
     "find",
-    "detective"
+    "detective",
+    "icon",
+    "mag",
+    "magnifier",
+    "pointing",
+    "tool"
   ],
   "🕯️": [
     "candle",
     "fire",
-    "wax"
+    "wax",
+    "light"
   ],
   "💡": [
     "light_bulb",
     "light",
     "electricity",
-    "idea"
+    "idea",
+    "comic",
+    "electric"
   ],
   "🔦": [
     "flashlight",
     "dark",
     "camping",
     "sight",
-    "night"
+    "night",
+    "electric",
+    "light",
+    "tool",
+    "torch"
   ],
   "🏮": [
     "red_paper_lantern",
     "light",
     "paper",
     "halloween",
-    "spooky"
+    "spooky",
+    "asian",
+    "bar",
+    "izakaya",
+    "japanese"
   ],
   "🪔": [
     "diya_lamp",
-    "lighting"
+    "lighting",
+    "oil"
   ],
   "📔": [
     "notebook_with_decorative_cover",
@@ -7656,7 +11604,9 @@
     "notes",
     "record",
     "paper",
-    "study"
+    "study",
+    "book",
+    "decorated"
   ],
   "📕": [
     "closed_book",
@@ -7664,7 +11614,8 @@
     "library",
     "knowledge",
     "textbook",
-    "learn"
+    "learn",
+    "red"
   ],
   "📖": [
     "open_book",
@@ -7674,14 +11625,16 @@
     "knowledge",
     "literature",
     "learn",
-    "study"
+    "study",
+    "novel"
   ],
   "📗": [
     "green_book",
     "read",
     "library",
     "knowledge",
-    "study"
+    "study",
+    "textbook"
   ],
   "📘": [
     "blue_book",
@@ -7689,7 +11642,8 @@
     "library",
     "knowledge",
     "learn",
-    "study"
+    "study",
+    "textbook"
   ],
   "📙": [
     "orange_book",
@@ -7703,7 +11657,10 @@
     "books",
     "literature",
     "library",
-    "study"
+    "study",
+    "book",
+    "pile",
+    "stack"
   ],
   "📓": [
     "notebook",
@@ -7711,55 +11668,85 @@
     "record",
     "notes",
     "paper",
-    "study"
+    "study",
+    "black",
+    "book",
+    "composition",
+    "white"
   ],
   "📒": [
     "ledger",
     "notes",
-    "paper"
+    "paper",
+    "binder",
+    "book",
+    "bound",
+    "notebook",
+    "spiral",
+    "yellow"
   ],
   "📃": [
     "page_with_curl",
     "documents",
     "office",
-    "paper"
+    "paper",
+    "curled",
+    "curly page",
+    "document"
   ],
   "📜": [
     "scroll",
     "documents",
     "ancient",
     "history",
-    "paper"
+    "paper",
+    "degree",
+    "document",
+    "parchment"
   ],
   "📄": [
     "page_facing_up",
     "documents",
     "office",
     "paper",
-    "information"
+    "information",
+    "document",
+    "printed"
   ],
   "📰": [
     "newspaper",
     "press",
-    "headline"
+    "headline",
+    "communication",
+    "news",
+    "paper"
   ],
   "🗞️": [
     "rolled_up_newspaper",
     "press",
-    "headline"
+    "headline",
+    "delivery",
+    "news",
+    "paper",
+    "roll"
   ],
   "📑": [
     "bookmark_tabs",
     "favorite",
     "save",
     "order",
-    "tidy"
+    "tidy",
+    "mark",
+    "marker"
   ],
   "🔖": [
     "bookmark",
     "favorite",
     "label",
-    "save"
+    "save",
+    "mark",
+    "price",
+    "tag"
   ],
   "🏷️": [
     "label",
@@ -7771,7 +11758,11 @@
     "dollar",
     "payment",
     "coins",
-    "sale"
+    "sale",
+    "cream",
+    "moneybag",
+    "moneybags",
+    "rich"
   ],
   "💴": [
     "yen_banknote",
@@ -7779,21 +11770,36 @@
     "sales",
     "japanese",
     "dollar",
-    "currency"
+    "currency",
+    "bank",
+    "banknotes",
+    "bill",
+    "note",
+    "sign"
   ],
   "💵": [
     "dollar_banknote",
     "money",
     "sales",
     "bill",
-    "currency"
+    "currency",
+    "american",
+    "bank",
+    "banknotes",
+    "note",
+    "sign"
   ],
   "💶": [
     "euro_banknote",
     "money",
     "sales",
     "dollar",
-    "currency"
+    "currency",
+    "bank",
+    "banknotes",
+    "bill",
+    "note",
+    "sign"
   ],
   "💷": [
     "pound_banknote",
@@ -7804,14 +11810,28 @@
     "bills",
     "uk",
     "england",
-    "currency"
+    "currency",
+    "bank",
+    "banknotes",
+    "bill",
+    "note",
+    "quid",
+    "sign",
+    "twenty"
   ],
   "💸": [
     "money_with_wings",
     "dollar",
     "bills",
     "payment",
-    "sale"
+    "sale",
+    "bank",
+    "banknote",
+    "bill",
+    "fly",
+    "flying",
+    "losing",
+    "note"
   ],
   "💳": [
     "credit_card",
@@ -7820,26 +11840,49 @@
     "dollar",
     "bill",
     "payment",
-    "shopping"
+    "shopping",
+    "amex",
+    "bank",
+    "club",
+    "diners",
+    "mastercard",
+    "subscription",
+    "visa"
   ],
   "🧾": [
     "receipt",
     "accounting",
-    "expenses"
+    "expenses",
+    "bookkeeping",
+    "evidence",
+    "proof"
   ],
   "💹": [
     "chart_increasing_with_yen",
     "green-square",
     "graph",
     "presentation",
-    "stats"
+    "stats",
+    "bank",
+    "currency",
+    "exchange",
+    "growth",
+    "market",
+    "money",
+    "rate",
+    "rise",
+    "sign",
+    "trend",
+    "upward",
+    "upwards"
   ],
   "💱": [
     "currency_exchange",
     "money",
     "sales",
     "dollar",
-    "travel"
+    "travel",
+    "bank"
   ],
   "💲": [
     "heavy_dollar_sign",
@@ -7854,32 +11897,61 @@
     "letter",
     "postal",
     "inbox",
-    "communication"
+    "communication",
+    "email",
+    "✉ letter"
   ],
   "📧": [
     "e_mail",
     "communication",
-    "inbox"
+    "inbox",
+    "email",
+    "letter",
+    "symbol"
   ],
   "📨": [
     "incoming_envelope",
     "email",
-    "inbox"
+    "inbox",
+    "communication",
+    "fast",
+    "letter",
+    "lines",
+    "mail",
+    "receive"
   ],
   "📩": [
     "envelope_with_arrow",
     "email",
-    "communication"
+    "communication",
+    "above",
+    "down",
+    "downwards",
+    "insert",
+    "letter",
+    "mail",
+    "outgoing",
+    "sent"
   ],
   "📤": [
     "outbox_tray",
     "inbox",
-    "email"
+    "email",
+    "box",
+    "communication",
+    "letter",
+    "mail",
+    "sent"
   ],
   "📥": [
     "inbox_tray",
     "email",
-    "documents"
+    "documents",
+    "box",
+    "communication",
+    "letter",
+    "mail",
+    "receive"
   ],
   "📦": [
     "package",
@@ -7887,41 +11959,58 @@
     "gift",
     "cardboard",
     "box",
-    "moving"
+    "moving",
+    "communication",
+    "parcel",
+    "shipping"
   ],
   "📫": [
     "closed_mailbox_with_raised_flag",
     "email",
     "inbox",
-    "communication"
+    "communication",
+    "mail",
+    "postbox"
   ],
   "📪": [
     "closed_mailbox_with_lowered_flag",
     "email",
     "communication",
-    "inbox"
+    "inbox",
+    "mail",
+    "postbox"
   ],
   "📬": [
     "open_mailbox_with_raised_flag",
     "email",
     "inbox",
-    "communication"
+    "communication",
+    "mail",
+    "postbox"
   ],
   "📭": [
     "open_mailbox_with_lowered_flag",
     "email",
-    "inbox"
+    "inbox",
+    "communication",
+    "mail",
+    "no",
+    "postbox"
   ],
   "📮": [
     "postbox",
     "email",
     "letter",
-    "envelope"
+    "envelope",
+    "communication",
+    "mail",
+    "mailbox"
   ],
   "🗳️": [
     "ballot_box_with_ballot",
     "election",
-    "vote"
+    "vote",
+    "voting"
   ],
   "✏️": [
     "pencil",
@@ -7930,37 +12019,56 @@
     "paper",
     "writing",
     "school",
-    "study"
+    "study",
+    "lead",
+    "pencil2"
   ],
   "✒️": [
     "black_nib",
     "pen",
     "stationery",
     "writing",
-    "write"
+    "write",
+    "fountain",
+    "✒ fountain"
   ],
   "🖋️": [
     "fountain_pen",
     "stationery",
     "writing",
-    "write"
+    "write",
+    "communication",
+    "left",
+    "lower"
   ],
   "🖊️": [
     "pen",
     "stationery",
     "writing",
-    "write"
+    "write",
+    "ballpoint",
+    "communication",
+    "left",
+    "lower"
   ],
   "🖌️": [
     "paintbrush",
     "drawing",
     "creativity",
-    "art"
+    "art",
+    "brush",
+    "communication",
+    "left",
+    "lower",
+    "painting"
   ],
   "🖍️": [
     "crayon",
     "drawing",
-    "creativity"
+    "creativity",
+    "communication",
+    "left",
+    "lower"
   ],
   "📝": [
     "memo",
@@ -7975,7 +12083,11 @@
     "quiz",
     "test",
     "study",
-    "compose"
+    "compose",
+    "communication",
+    "document",
+    "memorandum",
+    "note"
   ],
   "💼": [
     "briefcase",
@@ -7985,13 +12097,17 @@
     "law",
     "legal",
     "job",
-    "career"
+    "career",
+    "suitcase"
   ],
   "📁": [
     "file_folder",
     "documents",
     "business",
-    "office"
+    "office",
+    "closed",
+    "directory",
+    "manilla"
   ],
   "📂": [
     "open_file_folder",
@@ -8006,29 +12122,41 @@
   ],
   "📅": [
     "calendar",
-    "schedule"
+    "schedule",
+    "date",
+    "day",
+    "emoji",
+    "july",
+    "world"
   ],
   "📆": [
     "tear_off_calendar",
     "schedule",
     "date",
-    "planning"
+    "planning",
+    "day",
+    "desk"
   ],
   "🗒️": [
     "spiral_notepad",
     "memo",
-    "stationery"
+    "stationery",
+    "note",
+    "pad"
   ],
   "🗓️": [
     "spiral_calendar",
     "date",
     "schedule",
-    "planning"
+    "planning",
+    "pad"
   ],
   "📇": [
     "card_index",
     "business",
-    "stationery"
+    "stationery",
+    "rolodex",
+    "system"
   ],
   "📈": [
     "chart_increasing",
@@ -8041,7 +12169,15 @@
     "money",
     "sales",
     "good",
-    "success"
+    "success",
+    "growth",
+    "metrics",
+    "pointing",
+    "positive chart",
+    "trend",
+    "up",
+    "upward",
+    "upwards"
   ],
   "📉": [
     "chart_decreasing",
@@ -8054,13 +12190,20 @@
     "money",
     "sales",
     "bad",
-    "failure"
+    "failure",
+    "down",
+    "downwards",
+    "down pointing",
+    "metrics",
+    "negative chart",
+    "trend"
   ],
   "📊": [
     "bar_chart",
     "graph",
     "presentation",
-    "stats"
+    "stats",
+    "metrics"
   ],
   "📋": [
     "clipboard",
@@ -8071,24 +12214,35 @@
     "pushpin",
     "stationery",
     "mark",
-    "here"
+    "here",
+    "location",
+    "pin",
+    "tack",
+    "thumb"
   ],
   "📍": [
     "round_pushpin",
     "stationery",
     "location",
     "map",
-    "here"
+    "here",
+    "dropped",
+    "pin",
+    "red"
   ],
   "📎": [
     "paperclip",
     "documents",
-    "stationery"
+    "stationery",
+    "clippy"
   ],
   "🖇️": [
     "linked_paperclips",
     "documents",
-    "stationery"
+    "stationery",
+    "communication",
+    "link",
+    "paperclip"
   ],
   "📏": [
     "straight_ruler",
@@ -8099,19 +12253,25 @@
     "school",
     "drawing",
     "architect",
-    "sketch"
+    "sketch",
+    "edge"
   ],
   "📐": [
     "triangular_ruler",
     "stationery",
     "math",
     "architect",
-    "sketch"
+    "sketch",
+    "set",
+    "triangle"
   ],
   "✂️": [
     "scissors",
     "stationery",
-    "cut"
+    "cut",
+    "black",
+    "cutting",
+    "tool"
   ],
   "🗃️": [
     "card_file_box",
@@ -8129,73 +12289,108 @@
     "trash",
     "rubbish",
     "garbage",
-    "toss"
+    "toss",
+    "basket",
+    "can",
+    "litter",
+    "wastepaper"
   ],
   "🔒": [
     "locked",
     "security",
     "password",
-    "padlock"
+    "padlock",
+    "closed",
+    "lock",
+    "private"
   ],
   "🔓": [
     "unlocked",
     "privacy",
-    "security"
+    "security",
+    "lock",
+    "open",
+    "padlock",
+    "unlock"
   ],
   "🔏": [
     "locked_with_pen",
     "security",
-    "secret"
+    "secret",
+    "fountain",
+    "ink",
+    "lock",
+    "lock with",
+    "nib",
+    "privacy"
   ],
   "🔐": [
     "locked_with_key",
     "security",
-    "privacy"
+    "privacy",
+    "closed",
+    "lock",
+    "secure"
   ],
   "🔑": [
     "key",
     "lock",
     "door",
-    "password"
+    "password",
+    "gold"
   ],
   "🗝️": [
     "old_key",
     "lock",
     "door",
-    "password"
+    "password",
+    "clue"
   ],
   "🔨": [
     "hammer",
     "tools",
     "build",
-    "create"
+    "create",
+    "claw",
+    "handyman",
+    "tool"
   ],
   "🪓": [
     "axe",
     "tool",
     "chop",
-    "cut"
+    "cut",
+    "hatchet",
+    "split",
+    "wood"
   ],
   "⛏️": [
     "pick",
     "tools",
-    "dig"
+    "dig",
+    "mining",
+    "pickaxe",
+    "tool"
   ],
   "⚒️": [
     "hammer_and_pick",
     "tools",
     "build",
-    "create"
+    "create",
+    "tool"
   ],
   "🛠️": [
     "hammer_and_wrench",
     "tools",
     "build",
-    "create"
+    "create",
+    "spanner",
+    "tool"
   ],
   "🗡️": [
     "dagger",
-    "weapon"
+    "weapon",
+    "knife"
   ],
   "⚔️": [
     "crossed_swords",
@@ -8205,16 +12400,28 @@
     "pistol",
     "violence",
     "weapon",
-    "revolver"
+    "revolver",
+    "gun",
+    "handgun",
+    "shoot",
+    "squirt",
+    "tool",
+    "water"
   ],
   "🏹": [
     "bow_and_arrow",
-    "sports"
+    "sports",
+    "archer",
+    "archery",
+    "sagittarius",
+    "tool",
+    "zodiac"
   ],
   "🛡️": [
     "shield",
     "protection",
-    "security"
+    "security",
+    "weapon"
   ],
   "🔧": [
     "wrench",
@@ -8222,41 +12429,64 @@
     "diy",
     "ikea",
     "fix",
-    "maintainer"
+    "maintainer",
+    "spanner",
+    "tool"
   ],
   "🔩": [
     "nut_and_bolt",
     "handy",
     "tools",
-    "fix"
+    "fix",
+    "screw",
+    "tool"
   ],
   "⚙️": [
     "gear",
-    "cog"
+    "cog",
+    "cogwheel",
+    "tool"
   ],
   "🗜️": [
     "clamp",
-    "tool"
+    "tool",
+    "compress",
+    "compression",
+    "table",
+    "vice",
+    "winzip"
   ],
   "⚖️": [
     "balance_scale",
     "law",
     "fairness",
-    "weight"
+    "weight",
+    "justice",
+    "libra",
+    "scales",
+    "tool",
+    "zodiac"
   ],
   "🦯": [
     "probing_cane",
-    "accessibility"
+    "accessibility",
+    "blind",
+    "white"
   ],
   "🔗": [
     "link",
     "rings",
-    "url"
+    "url",
+    "chain",
+    "hyperlink",
+    "linked",
+    "symbol"
   ],
   "⛓️": [
     "chains",
     "lock",
-    "arrest"
+    "arrest",
+    "chain"
   ],
   "🧰": [
     "toolbox",
@@ -8264,39 +12494,49 @@
     "diy",
     "fix",
     "maintainer",
-    "mechanic"
+    "mechanic",
+    "chest",
+    "tool"
   ],
   "🧲": [
     "magnet",
     "attraction",
-    "magnetic"
+    "magnetic",
+    "horseshoe"
   ],
   "⚗️": [
     "alembic",
     "distilling",
     "science",
     "experiment",
-    "chemistry"
+    "chemistry",
+    "tool"
   ],
   "🧪": [
     "test_tube",
     "chemistry",
     "experiment",
     "lab",
-    "science"
+    "science",
+    "chemist"
   ],
   "🧫": [
     "petri_dish",
     "bacteria",
     "biology",
     "culture",
-    "lab"
+    "lab",
+    "biologist"
   ],
   "🧬": [
     "dna",
     "biologist",
     "genetics",
-    "life"
+    "life",
+    "double",
+    "evolution",
+    "gene",
+    "helix"
   ],
   "🔬": [
     "microscope",
@@ -8304,7 +12544,10 @@
     "experiment",
     "zoomin",
     "science",
-    "study"
+    "study",
+    "investigate",
+    "magnify",
+    "tool"
   ],
   "🔭": [
     "telescope",
@@ -8312,14 +12555,18 @@
     "space",
     "zoom",
     "science",
-    "astronomy"
+    "astronomy",
+    "stargazing",
+    "tool"
   ],
   "📡": [
     "satellite_antenna",
     "communication",
     "future",
     "radio",
-    "space"
+    "space",
+    "dish",
+    "signal"
   ],
   "💉": [
     "syringe",
@@ -8330,14 +12577,25 @@
     "medicine",
     "needle",
     "doctor",
-    "nurse"
+    "nurse",
+    "shot",
+    "sick",
+    "tool",
+    "vaccination",
+    "vaccine"
   ],
   "🩸": [
     "drop_of_blood",
     "period",
     "hurt",
     "harm",
-    "wound"
+    "wound",
+    "bleed",
+    "doctor",
+    "donation",
+    "injury",
+    "medicine",
+    "menstruation"
   ],
   "💊": [
     "pill",
@@ -8345,36 +12603,57 @@
     "medicine",
     "doctor",
     "pharmacy",
-    "drug"
+    "drug",
+    "capsule",
+    "drugs",
+    "sick",
+    "tablet"
   ],
   "🩹": [
     "adhesive_bandage",
-    "heal"
+    "heal",
+    "aid",
+    "band",
+    "doctor",
+    "medicine",
+    "plaster"
   ],
   "🩺": [
     "stethoscope",
-    "health"
+    "health",
+    "doctor",
+    "heart",
+    "medicine"
   ],
   "🚪": [
     "door",
     "house",
     "entry",
-    "exit"
+    "exit",
+    "doorway",
+    "front"
   ],
   "🛏️": [
     "bed",
     "sleep",
-    "rest"
+    "rest",
+    "bedroom",
+    "hotel"
   ],
   "🛋️": [
     "couch_and_lamp",
     "read",
-    "chill"
+    "chill",
+    "hotel",
+    "lounge",
+    "settee",
+    "sofa"
   ],
   "🪑": [
     "chair",
     "sit",
-    "furniture"
+    "furniture",
+    "seat"
   ],
   "🚽": [
     "toilet",
@@ -8382,53 +12661,70 @@
     "wc",
     "washroom",
     "bathroom",
-    "potty"
+    "potty",
+    "loo"
   ],
   "🚿": [
     "shower",
     "clean",
     "water",
-    "bathroom"
+    "bathroom",
+    "bath",
+    "head"
   ],
   "🛁": [
     "bathtub",
     "clean",
     "shower",
-    "bathroom"
+    "bathroom",
+    "bath",
+    "bubble"
   ],
   "🪒": [
     "razor",
-    "cut"
+    "cut",
+    "sharp",
+    "shave"
   ],
   "🧴": [
     "lotion_bottle",
     "moisturizer",
-    "sunscreen"
+    "sunscreen",
+    "shampoo"
   ],
   "🧷": [
     "safety_pin",
-    "diaper"
+    "diaper",
+    "punk",
+    "rock"
   ],
   "🧹": [
     "broom",
     "cleaning",
     "sweeping",
-    "witch"
+    "witch",
+    "brush",
+    "sweep"
   ],
   "🧺": [
     "basket",
-    "laundry"
+    "laundry",
+    "farming",
+    "picnic"
   ],
   "🧻": [
     "roll_of_paper",
-    "roll"
+    "roll",
+    "toilet",
+    "towels"
   ],
   "🧼": [
     "soap",
     "bar",
     "bathing",
     "cleaning",
-    "lather"
+    "lather",
+    "soapdish"
   ],
   "🧽": [
     "sponge",
@@ -8438,7 +12734,8 @@
   ],
   "🧯": [
     "fire_extinguisher",
-    "quench"
+    "quench",
+    "extinguish"
   ],
   "🛒": [
     "shopping_cart",
@@ -8449,7 +12746,10 @@
     "kills",
     "tobacco",
     "joint",
-    "smoke"
+    "smoke",
+    "activity",
+    "smoking",
+    "symbol"
   ],
   "⚰️": [
     "coffin",
@@ -8470,12 +12770,19 @@
     "die",
     "death",
     "rip",
-    "ashes"
+    "ashes",
+    "vase"
   ],
   "🗿": [
     "moai",
     "rock",
-    "easter island"
+    "easter island",
+    "carving",
+    "face",
+    "human",
+    "moyai",
+    "statue",
+    "stone"
   ],
   "🏧": [
     "atm_sign",
@@ -8484,14 +12791,24 @@
     "cash",
     "blue-square",
     "payment",
-    "bank"
+    "bank",
+    "automated",
+    "machine",
+    "teller"
   ],
   "🚮": [
     "litter_in_bin_sign",
     "blue-square",
     "sign",
     "human",
-    "info"
+    "info",
+    "its",
+    "litterbox",
+    "person",
+    "place",
+    "put",
+    "symbol",
+    "trash"
   ],
   "🚰": [
     "potable_water",
@@ -8499,13 +12816,22 @@
     "liquid",
     "restroom",
     "cleaning",
-    "faucet"
+    "faucet",
+    "drink",
+    "drinking",
+    "symbol",
+    "tap",
+    "thirst",
+    "thirsty"
   ],
   "♿": [
     "wheelchair_symbol",
     "blue-square",
     "disabled",
-    "accessibility"
+    "accessibility",
+    "access",
+    "accessible",
+    "bathroom"
   ],
   "🚹": [
     "men_s_room",
@@ -8514,7 +12840,12 @@
     "wc",
     "blue-square",
     "gender",
-    "male"
+    "male",
+    "lavatory",
+    "man",
+    "mens",
+    "men’s",
+    "symbol"
   ],
   "🚺": [
     "women_s_room",
@@ -8524,7 +12855,13 @@
     "toilet",
     "loo",
     "restroom",
-    "gender"
+    "gender",
+    "lavatory",
+    "symbol",
+    "wc",
+    "womens",
+    "womens toilet",
+    "women’s"
   ],
   "🚻": [
     "restroom",
@@ -8532,23 +12869,33 @@
     "toilet",
     "refresh",
     "wc",
-    "gender"
+    "gender",
+    "bathroom",
+    "lavatory",
+    "sign"
   ],
   "🚼": [
     "baby_symbol",
     "orange-square",
-    "child"
+    "child",
+    "change",
+    "changing",
+    "nursery",
+    "station"
   ],
   "🚾": [
     "water_closet",
     "toilet",
     "restroom",
-    "blue-square"
+    "blue-square",
+    "lavatory",
+    "wc"
   ],
   "🛂": [
     "passport_control",
     "custom",
-    "blue-square"
+    "blue-square",
+    "border"
   ],
   "🛃": [
     "customs",
@@ -8565,7 +12912,13 @@
   "🛅": [
     "left_luggage",
     "blue-square",
-    "travel"
+    "travel",
+    "baggage",
+    "bag with",
+    "key",
+    "locked",
+    "locker",
+    "suitcase"
   ],
   "⚠️": [
     "warning",
@@ -8574,7 +12927,9 @@
     "alert",
     "error",
     "problem",
-    "issue"
+    "issue",
+    "sign",
+    "symbol"
   ],
   "🚸": [
     "children_crossing",
@@ -8583,7 +12938,11 @@
     "danger",
     "sign",
     "driving",
-    "yellow-diamond"
+    "yellow-diamond",
+    "child",
+    "kids",
+    "pedestrian",
+    "traffic"
   ],
   "⛔": [
     "no_entry",
@@ -8593,7 +12952,11 @@
     "bad",
     "denied",
     "stop",
-    "circle"
+    "circle",
+    "forbidden",
+    "not",
+    "prohibited",
+    "traffic"
   ],
   "🚫": [
     "prohibited",
@@ -8602,7 +12965,18 @@
     "limit",
     "denied",
     "disallow",
-    "circle"
+    "circle",
+    "backslash",
+    "banned",
+    "block",
+    "crossed",
+    "entry",
+    "forbidden",
+    "no",
+    "not",
+    "red",
+    "restricted",
+    "sign"
   ],
   "🚳": [
     "no_bicycles",
@@ -8611,41 +12985,75 @@
     "bike",
     "cyclist",
     "prohibited",
-    "circle"
+    "circle",
+    "forbidden",
+    "not",
+    "sign",
+    "vehicle"
   ],
   "🚭": [
     "no_smoking",
     "cigarette",
     "blue-square",
     "smell",
-    "smoke"
+    "smoke",
+    "forbidden",
+    "not",
+    "prohibited",
+    "sign",
+    "symbol"
   ],
   "🚯": [
     "no_littering",
     "trash",
     "bin",
     "garbage",
-    "circle"
+    "circle",
+    "do",
+    "forbidden",
+    "litter",
+    "not",
+    "prohibited",
+    "symbol"
   ],
   "🚱": [
     "non_potable_water",
     "drink",
     "faucet",
     "tap",
-    "circle"
+    "circle",
+    "drinking",
+    "forbidden",
+    "no",
+    "not",
+    "prohibited",
+    "symbol"
   ],
   "🚷": [
     "no_pedestrians",
     "rules",
     "crossing",
     "walking",
-    "circle"
+    "circle",
+    "forbidden",
+    "not",
+    "pedestrian",
+    "people",
+    "prohibited"
   ],
   "📵": [
     "no_mobile_phones",
     "iphone",
     "mute",
-    "circle"
+    "circle",
+    "cell",
+    "communication",
+    "forbidden",
+    "not",
+    "phone",
+    "prohibited",
+    "smartphones",
+    "telephone"
   ],
   "🔞": [
     "no_one_under_eighteen",
@@ -8654,23 +13062,41 @@
     "pub",
     "night",
     "minor",
-    "circle"
+    "circle",
+    "age",
+    "forbidden",
+    "not",
+    "nsfw",
+    "prohibited",
+    "restriction",
+    "symbol",
+    "underage"
   ],
   "☢️": [
     "radioactive",
     "nuclear",
-    "danger"
+    "danger",
+    "international",
+    "radiation",
+    "sign",
+    "symbol"
   ],
   "☣️": [
     "biohazard",
-    "danger"
+    "danger",
+    "sign"
   ],
   "⬆️": [
     "up_arrow",
     "blue-square",
     "continue",
     "top",
-    "direction"
+    "direction",
+    "black",
+    "cardinal",
+    "north",
+    "pointing",
+    "upwards"
   ],
   "↗️": [
     "up_right_arrow",
@@ -8678,38 +13104,72 @@
     "point",
     "direction",
     "diagonal",
-    "northeast"
+    "northeast",
+    "east",
+    "intercardinal",
+    "north",
+    "upper"
   ],
   "➡️": [
     "right_arrow",
     "blue-square",
-    "next"
+    "next",
+    "black",
+    "cardinal",
+    "direction",
+    "east",
+    "pointing",
+    "rightwards",
+    "right arrow"
   ],
   "↘️": [
     "down_right_arrow",
     "blue-square",
     "direction",
     "diagonal",
-    "southeast"
+    "southeast",
+    "east",
+    "intercardinal",
+    "lower",
+    "right arrow",
+    "south"
   ],
   "⬇️": [
     "down_arrow",
     "blue-square",
     "direction",
-    "bottom"
+    "bottom",
+    "black",
+    "cardinal",
+    "downwards",
+    "down arrow",
+    "pointing",
+    "south"
   ],
   "↙️": [
     "down_left_arrow",
     "blue-square",
     "direction",
     "diagonal",
-    "southwest"
+    "southwest",
+    "intercardinal",
+    "left arrow",
+    "lower",
+    "south",
+    "west"
   ],
   "⬅️": [
     "left_arrow",
     "blue-square",
     "previous",
-    "back"
+    "back",
+    "black",
+    "cardinal",
+    "direction",
+    "leftwards",
+    "left arrow",
+    "pointing",
+    "west"
   ],
   "↖️": [
     "up_left_arrow",
@@ -8717,21 +13177,31 @@
     "point",
     "direction",
     "diagonal",
-    "northwest"
+    "northwest",
+    "intercardinal",
+    "left arrow",
+    "north",
+    "upper",
+    "west"
   ],
   "↕️": [
     "up_down_arrow",
     "blue-square",
     "direction",
     "way",
-    "vertical"
+    "vertical",
+    "arrows",
+    "intercardinal",
+    "northwest"
   ],
   "↔️": [
     "left_right_arrow",
     "shape",
     "direction",
     "horizontal",
-    "sideways"
+    "sideways",
+    "arrows",
+    "horizontal arrows"
   ],
   "↩️": [
     "right_arrow_curving_left",
@@ -8739,279 +13209,475 @@
     "return",
     "blue-square",
     "undo",
-    "enter"
+    "enter",
+    "curved",
+    "email",
+    "hook",
+    "leftwards",
+    "reply"
   ],
   "↪️": [
     "left_arrow_curving_right",
     "blue-square",
     "return",
     "rotate",
-    "direction"
+    "direction",
+    "email",
+    "forward",
+    "hook",
+    "rightwards",
+    "right curved"
   ],
   "⤴️": [
     "right_arrow_curving_up",
     "blue-square",
     "direction",
-    "top"
+    "top",
+    "heading",
+    "pointing",
+    "rightwards",
+    "then",
+    "upwards"
   ],
   "⤵️": [
     "right_arrow_curving_down",
     "blue-square",
     "direction",
-    "bottom"
+    "bottom",
+    "curved",
+    "downwards",
+    "heading",
+    "pointing",
+    "rightwards",
+    "then"
   ],
   "🔃": [
     "clockwise_vertical_arrows",
     "sync",
     "cycle",
     "round",
-    "repeat"
+    "repeat",
+    "arrow",
+    "circle",
+    "downwards",
+    "open",
+    "reload",
+    "upwards"
   ],
   "🔄": [
     "counterclockwise_arrows_button",
     "blue-square",
     "sync",
-    "cycle"
+    "cycle",
+    "anticlockwise",
+    "arrow",
+    "circle",
+    "downwards",
+    "open",
+    "refresh",
+    "rotate",
+    "switch",
+    "upwards",
+    "withershins"
   ],
   "🔙": [
     "back_arrow",
     "arrow",
     "words",
-    "return"
+    "return",
+    "above",
+    "leftwards"
   ],
   "🔚": [
     "end_arrow",
     "words",
-    "arrow"
+    "arrow",
+    "above",
+    "leftwards"
   ],
   "🔛": [
     "on_arrow",
     "arrow",
-    "words"
+    "words",
+    "above",
+    "exclamation",
+    "left",
+    "mark",
+    "on!",
+    "right"
   ],
   "🔜": [
     "soon_arrow",
     "arrow",
-    "words"
+    "words",
+    "above",
+    "rightwards"
   ],
   "🔝": [
     "top_arrow",
     "words",
-    "blue-square"
+    "blue-square",
+    "above",
+    "up",
+    "upwards"
   ],
   "🛐": [
     "place_of_worship",
     "religion",
     "church",
     "temple",
-    "prayer"
+    "prayer",
+    "building",
+    "religious"
   ],
   "⚛️": [
     "atom_symbol",
     "science",
     "physics",
-    "chemistry"
+    "chemistry",
+    "atheist"
   ],
   "🕉️": [
     "om",
     "hinduism",
     "buddhism",
     "sikhism",
-    "jainism"
+    "jainism",
+    "aumkara",
+    "hindu",
+    "omkara",
+    "pranava",
+    "religion",
+    "symbol"
   ],
   "✡️": [
     "star_of_david",
-    "judaism"
+    "judaism",
+    "jew",
+    "jewish",
+    "magen",
+    "religion"
   ],
   "☸️": [
     "wheel_of_dharma",
     "hinduism",
     "buddhism",
     "sikhism",
-    "jainism"
+    "jainism",
+    "buddhist",
+    "helm",
+    "religion"
   ],
   "☯️": [
     "yin_yang",
-    "balance"
+    "balance",
+    "religion",
+    "tao",
+    "taoist"
   ],
   "✝️": [
     "latin_cross",
-    "christianity"
+    "christianity",
+    "christian",
+    "religion"
   ],
   "☦️": [
     "orthodox_cross",
     "suppedaneum",
-    "religion"
+    "religion",
+    "christian"
   ],
   "☪️": [
     "star_and_crescent",
-    "islam"
+    "islam",
+    "muslim",
+    "religion"
   ],
   "☮️": [
     "peace_symbol",
-    "hippie"
+    "hippie",
+    "sign"
   ],
   "🕎": [
     "menorah",
     "hanukkah",
     "candles",
-    "jewish"
+    "jewish",
+    "branches",
+    "candelabrum",
+    "candlestick",
+    "chanukiah",
+    "nine",
+    "religion"
   ],
   "🔯": [
     "dotted_six_pointed_star",
     "purple-square",
     "religion",
     "jewish",
-    "hexagram"
+    "hexagram",
+    "dot",
+    "fortune",
+    "middle"
   ],
   "♈": [
     "aries",
     "sign",
     "purple-square",
     "zodiac",
-    "astrology"
+    "astrology",
+    "ram"
   ],
   "♉": [
     "taurus",
     "purple-square",
     "sign",
     "zodiac",
-    "astrology"
+    "astrology",
+    "bull",
+    "ox"
   ],
   "♊": [
     "gemini",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "twins"
   ],
   "♋": [
     "cancer",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "crab"
   ],
   "♌": [
     "leo",
     "sign",
     "purple-square",
     "zodiac",
-    "astrology"
+    "astrology",
+    "lion"
   ],
   "♍": [
     "virgo",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "maiden",
+    "virgin"
   ],
   "♎": [
     "libra",
     "sign",
     "purple-square",
     "zodiac",
-    "astrology"
+    "astrology",
+    "balance",
+    "justice",
+    "scales"
   ],
   "♏": [
     "scorpio",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "scorpion",
+    "scorpius"
   ],
   "♐": [
     "sagittarius",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "archer"
   ],
   "♑": [
     "capricorn",
     "sign",
     "zodiac",
     "purple-square",
-    "astrology"
+    "astrology",
+    "goat"
   ],
   "♒": [
     "aquarius",
     "sign",
     "purple-square",
     "zodiac",
-    "astrology"
+    "astrology",
+    "bearer",
+    "water"
   ],
   "♓": [
     "pisces",
     "purple-square",
     "sign",
     "zodiac",
-    "astrology"
+    "astrology",
+    "fish"
   ],
   "⛎": [
     "ophiuchus",
     "sign",
     "purple-square",
     "constellation",
-    "astrology"
+    "astrology",
+    "bearer",
+    "serpent",
+    "snake",
+    "zodiac"
   ],
   "🔀": [
     "shuffle_tracks_button",
     "blue-square",
     "shuffle",
     "music",
-    "random"
+    "random",
+    "arrow",
+    "arrows",
+    "crossed",
+    "rightwards",
+    "symbol",
+    "twisted"
   ],
   "🔁": [
     "repeat_button",
     "loop",
-    "record"
+    "record",
+    "arrow",
+    "arrows",
+    "circle",
+    "clockwise",
+    "leftwards",
+    "open",
+    "retweet",
+    "rightwards",
+    "symbol"
   ],
   "🔂": [
     "repeat_single_button",
     "blue-square",
-    "loop"
+    "loop",
+    "arrow",
+    "arrows",
+    "circle",
+    "circled",
+    "clockwise",
+    "leftwards",
+    "number",
+    "once",
+    "one",
+    "open",
+    "overlay",
+    "rightwards",
+    "symbol",
+    "track"
   ],
   "▶️": [
     "play_button",
     "blue-square",
     "right",
     "direction",
-    "play"
+    "play",
+    "arrow",
+    "black",
+    "forward",
+    "pointing",
+    "right triangle",
+    "triangle"
   ],
   "⏩": [
     "fast_forward_button",
     "blue-square",
     "play",
     "speed",
-    "continue"
+    "continue",
+    "arrow",
+    "black",
+    "double",
+    "pointing",
+    "right",
+    "symbol",
+    "triangle"
   ],
   "⏭️": [
     "next_track_button",
     "forward",
     "next",
-    "blue-square"
+    "blue-square",
+    "arrow",
+    "bar",
+    "black",
+    "double",
+    "pointing",
+    "right",
+    "scene",
+    "skip",
+    "symbol",
+    "triangle",
+    "vertical"
   ],
   "⏯️": [
     "play_or_pause_button",
     "blue-square",
     "play",
-    "pause"
+    "pause",
+    "arrow",
+    "bar",
+    "black",
+    "double",
+    "play/pause",
+    "pointing",
+    "right",
+    "symbol",
+    "triangle",
+    "vertical"
   ],
   "◀️": [
     "reverse_button",
     "blue-square",
     "left",
-    "direction"
+    "direction",
+    "arrow",
+    "backward",
+    "black",
+    "pointing",
+    "triangle"
   ],
   "⏪": [
     "fast_reverse_button",
     "play",
-    "blue-square"
+    "blue-square",
+    "arrow",
+    "black",
+    "double",
+    "left",
+    "pointing",
+    "rewind",
+    "symbol",
+    "triangle"
   ],
   "⏮️": [
     "last_track_button",
-    "backward"
+    "backward",
+    "arrow",
+    "bar",
+    "black",
+    "double",
+    "left",
+    "pointing",
+    "previous",
+    "scene",
+    "skip",
+    "symbol",
+    "triangle",
+    "vertical"
   ],
   "🔼": [
     "upwards_button",
@@ -9020,42 +13686,76 @@
     "direction",
     "point",
     "forward",
-    "top"
+    "top",
+    "arrow",
+    "pointing",
+    "red",
+    "small",
+    "up"
   ],
   "⏫": [
     "fast_up_button",
     "blue-square",
     "direction",
-    "top"
+    "top",
+    "arrow",
+    "black",
+    "double",
+    "pointing",
+    "triangle"
   ],
   "🔽": [
     "downwards_button",
     "blue-square",
     "direction",
-    "bottom"
+    "bottom",
+    "arrow",
+    "down",
+    "pointing",
+    "red",
+    "small",
+    "triangle"
   ],
   "⏬": [
     "fast_down_button",
     "blue-square",
     "direction",
-    "bottom"
+    "bottom",
+    "arrow",
+    "black",
+    "double",
+    "pointing",
+    "triangle"
   ],
   "⏸️": [
     "pause_button",
     "pause",
-    "blue-square"
+    "blue-square",
+    "bar",
+    "double",
+    "symbol",
+    "vertical"
   ],
   "⏹️": [
     "stop_button",
-    "blue-square"
+    "blue-square",
+    "black",
+    "for",
+    "square",
+    "symbol"
   ],
   "⏺️": [
     "record_button",
-    "blue-square"
+    "blue-square",
+    "black",
+    "circle",
+    "for",
+    "symbol"
   ],
   "⏏️": [
     "eject_button",
-    "blue-square"
+    "blue-square",
+    "symbol"
   ],
   "🎦": [
     "cinema",
@@ -9065,19 +13765,33 @@
     "movie",
     "curtain",
     "stage",
-    "theater"
+    "theater",
+    "activity",
+    "camera",
+    "entertainment",
+    "movies",
+    "screen",
+    "symbol"
   ],
   "🔅": [
     "dim_button",
     "sun",
     "afternoon",
     "warm",
-    "summer"
+    "summer",
+    "brightness",
+    "decrease",
+    "low",
+    "symbol"
   ],
   "🔆": [
     "bright_button",
     "sun",
-    "light"
+    "light",
+    "brightness",
+    "high",
+    "increase",
+    "symbol"
   ],
   "📶": [
     "antenna_bars",
@@ -9088,73 +13802,136 @@
     "connection",
     "wifi",
     "bluetooth",
-    "bars"
+    "bars",
+    "bar",
+    "cell",
+    "cellular",
+    "communication",
+    "mobile",
+    "signal",
+    "stairs",
+    "strength",
+    "telephone"
   ],
   "📳": [
     "vibration_mode",
     "orange-square",
-    "phone"
+    "phone",
+    "cell",
+    "communication",
+    "heart",
+    "mobile",
+    "silent",
+    "telephone"
   ],
   "📴": [
     "mobile_phone_off",
     "mute",
     "orange-square",
     "silence",
-    "quiet"
+    "quiet",
+    "cell",
+    "communication",
+    "telephone"
   ],
   "♀️": [
     "female_sign",
     "woman",
     "women",
     "lady",
-    "girl"
+    "girl",
+    "symbol",
+    "venus"
   ],
   "♂️": [
     "male_sign",
     "man",
     "boy",
-    "men"
+    "men",
+    "mars",
+    "symbol"
   ],
   "⚕️": [
     "medical_symbol",
     "health",
-    "hospital"
+    "hospital",
+    "aesculapius",
+    "asclepius",
+    "asklepios",
+    "care",
+    "doctor",
+    "medicine",
+    "rod",
+    "snake",
+    "staff"
   ],
   "♾️": [
     "infinity",
-    "forever"
+    "forever",
+    "paper",
+    "permanent",
+    "sign",
+    "unbounded",
+    "universal"
   ],
   "♻️": [
     "recycling_symbol",
     "arrow",
     "environment",
     "garbage",
-    "trash"
+    "trash",
+    "black",
+    "green",
+    "logo",
+    "recycle",
+    "universal"
   ],
   "⚜️": [
     "fleur_de_lis",
     "decorative",
-    "scout"
+    "scout",
+    "new",
+    "orleans",
+    "saints",
+    "scouts"
   ],
   "🔱": [
     "trident_emblem",
     "weapon",
-    "spear"
+    "spear",
+    "anchor",
+    "pitchfork",
+    "ship",
+    "tool"
   ],
   "📛": [
     "name_badge",
     "fire",
-    "forbid"
+    "forbid",
+    "tag",
+    "tofu"
   ],
   "🔰": [
     "japanese_symbol_for_beginner",
     "badge",
-    "shield"
+    "shield",
+    "chevron",
+    "green",
+    "leaf",
+    "mark",
+    "shoshinsha",
+    "tool",
+    "yellow"
   ],
   "⭕": [
     "hollow_red_circle",
     "circle",
-    "round"
+    "round",
+    "correct",
+    "heavy",
+    "large",
+    "mark",
+    "o"
   ],
   "✅": [
     "check_mark_button",
@@ -9164,7 +13941,11 @@
     "vote",
     "election",
     "answer",
-    "tick"
+    "tick",
+    "green",
+    "heavy",
+    "symbol",
+    "white"
   ],
   "☑️": [
     "check_box_with_check",
@@ -9175,7 +13956,10 @@
     "vote",
     "election",
     "yes",
-    "tick"
+    "tick",
+    "ballot",
+    "checkbox",
+    "mark"
   ],
   "✔️": [
     "check_mark",
@@ -9183,12 +13967,18 @@
     "nike",
     "answer",
     "yes",
-    "tick"
+    "tick",
+    "heavy"
   ],
   "✖️": [
     "multiplication_sign",
     "math",
-    "calculation"
+    "calculation",
+    "cancel",
+    "heavy",
+    "multiply",
+    "symbol",
+    "x"
   ],
   "❌": [
     "cross_mark",
@@ -9196,14 +13986,20 @@
     "delete",
     "remove",
     "cancel",
-    "red"
+    "red",
+    "multiplication",
+    "multiply",
+    "x"
   ],
   "❎": [
     "cross_mark_button",
     "x",
     "green-square",
     "no",
-    "deny"
+    "deny",
+    "negative",
+    "square",
+    "squared"
   ],
   "➕": [
     "plus_sign",
@@ -9211,32 +14007,43 @@
     "calculation",
     "addition",
     "more",
-    "increase"
+    "increase",
+    "heavy",
+    "symbol"
   ],
   "➖": [
     "minus_sign",
     "math",
     "calculation",
     "subtract",
-    "less"
+    "less",
+    "heavy",
+    "symbol"
   ],
   "➗": [
     "division_sign",
     "divide",
     "math",
-    "calculation"
+    "calculation",
+    "heavy",
+    "symbol"
   ],
   "➰": [
     "curly_loop",
     "scribble",
     "draw",
     "shape",
-    "squiggle"
+    "squiggle",
+    "curl",
+    "curling"
   ],
   "➿": [
     "double_curly_loop",
     "tape",
-    "cassette"
+    "cassette",
+    "curl",
+    "curling",
+    "voicemail"
   ],
   "〽️": [
     "part_alternation_mark",
@@ -9245,7 +14052,9 @@
     "stats",
     "business",
     "economics",
-    "bad"
+    "bad",
+    "m",
+    "mcdonald’s"
   ],
   "✳️": [
     "eight_spoked_asterisk",
@@ -9257,7 +14066,9 @@
     "eight_pointed_star",
     "orange-square",
     "shape",
-    "polygon"
+    "polygon",
+    "black",
+    "orange"
   ],
   "❇️": [
     "sparkle",
@@ -9270,25 +14081,38 @@
   "‼️": [
     "double_exclamation_mark",
     "exclamation",
-    "surprise"
+    "surprise",
+    "bangbang",
+    "punctuation",
+    "red"
   ],
   "⁉️": [
     "exclamation_question_mark",
     "wat",
     "punctuation",
-    "surprise"
+    "surprise",
+    "interrobang",
+    "red"
   ],
   "❓": [
     "question_mark",
     "doubt",
-    "confused"
+    "confused",
+    "black",
+    "ornament",
+    "punctuation",
+    "red"
   ],
   "❔": [
     "white_question_mark",
     "doubts",
     "gray",
     "huh",
-    "confused"
+    "confused",
+    "grey",
+    "ornament",
+    "outlined",
+    "punctuation"
   ],
   "❕": [
     "white_exclamation_mark",
@@ -9296,7 +14120,10 @@
     "punctuation",
     "gray",
     "wow",
-    "warning"
+    "warning",
+    "grey",
+    "ornament",
+    "outlined"
   ],
   "❗": [
     "exclamation_mark",
@@ -9305,7 +14132,10 @@
     "surprise",
     "punctuation",
     "wow",
-    "warning"
+    "warning",
+    "bang",
+    "red",
+    "symbol"
   ],
   "〰️": [
     "wavy_dash",
@@ -9314,7 +14144,9 @@
     "moustache",
     "mustache",
     "squiggle",
-    "scribble"
+    "scribble",
+    "punctuation",
+    "wave"
   ],
   "©️": [
     "copyright",
@@ -9322,30 +14154,44 @@
     "license",
     "circle",
     "law",
-    "legal"
+    "legal",
+    "c",
+    "sign"
   ],
   "®️": [
     "registered",
     "alphabet",
-    "circle"
+    "circle",
+    "r",
+    "sign"
   ],
   "™️": [
     "trade_mark",
     "trademark",
     "brand",
     "law",
-    "legal"
+    "legal",
+    "sign",
+    "tm"
   ],
   "#️⃣": [
     "keycap_",
     "symbol",
     "blue-square",
-    "twitter"
+    "twitter",
+    "hash",
+    "hashtag",
+    "key",
+    "number",
+    "octothorpe",
+    "pound",
+    "sign"
   ],
   "*️⃣": [
     "keycap_",
     "star",
-    "keycap"
+    "keycap",
+    "asterisk"
   ],
   "0️⃣": [
     "keycap_0",
@@ -9353,14 +14199,16 @@
     "numbers",
     "blue-square",
     "null",
-    "zero"
+    "zero",
+    "digit"
   ],
   "1️⃣": [
     "keycap_1",
     "blue-square",
     "numbers",
     "1",
-    "one"
+    "one",
+    "digit"
   ],
   "2️⃣": [
     "keycap_2",
@@ -9368,7 +14216,8 @@
     "2",
     "prime",
     "blue-square",
-    "two"
+    "two",
+    "digit"
   ],
   "3️⃣": [
     "keycap_3",
@@ -9376,14 +14225,16 @@
     "numbers",
     "prime",
     "blue-square",
-    "three"
+    "three",
+    "digit"
   ],
   "4️⃣": [
     "keycap_4",
     "4",
     "numbers",
     "blue-square",
-    "four"
+    "four",
+    "digit"
   ],
   "5️⃣": [
     "keycap_5",
@@ -9391,14 +14242,16 @@
     "numbers",
     "blue-square",
     "prime",
-    "five"
+    "five",
+    "digit"
   ],
   "6️⃣": [
     "keycap_6",
     "6",
     "numbers",
     "blue-square",
-    "six"
+    "six",
+    "digit"
   ],
   "7️⃣": [
     "keycap_7",
@@ -9406,28 +14259,32 @@
     "numbers",
     "blue-square",
     "prime",
-    "seven"
+    "seven",
+    "digit"
   ],
   "8️⃣": [
     "keycap_8",
     "8",
     "blue-square",
     "numbers",
-    "eight"
+    "eight",
+    "digit"
   ],
   "9️⃣": [
     "keycap_9",
     "blue-square",
     "numbers",
     "9",
-    "nine"
+    "nine",
+    "digit"
   ],
   "🔟": [
     "keycap_10",
     "numbers",
     "10",
     "blue-square",
-    "ten"
+    "ten",
+    "number"
   ],
   "🔠": [
     "input_latin_uppercase",
@@ -9435,14 +14292,22 @@
     "words",
     "letters",
     "uppercase",
-    "blue-square"
+    "blue-square",
+    "abcd",
+    "capital",
+    "for",
+    "symbol"
   ],
   "🔡": [
     "input_latin_lowercase",
     "blue-square",
     "letters",
     "lowercase",
-    "alphabet"
+    "alphabet",
+    "abcd",
+    "for",
+    "small",
+    "symbol"
   ],
   "🔢": [
     "input_numbers",
@@ -9452,7 +14317,10 @@
     "1",
     "2",
     "3",
-    "4"
+    "4",
+    "for",
+    "numeric",
+    "symbol"
   ],
   "🔣": [
     "input_symbols",
@@ -9462,95 +14330,163 @@
     "ampersand",
     "percent",
     "glyphs",
-    "characters"
+    "characters",
+    "for",
+    "symbol",
+    "symbol input"
   ],
   "🔤": [
     "input_latin_letters",
     "blue-square",
-    "alphabet"
+    "alphabet",
+    "abc",
+    "for",
+    "symbol"
   ],
   "🅰️": [
     "a_button",
     "red-square",
     "alphabet",
-    "letter"
+    "letter",
+    "blood",
+    "capital",
+    "latin",
+    "negative",
+    "squared",
+    "type"
   ],
   "🆎": [
     "ab_button",
     "red-square",
-    "alphabet"
+    "alphabet",
+    "blood",
+    "negative",
+    "squared",
+    "type"
   ],
   "🅱️": [
     "b_button",
     "red-square",
     "alphabet",
-    "letter"
+    "letter",
+    "blood",
+    "capital",
+    "latin",
+    "negative",
+    "squared",
+    "type"
   ],
   "🆑": [
     "cl_button",
     "alphabet",
     "words",
-    "red-square"
+    "red-square",
+    "clear",
+    "sign",
+    "squared"
   ],
   "🆒": [
     "cool_button",
     "words",
-    "blue-square"
+    "blue-square",
+    "sign",
+    "square",
+    "squared"
   ],
   "🆓": [
     "free_button",
     "blue-square",
-    "words"
+    "words",
+    "sign",
+    "squared"
   ],
   "ℹ️": [
     "information",
     "blue-square",
     "alphabet",
-    "letter"
+    "letter",
+    "i",
+    "info",
+    "lowercase",
+    "source",
+    "tourist"
   ],
   "🆔": [
     "id_button",
     "purple-square",
-    "words"
+    "words",
+    "identification",
+    "identity",
+    "sign",
+    "squared"
   ],
   "Ⓜ️": [
     "circled_m",
     "alphabet",
     "blue-circle",
-    "letter"
+    "letter",
+    "capital",
+    "circle",
+    "latin",
+    "metro"
   ],
   "🆕": [
     "new_button",
     "blue-square",
     "words",
-    "start"
+    "start",
+    "fresh",
+    "sign",
+    "squared"
   ],
   "🆖": [
     "ng_button",
     "blue-square",
     "words",
     "shape",
-    "icon"
+    "icon",
+    "blooper",
+    "good",
+    "no",
+    "sign",
+    "squared"
   ],
   "🅾️": [
     "o_button",
     "alphabet",
     "red-square",
-    "letter"
+    "letter",
+    "blood",
+    "capital",
+    "latin",
+    "negative",
+    "o2",
+    "squared",
+    "type"
   ],
   "🆗": [
     "ok_button",
     "good",
     "agree",
     "yes",
-    "blue-square"
+    "blue-square",
+    "okay",
+    "sign",
+    "square",
+    "squared"
   ],
   "🅿️": [
     "p_button",
     "cars",
     "blue-square",
     "alphabet",
-    "letter"
+    "letter",
+    "capital",
+    "latin",
+    "negative",
+    "parking",
+    "sign",
+    "squared"
   ],
   "🆘": [
     "sos_button",
@@ -9558,18 +14494,30 @@
     "red-square",
     "words",
     "emergency",
-    "911"
+    "911",
+    "distress",
+    "sign",
+    "signal",
+    "squared"
   ],
   "🆙": [
     "up_button",
     "blue-square",
     "above",
-    "high"
+    "high",
+    "exclamation",
+    "level",
+    "mark",
+    "sign",
+    "squared",
+    "up!"
   ],
   "🆚": [
     "vs_button",
     "words",
-    "orange-square"
+    "orange-square",
+    "squared",
+    "versus"
   ],
   "🈁": [
     "japanese_here_button",
@@ -9577,13 +14525,27 @@
     "here",
     "katakana",
     "japanese",
-    "destination"
+    "destination",
+    "koko",
+    "meaning",
+    "sign",
+    "squared",
+    "word",
+    "“here”"
   ],
   "🈂️": [
     "japanese_service_charge_button",
     "japanese",
     "blue-square",
-    "katakana"
+    "katakana",
+    "charge”",
+    "meaning",
+    "or",
+    "sa",
+    "sign",
+    "squared",
+    "“service",
+    "“service”"
   ],
   "🈷️": [
     "japanese_monthly_amount_button",
@@ -9592,21 +14554,51 @@
     "moon",
     "japanese",
     "orange-square",
-    "kanji"
+    "kanji",
+    "amount”",
+    "cjk",
+    "ideograph",
+    "meaning",
+    "radical",
+    "sign",
+    "squared",
+    "u6708",
+    "unified",
+    "“monthly"
   ],
   "🈶": [
     "japanese_not_free_of_charge_button",
     "orange-square",
     "chinese",
     "have",
-    "kanji"
+    "kanji",
+    "charge”",
+    "cjk",
+    "exist",
+    "ideograph",
+    "meaning",
+    "own",
+    "sign",
+    "squared",
+    "u6709",
+    "unified",
+    "“not"
   ],
   "🈯": [
     "japanese_reserved_button",
     "chinese",
     "point",
     "green-square",
-    "kanji"
+    "kanji",
+    "cjk",
+    "finger",
+    "ideograph",
+    "meaning",
+    "sign",
+    "squared",
+    "u6307",
+    "unified",
+    "“reserved”"
   ],
   "🉐": [
     "japanese_bargain_button",
@@ -9614,7 +14606,14 @@
     "kanji",
     "obtain",
     "get",
-    "circle"
+    "circle",
+    "acquire",
+    "advantage",
+    "circled",
+    "ideograph",
+    "meaning",
+    "sign",
+    "“bargain”"
   ],
   "🈹": [
     "japanese_discount_button",
@@ -9622,7 +14621,17 @@
     "divide",
     "chinese",
     "kanji",
-    "pink-square"
+    "pink-square",
+    "bargain",
+    "cjk",
+    "ideograph",
+    "meaning",
+    "sale",
+    "sign",
+    "squared",
+    "u5272",
+    "unified",
+    "“discount”"
   ],
   "🈚": [
     "japanese_free_of_charge_button",
@@ -9630,7 +14639,18 @@
     "chinese",
     "kanji",
     "japanese",
-    "orange-square"
+    "orange-square",
+    "charge”",
+    "cjk",
+    "ideograph",
+    "lacking",
+    "meaning",
+    "negation",
+    "sign",
+    "squared",
+    "u7121",
+    "unified",
+    "“free"
   ],
   "🈲": [
     "japanese_prohibited_button",
@@ -9640,7 +14660,17 @@
     "forbidden",
     "limit",
     "restricted",
-    "red-square"
+    "red-square",
+    "cjk",
+    "forbid",
+    "ideograph",
+    "meaning",
+    "prohibit",
+    "sign",
+    "squared",
+    "u7981",
+    "unified",
+    "“prohibited”"
   ],
   "🉑": [
     "japanese_acceptable_button",
@@ -9650,14 +14680,32 @@
     "kanji",
     "agree",
     "yes",
-    "orange-circle"
+    "orange-circle",
+    "accept",
+    "circled",
+    "ideograph",
+    "meaning",
+    "sign",
+    "“acceptable”"
   ],
   "🈸": [
     "japanese_application_button",
     "chinese",
     "japanese",
     "kanji",
-    "orange-square"
+    "orange-square",
+    "apply",
+    "cjk",
+    "form",
+    "ideograph",
+    "meaning",
+    "monkey",
+    "request",
+    "sign",
+    "squared",
+    "u7533",
+    "unified",
+    "“application”"
   ],
   "🈴": [
     "japanese_passing_grade_button",
@@ -9665,7 +14713,18 @@
     "chinese",
     "join",
     "kanji",
-    "red-square"
+    "red-square",
+    "agreement",
+    "cjk",
+    "grade”",
+    "ideograph",
+    "meaning",
+    "sign",
+    "squared",
+    "together",
+    "u5408",
+    "unified",
+    "“passing"
   ],
   "🈳": [
     "japanese_vacancy_button",
@@ -9674,14 +14733,31 @@
     "chinese",
     "empty",
     "sky",
-    "blue-square"
+    "blue-square",
+    "7a7a",
+    "available",
+    "cjk",
+    "ideograph",
+    "meaning",
+    "sign",
+    "squared",
+    "u7a7a",
+    "unified",
+    "“vacancy”"
   ],
   "㊗️": [
     "japanese_congratulations_button",
     "chinese",
     "kanji",
     "japanese",
-    "red-circle"
+    "red-circle",
+    "circled",
+    "congratulate",
+    "congratulation",
+    "ideograph",
+    "meaning",
+    "sign",
+    "“congratulations”"
   ],
   "㊙️": [
     "japanese_secret_button",
@@ -9689,13 +14765,31 @@
     "chinese",
     "sshh",
     "kanji",
-    "red-circle"
+    "red-circle",
+    "circled",
+    "ideograph",
+    "meaning",
+    "sign",
+    "“secret”"
   ],
   "🈺": [
     "japanese_open_for_business_button",
     "japanese",
     "opening hours",
-    "orange-square"
+    "orange-square",
+    "55b6",
+    "business”",
+    "chinese",
+    "cjk",
+    "ideograph",
+    "meaning",
+    "operating",
+    "sign",
+    "squared",
+    "u55b6",
+    "unified",
+    "work",
+    "“open"
   ],
   "🈵": [
     "japanese_no_vacancy_button",
@@ -9703,156 +14797,220 @@
     "chinese",
     "japanese",
     "red-square",
-    "kanji"
+    "kanji",
+    "6e80",
+    "cjk",
+    "fullness",
+    "ideograph",
+    "meaning",
+    "sign",
+    "squared",
+    "u6e80",
+    "unified",
+    "vacancy”",
+    "“full;",
+    "“no"
   ],
   "🔴": [
     "red_circle",
     "shape",
     "error",
-    "danger"
+    "danger",
+    "geometric",
+    "large"
   ],
   "🟠": [
     "orange_circle",
-    "round"
+    "round",
+    "geometric",
+    "large"
   ],
   "🟡": [
     "yellow_circle",
-    "round"
+    "round",
+    "geometric",
+    "large"
   ],
   "🟢": [
     "green_circle",
-    "round"
+    "round",
+    "geometric",
+    "large"
   ],
   "🔵": [
     "blue_circle",
     "shape",
     "icon",
-    "button"
+    "button",
+    "geometric",
+    "large"
   ],
   "🟣": [
     "purple_circle",
-    "round"
+    "round",
+    "geometric",
+    "large"
   ],
   "🟤": [
     "brown_circle",
-    "round"
+    "round",
+    "geometric",
+    "large"
   ],
   "⚫": [
     "black_circle",
     "shape",
     "button",
-    "round"
+    "round",
+    "geometric",
+    "medium"
   ],
   "⚪": [
     "white_circle",
     "shape",
-    "round"
+    "round",
+    "geometric",
+    "medium"
   ],
   "🟥": [
-    "red_square"
+    "red_square",
+    "card",
+    "geometric",
+    "large"
   ],
   "🟧": [
-    "orange_square"
+    "orange_square",
+    "geometric",
+    "large"
   ],
   "🟨": [
-    "yellow_square"
+    "yellow_square",
+    "card",
+    "geometric",
+    "large"
   ],
   "🟩": [
-    "green_square"
+    "green_square",
+    "geometric",
+    "large"
   ],
   "🟦": [
-    "blue_square"
+    "blue_square",
+    "geometric",
+    "large"
   ],
   "🟪": [
-    "purple_square"
+    "purple_square",
+    "geometric",
+    "large"
   ],
   "🟫": [
-    "brown_square"
+    "brown_square",
+    "geometric",
+    "large"
   ],
   "⬛": [
     "black_large_square",
     "shape",
     "icon",
-    "button"
+    "button",
+    "geometric"
   ],
   "⬜": [
     "white_large_square",
     "shape",
     "icon",
     "stone",
-    "button"
+    "button",
+    "geometric"
   ],
   "◼️": [
     "black_medium_square",
     "shape",
     "button",
-    "icon"
+    "icon",
+    "geometric"
   ],
   "◻️": [
     "white_medium_square",
     "shape",
     "stone",
-    "icon"
+    "icon",
+    "geometric"
   ],
   "◾": [
     "black_medium_small_square",
     "icon",
     "shape",
-    "button"
+    "button",
+    "geometric"
   ],
   "◽": [
     "white_medium_small_square",
     "shape",
     "stone",
     "icon",
-    "button"
+    "button",
+    "geometric"
   ],
   "▪️": [
     "black_small_square",
     "shape",
-    "icon"
+    "icon",
+    "geometric"
   ],
   "▫️": [
     "white_small_square",
     "shape",
-    "icon"
+    "icon",
+    "geometric"
   ],
   "🔶": [
     "large_orange_diamond",
     "shape",
     "jewel",
-    "gem"
+    "gem",
+    "geometric"
   ],
   "🔷": [
     "large_blue_diamond",
     "shape",
     "jewel",
-    "gem"
+    "gem",
+    "geometric"
   ],
   "🔸": [
     "small_orange_diamond",
     "shape",
     "jewel",
-    "gem"
+    "gem",
+    "geometric"
   ],
   "🔹": [
     "small_blue_diamond",
     "shape",
     "jewel",
-    "gem"
+    "gem",
+    "geometric"
   ],
   "🔺": [
     "red_triangle_pointed_up",
     "shape",
     "direction",
     "up",
-    "top"
+    "top",
+    "geometric",
+    "pointing",
+    "small"
   ],
   "🔻": [
     "red_triangle_pointed_down",
     "shape",
     "direction",
-    "bottom"
+    "bottom",
+    "geometric",
+    "pointing",
+    "small"
   ],
   "💠": [
     "diamond_with_a_dot",
@@ -9860,49 +15018,75 @@
     "blue",
     "gem",
     "crystal",
-    "fancy"
+    "fancy",
+    "comic",
+    "cuteness",
+    "flower",
+    "geometric",
+    "inside",
+    "kawaii",
+    "shape"
   ],
   "🔘": [
     "radio_button",
     "input",
     "old",
     "music",
-    "circle"
+    "circle",
+    "geometric"
   ],
   "🔳": [
     "white_square_button",
     "shape",
-    "input"
+    "input",
+    "geometric",
+    "outlined"
   ],
   "🔲": [
     "black_square_button",
     "shape",
     "input",
-    "frame"
+    "frame",
+    "geometric"
   ],
   "🏁": [
     "chequered_flag",
     "contest",
     "finishline",
     "race",
-    "gokart"
+    "gokart",
+    "checkered",
+    "finish",
+    "girl",
+    "grid",
+    "milestone",
+    "racing"
   ],
   "🚩": [
     "triangular_flag",
     "mark",
     "milestone",
-    "place"
+    "place",
+    "pole",
+    "post",
+    "red"
   ],
   "🎌": [
     "crossed_flags",
     "japanese",
     "nation",
     "country",
-    "border"
+    "border",
+    "activity",
+    "celebration",
+    "cross",
+    "flag",
+    "two"
   ],
   "🏴": [
     "black_flag",
-    "pirate"
+    "pirate",
+    "waving"
   ],
   "🏳️": [
     "white_flag",
@@ -9911,7 +15095,8 @@
     "lost",
     "surrender",
     "give up",
-    "fail"
+    "fail",
+    "waving"
   ],
   "🏳️‍🌈": [
     "rainbow_flag",
@@ -9930,7 +15115,11 @@
     "skull",
     "crossbones",
     "flag",
-    "banner"
+    "banner",
+    "jolly",
+    "plunder",
+    "roger",
+    "treasure"
   ],
   "🇦🇨": [
     "flag_ascension_island"
@@ -9942,7 +15131,8 @@
     "nation",
     "country",
     "banner",
-    "andorra"
+    "andorra",
+    "andorran"
   ],
   "🇦🇪": [
     "flag_united_arab_emirates",
@@ -9953,7 +15143,9 @@
     "nation",
     "country",
     "banner",
-    "united_arab_emirates"
+    "united_arab_emirates",
+    "emirati",
+    "uae"
   ],
   "🇦🇫": [
     "flag_afghanistan",
@@ -9962,7 +15154,8 @@
     "nation",
     "country",
     "banner",
-    "afghanistan"
+    "afghanistan",
+    "afghan"
   ],
   "🇦🇬": [
     "flag_antigua_barbuda",
@@ -9981,7 +15174,8 @@
     "nation",
     "country",
     "banner",
-    "anguilla"
+    "anguilla",
+    "anguillan"
   ],
   "🇦🇱": [
     "flag_albania",
@@ -9990,7 +15184,8 @@
     "nation",
     "country",
     "banner",
-    "albania"
+    "albania",
+    "albanian"
   ],
   "🇦🇲": [
     "flag_armenia",
@@ -9999,7 +15194,8 @@
     "nation",
     "country",
     "banner",
-    "armenia"
+    "armenia",
+    "armenian"
   ],
   "🇦🇴": [
     "flag_angola",
@@ -10008,7 +15204,8 @@
     "nation",
     "country",
     "banner",
-    "angola"
+    "angola",
+    "angolan"
   ],
   "🇦🇶": [
     "flag_antarctica",
@@ -10017,7 +15214,8 @@
     "nation",
     "country",
     "banner",
-    "antarctica"
+    "antarctica",
+    "antarctic"
   ],
   "🇦🇷": [
     "flag_argentina",
@@ -10026,7 +15224,8 @@
     "nation",
     "country",
     "banner",
-    "argentina"
+    "argentina",
+    "argentinian"
   ],
   "🇦🇸": [
     "flag_american_samoa",
@@ -10036,7 +15235,8 @@
     "nation",
     "country",
     "banner",
-    "american_samoa"
+    "american_samoa",
+    "samoan"
   ],
   "🇦🇹": [
     "flag_austria",
@@ -10045,7 +15245,8 @@
     "nation",
     "country",
     "banner",
-    "austria"
+    "austria",
+    "austrian"
   ],
   "🇦🇺": [
     "flag_australia",
@@ -10054,7 +15255,11 @@
     "nation",
     "country",
     "banner",
-    "australia"
+    "australia",
+    "aussie",
+    "australian",
+    "heard",
+    "mcdonald"
   ],
   "🇦🇼": [
     "flag_aruba",
@@ -10063,7 +15268,8 @@
     "nation",
     "country",
     "banner",
-    "aruba"
+    "aruba",
+    "aruban"
   ],
   "🇦🇽": [
     "flag_aland_islands",
@@ -10082,7 +15288,8 @@
     "nation",
     "country",
     "banner",
-    "azerbaijan"
+    "azerbaijan",
+    "azerbaijani"
   ],
   "🇧🇦": [
     "flag_bosnia_herzegovina",
@@ -10101,7 +15308,9 @@
     "nation",
     "country",
     "banner",
-    "barbados"
+    "barbados",
+    "bajan",
+    "barbadian"
   ],
   "🇧🇩": [
     "flag_bangladesh",
@@ -10110,7 +15319,8 @@
     "nation",
     "country",
     "banner",
-    "bangladesh"
+    "bangladesh",
+    "bangladeshi"
   ],
   "🇧🇪": [
     "flag_belgium",
@@ -10119,7 +15329,8 @@
     "nation",
     "country",
     "banner",
-    "belgium"
+    "belgium",
+    "belgian"
   ],
   "🇧🇫": [
     "flag_burkina_faso",
@@ -10129,7 +15340,8 @@
     "nation",
     "country",
     "banner",
-    "burkina_faso"
+    "burkina_faso",
+    "burkinabe"
   ],
   "🇧🇬": [
     "flag_bulgaria",
@@ -10138,7 +15350,8 @@
     "nation",
     "country",
     "banner",
-    "bulgaria"
+    "bulgaria",
+    "bulgarian"
   ],
   "🇧🇭": [
     "flag_bahrain",
@@ -10147,7 +15360,9 @@
     "nation",
     "country",
     "banner",
-    "bahrain"
+    "bahrain",
+    "bahrainian",
+    "bahrani"
   ],
   "🇧🇮": [
     "flag_burundi",
@@ -10156,7 +15371,8 @@
     "nation",
     "country",
     "banner",
-    "burundi"
+    "burundi",
+    "burundian"
   ],
   "🇧🇯": [
     "flag_benin",
@@ -10165,7 +15381,8 @@
     "nation",
     "country",
     "banner",
-    "benin"
+    "benin",
+    "beninese"
   ],
   "🇧🇱": [
     "flag_st_barthelemy",
@@ -10175,7 +15392,8 @@
     "nation",
     "country",
     "banner",
-    "st_barthelemy"
+    "st_barthelemy",
+    "st."
   ],
   "🇧🇲": [
     "flag_bermuda",
@@ -10184,7 +15402,8 @@
     "nation",
     "country",
     "banner",
-    "bermuda"
+    "bermuda",
+    "bermudan flag"
   ],
   "🇧🇳": [
     "flag_brunei",
@@ -10194,7 +15413,8 @@
     "nation",
     "country",
     "banner",
-    "brunei"
+    "brunei",
+    "bruneian"
   ],
   "🇧🇴": [
     "flag_bolivia",
@@ -10203,7 +15423,8 @@
     "nation",
     "country",
     "banner",
-    "bolivia"
+    "bolivia",
+    "bolivian"
   ],
   "🇧🇶": [
     "flag_caribbean_netherlands",
@@ -10212,7 +15433,10 @@
     "nation",
     "country",
     "banner",
-    "caribbean_netherlands"
+    "caribbean_netherlands",
+    "eustatius",
+    "saba",
+    "sint"
   ],
   "🇧🇷": [
     "flag_brazil",
@@ -10221,7 +15445,10 @@
     "nation",
     "country",
     "banner",
-    "brazil"
+    "brazil",
+    "brasil",
+    "brazilian",
+    "for"
   ],
   "🇧🇸": [
     "flag_bahamas",
@@ -10230,7 +15457,8 @@
     "nation",
     "country",
     "banner",
-    "bahamas"
+    "bahamas",
+    "bahamian"
   ],
   "🇧🇹": [
     "flag_bhutan",
@@ -10239,7 +15467,8 @@
     "nation",
     "country",
     "banner",
-    "bhutan"
+    "bhutan",
+    "bhutanese"
   ],
   "🇧🇻": [
     "flag_bouvet_island",
@@ -10252,7 +15481,8 @@
     "nation",
     "country",
     "banner",
-    "botswana"
+    "botswana",
+    "batswana"
   ],
   "🇧🇾": [
     "flag_belarus",
@@ -10261,7 +15491,8 @@
     "nation",
     "country",
     "banner",
-    "belarus"
+    "belarus",
+    "belarusian"
   ],
   "🇧🇿": [
     "flag_belize",
@@ -10270,7 +15501,8 @@
     "nation",
     "country",
     "banner",
-    "belize"
+    "belize",
+    "belizean"
   ],
   "🇨🇦": [
     "flag_canada",
@@ -10279,7 +15511,8 @@
     "nation",
     "country",
     "banner",
-    "canada"
+    "canada",
+    "canadian"
   ],
   "🇨🇨": [
     "flag_cocos_islands",
@@ -10290,7 +15523,8 @@
     "nation",
     "country",
     "banner",
-    "cocos_islands"
+    "cocos_islands",
+    "island"
   ],
   "🇨🇩": [
     "flag_congo_kinshasa",
@@ -10301,7 +15535,8 @@
     "nation",
     "country",
     "banner",
-    "congo_kinshasa"
+    "congo_kinshasa",
+    "drc"
   ],
   "🇨🇫": [
     "flag_central_african_republic",
@@ -10321,7 +15556,8 @@
     "nation",
     "country",
     "banner",
-    "congo_brazzaville"
+    "congo_brazzaville",
+    "republic"
   ],
   "🇨🇭": [
     "flag_switzerland",
@@ -10330,7 +15566,10 @@
     "nation",
     "country",
     "banner",
-    "switzerland"
+    "switzerland",
+    "cross",
+    "red",
+    "swiss"
   ],
   "🇨🇮": [
     "flag_cote_d_ivoire",
@@ -10340,7 +15579,10 @@
     "nation",
     "country",
     "banner",
-    "cote_d_ivoire"
+    "cote_d_ivoire",
+    "côte",
+    "divoire",
+    "d’ivoire"
   ],
   "🇨🇰": [
     "flag_cook_islands",
@@ -10350,7 +15592,9 @@
     "nation",
     "country",
     "banner",
-    "cook_islands"
+    "cook_islands",
+    "island",
+    "islander"
   ],
   "🇨🇱": [
     "flag_chile",
@@ -10358,7 +15602,8 @@
     "nation",
     "country",
     "banner",
-    "chile"
+    "chile",
+    "chilean"
   ],
   "🇨🇲": [
     "flag_cameroon",
@@ -10367,7 +15612,8 @@
     "nation",
     "country",
     "banner",
-    "cameroon"
+    "cameroon",
+    "cameroonian"
   ],
   "🇨🇳": [
     "flag_china",
@@ -10377,7 +15623,12 @@
     "flag",
     "country",
     "nation",
-    "banner"
+    "banner",
+    "cn",
+    "indicator",
+    "letters",
+    "regional",
+    "symbol"
   ],
   "🇨🇴": [
     "flag_colombia",
@@ -10386,7 +15637,8 @@
     "nation",
     "country",
     "banner",
-    "colombia"
+    "colombia",
+    "colombian"
   ],
   "🇨🇵": [
     "flag_clipperton_island"
@@ -10399,7 +15651,8 @@
     "nation",
     "country",
     "banner",
-    "costa_rica"
+    "costa_rica",
+    "rican"
   ],
   "🇨🇺": [
     "flag_cuba",
@@ -10408,7 +15661,8 @@
     "nation",
     "country",
     "banner",
-    "cuba"
+    "cuba",
+    "cuban"
   ],
   "🇨🇻": [
     "flag_cape_verde",
@@ -10418,7 +15672,8 @@
     "nation",
     "country",
     "banner",
-    "cape_verde"
+    "cape_verde",
+    "verdian"
   ],
   "🇨🇼": [
     "flag_curacao",
@@ -10427,7 +15682,9 @@
     "nation",
     "country",
     "banner",
-    "curacao"
+    "curacao",
+    "antilles",
+    "curaçaoan"
   ],
   "🇨🇽": [
     "flag_christmas_island",
@@ -10446,7 +15703,8 @@
     "nation",
     "country",
     "banner",
-    "cyprus"
+    "cyprus",
+    "cypriot"
   ],
   "🇨🇿": [
     "flag_czechia",
@@ -10455,7 +15713,9 @@
     "nation",
     "country",
     "banner",
-    "czechia"
+    "czechia",
+    "czech",
+    "republic"
   ],
   "🇩🇪": [
     "flag_germany",
@@ -10464,7 +15724,13 @@
     "flag",
     "country",
     "banner",
-    "germany"
+    "germany",
+    "de",
+    "deutsch",
+    "indicator",
+    "letters",
+    "regional",
+    "symbol"
   ],
   "🇩🇬": [
     "flag_diego_garcia"
@@ -10476,7 +15742,8 @@
     "nation",
     "country",
     "banner",
-    "djibouti"
+    "djibouti",
+    "djiboutian"
   ],
   "🇩🇰": [
     "flag_denmark",
@@ -10485,7 +15752,8 @@
     "nation",
     "country",
     "banner",
-    "denmark"
+    "denmark",
+    "danish"
   ],
   "🇩🇲": [
     "flag_dominica",
@@ -10504,7 +15772,9 @@
     "nation",
     "country",
     "banner",
-    "dominican_republic"
+    "dominican_republic",
+    "dom",
+    "rep"
   ],
   "🇩🇿": [
     "flag_algeria",
@@ -10513,7 +15783,8 @@
     "nation",
     "country",
     "banner",
-    "algeria"
+    "algeria",
+    "algerian"
   ],
   "🇪🇦": [
     "flag_ceuta_melilla"
@@ -10525,7 +15796,8 @@
     "nation",
     "country",
     "banner",
-    "ecuador"
+    "ecuador",
+    "ecuadorian"
   ],
   "🇪🇪": [
     "flag_estonia",
@@ -10534,7 +15806,8 @@
     "nation",
     "country",
     "banner",
-    "estonia"
+    "estonia",
+    "estonian"
   ],
   "🇪🇬": [
     "flag_egypt",
@@ -10543,7 +15816,8 @@
     "nation",
     "country",
     "banner",
-    "egypt"
+    "egypt",
+    "egyptian"
   ],
   "🇪🇭": [
     "flag_western_sahara",
@@ -10553,7 +15827,9 @@
     "nation",
     "country",
     "banner",
-    "western_sahara"
+    "western_sahara",
+    "saharan",
+    "west"
   ],
   "🇪🇷": [
     "flag_eritrea",
@@ -10562,7 +15838,8 @@
     "nation",
     "country",
     "banner",
-    "eritrea"
+    "eritrea",
+    "eritrean"
   ],
   "🇪🇸": [
     "flag_spain",
@@ -10570,7 +15847,15 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "ceuta",
+    "es",
+    "indicator",
+    "letters",
+    "melilla",
+    "regional",
+    "spanish",
+    "symbol"
   ],
   "🇪🇹": [
     "flag_ethiopia",
@@ -10579,14 +15864,16 @@
     "nation",
     "country",
     "banner",
-    "ethiopia"
+    "ethiopia",
+    "ethiopian"
   ],
   "🇪🇺": [
     "flag_european_union",
     "european",
     "union",
     "flag",
-    "banner"
+    "banner",
+    "eu"
   ],
   "🇫🇮": [
     "flag_finland",
@@ -10595,7 +15882,8 @@
     "nation",
     "country",
     "banner",
-    "finland"
+    "finland",
+    "finnish"
   ],
   "🇫🇯": [
     "flag_fiji",
@@ -10604,7 +15892,8 @@
     "nation",
     "country",
     "banner",
-    "fiji"
+    "fiji",
+    "fijian"
   ],
   "🇫🇰": [
     "flag_falkland_islands",
@@ -10615,7 +15904,11 @@
     "nation",
     "country",
     "banner",
-    "falkland_islands"
+    "falkland_islands",
+    "falklander",
+    "falklands",
+    "island",
+    "islas"
   ],
   "🇫🇲": [
     "flag_micronesia",
@@ -10625,7 +15918,8 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "micronesian"
   ],
   "🇫🇴": [
     "flag_faroe_islands",
@@ -10635,7 +15929,9 @@
     "nation",
     "country",
     "banner",
-    "faroe_islands"
+    "faroe_islands",
+    "island",
+    "islander"
   ],
   "🇫🇷": [
     "flag_france",
@@ -10644,7 +15940,17 @@
     "nation",
     "france",
     "french",
-    "country"
+    "country",
+    "clipperton",
+    "fr",
+    "indicator",
+    "island",
+    "letters",
+    "martin",
+    "regional",
+    "saint",
+    "st.",
+    "symbol"
   ],
   "🇬🇦": [
     "flag_gabon",
@@ -10653,7 +15959,8 @@
     "nation",
     "country",
     "banner",
-    "gabon"
+    "gabon",
+    "gabonese"
   ],
   "🇬🇧": [
     "flag_united_kingdom",
@@ -10672,7 +15979,11 @@
     "english",
     "england",
     "union jack",
-    "united_kingdom"
+    "united_kingdom",
+    "cornwall",
+    "gb",
+    "scotland",
+    "wales"
   ],
   "🇬🇩": [
     "flag_grenada",
@@ -10681,7 +15992,8 @@
     "nation",
     "country",
     "banner",
-    "grenada"
+    "grenada",
+    "grenadian"
   ],
   "🇬🇪": [
     "flag_georgia",
@@ -10690,7 +16002,8 @@
     "nation",
     "country",
     "banner",
-    "georgia"
+    "georgia",
+    "georgian"
   ],
   "🇬🇫": [
     "flag_french_guiana",
@@ -10700,7 +16013,8 @@
     "nation",
     "country",
     "banner",
-    "french_guiana"
+    "french_guiana",
+    "guinean"
   ],
   "🇬🇬": [
     "flag_guernsey",
@@ -10718,7 +16032,8 @@
     "nation",
     "country",
     "banner",
-    "ghana"
+    "ghana",
+    "ghanaian"
   ],
   "🇬🇮": [
     "flag_gibraltar",
@@ -10727,7 +16042,8 @@
     "nation",
     "country",
     "banner",
-    "gibraltar"
+    "gibraltar",
+    "gibraltarian"
   ],
   "🇬🇱": [
     "flag_greenland",
@@ -10736,7 +16052,8 @@
     "nation",
     "country",
     "banner",
-    "greenland"
+    "greenland",
+    "greenlandic"
   ],
   "🇬🇲": [
     "flag_gambia",
@@ -10745,7 +16062,8 @@
     "nation",
     "country",
     "banner",
-    "gambia"
+    "gambia",
+    "gambian flag"
   ],
   "🇬🇳": [
     "flag_guinea",
@@ -10754,7 +16072,8 @@
     "nation",
     "country",
     "banner",
-    "guinea"
+    "guinea",
+    "guinean"
   ],
   "🇬🇵": [
     "flag_guadeloupe",
@@ -10763,7 +16082,8 @@
     "nation",
     "country",
     "banner",
-    "guadeloupe"
+    "guadeloupe",
+    "guadeloupean"
   ],
   "🇬🇶": [
     "flag_equatorial_guinea",
@@ -10773,7 +16093,9 @@
     "nation",
     "country",
     "banner",
-    "equatorial_guinea"
+    "equatorial_guinea",
+    "equatoguinean",
+    "guinean"
   ],
   "🇬🇷": [
     "flag_greece",
@@ -10782,7 +16104,8 @@
     "nation",
     "country",
     "banner",
-    "greece"
+    "greece",
+    "greek"
   ],
   "🇬🇸": [
     "flag_south_georgia_south_sandwich_islands",
@@ -10794,7 +16117,8 @@
     "nation",
     "country",
     "banner",
-    "south_georgia_south_sandwich_islands"
+    "south_georgia_south_sandwich_islands",
+    "island"
   ],
   "🇬🇹": [
     "flag_guatemala",
@@ -10803,7 +16127,8 @@
     "nation",
     "country",
     "banner",
-    "guatemala"
+    "guatemala",
+    "guatemalan"
   ],
   "🇬🇺": [
     "flag_guam",
@@ -10812,7 +16137,9 @@
     "nation",
     "country",
     "banner",
-    "guam"
+    "guam",
+    "chamorro",
+    "guamanian"
   ],
   "🇬🇼": [
     "flag_guinea_bissau",
@@ -10831,7 +16158,8 @@
     "nation",
     "country",
     "banner",
-    "guyana"
+    "guyana",
+    "guyanese"
   ],
   "🇭🇰": [
     "flag_hong_kong_sar_china",
@@ -10853,7 +16181,8 @@
     "nation",
     "country",
     "banner",
-    "honduras"
+    "honduras",
+    "honduran"
   ],
   "🇭🇷": [
     "flag_croatia",
@@ -10862,7 +16191,8 @@
     "nation",
     "country",
     "banner",
-    "croatia"
+    "croatia",
+    "croatian"
   ],
   "🇭🇹": [
     "flag_haiti",
@@ -10871,7 +16201,8 @@
     "nation",
     "country",
     "banner",
-    "haiti"
+    "haiti",
+    "haitian"
   ],
   "🇭🇺": [
     "flag_hungary",
@@ -10880,7 +16211,8 @@
     "nation",
     "country",
     "banner",
-    "hungary"
+    "hungary",
+    "hungarian"
   ],
   "🇮🇨": [
     "flag_canary_islands",
@@ -10890,7 +16222,8 @@
     "nation",
     "country",
     "banner",
-    "canary_islands"
+    "canary_islands",
+    "island"
   ],
   "🇮🇩": [
     "flag_indonesia",
@@ -10898,7 +16231,8 @@
     "nation",
     "country",
     "banner",
-    "indonesia"
+    "indonesia",
+    "indonesian"
   ],
   "🇮🇪": [
     "flag_ireland",
@@ -10907,7 +16241,8 @@
     "nation",
     "country",
     "banner",
-    "ireland"
+    "ireland",
+    "irish flag"
   ],
   "🇮🇱": [
     "flag_israel",
@@ -10916,7 +16251,8 @@
     "nation",
     "country",
     "banner",
-    "israel"
+    "israel",
+    "israeli"
   ],
   "🇮🇲": [
     "flag_isle_of_man",
@@ -10926,7 +16262,8 @@
     "nation",
     "country",
     "banner",
-    "isle_of_man"
+    "isle_of_man",
+    "manx"
   ],
   "🇮🇳": [
     "flag_india",
@@ -10935,7 +16272,8 @@
     "nation",
     "country",
     "banner",
-    "india"
+    "india",
+    "indian"
   ],
   "🇮🇴": [
     "flag_british_indian_ocean_territory",
@@ -10947,7 +16285,11 @@
     "nation",
     "country",
     "banner",
-    "british_indian_ocean_territory"
+    "british_indian_ocean_territory",
+    "chagos",
+    "diego",
+    "garcia",
+    "island"
   ],
   "🇮🇶": [
     "flag_iraq",
@@ -10956,7 +16298,8 @@
     "nation",
     "country",
     "banner",
-    "iraq"
+    "iraq",
+    "iraqi"
   ],
   "🇮🇷": [
     "flag_iran",
@@ -10966,7 +16309,8 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "iranian flag"
   ],
   "🇮🇸": [
     "flag_iceland",
@@ -10975,7 +16319,8 @@
     "nation",
     "country",
     "banner",
-    "iceland"
+    "iceland",
+    "icelandic"
   ],
   "🇮🇹": [
     "flag_italy",
@@ -10983,7 +16328,12 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "indicator",
+    "italian",
+    "letters",
+    "regional",
+    "symbol"
   ],
   "🇯🇪": [
     "flag_jersey",
@@ -11001,7 +16351,8 @@
     "nation",
     "country",
     "banner",
-    "jamaica"
+    "jamaica",
+    "jamaican flag"
   ],
   "🇯🇴": [
     "flag_jordan",
@@ -11010,7 +16361,8 @@
     "nation",
     "country",
     "banner",
-    "jordan"
+    "jordan",
+    "jordanian"
   ],
   "🇯🇵": [
     "flag_japan",
@@ -11021,7 +16373,11 @@
     "banner",
     "japan",
     "jp",
-    "ja"
+    "ja",
+    "indicator",
+    "letters",
+    "regional",
+    "symbol"
   ],
   "🇰🇪": [
     "flag_kenya",
@@ -11030,7 +16386,8 @@
     "nation",
     "country",
     "banner",
-    "kenya"
+    "kenya",
+    "kenyan"
   ],
   "🇰🇬": [
     "flag_kyrgyzstan",
@@ -11039,7 +16396,8 @@
     "nation",
     "country",
     "banner",
-    "kyrgyzstan"
+    "kyrgyzstan",
+    "kyrgyzstani"
   ],
   "🇰🇭": [
     "flag_cambodia",
@@ -11048,7 +16406,8 @@
     "nation",
     "country",
     "banner",
-    "cambodia"
+    "cambodia",
+    "cambodian"
   ],
   "🇰🇮": [
     "flag_kiribati",
@@ -11057,7 +16416,8 @@
     "nation",
     "country",
     "banner",
-    "kiribati"
+    "kiribati",
+    "i"
   ],
   "🇰🇲": [
     "flag_comoros",
@@ -11066,7 +16426,8 @@
     "nation",
     "country",
     "banner",
-    "comoros"
+    "comoros",
+    "comoran"
   ],
   "🇰🇳": [
     "flag_st_kitts_nevis",
@@ -11077,7 +16438,8 @@
     "nation",
     "country",
     "banner",
-    "st_kitts_nevis"
+    "st_kitts_nevis",
+    "st."
   ],
   "🇰🇵": [
     "flag_north_korea",
@@ -11087,7 +16449,8 @@
     "flag",
     "country",
     "banner",
-    "north_korea"
+    "north_korea",
+    "korean"
   ],
   "🇰🇷": [
     "flag_south_korea",
@@ -11097,7 +16460,13 @@
     "flag",
     "country",
     "banner",
-    "south_korea"
+    "south_korea",
+    "indicator",
+    "korean",
+    "kr",
+    "letters",
+    "regional",
+    "symbol"
   ],
   "🇰🇼": [
     "flag_kuwait",
@@ -11106,7 +16475,8 @@
     "nation",
     "country",
     "banner",
-    "kuwait"
+    "kuwait",
+    "kuwaiti"
   ],
   "🇰🇾": [
     "flag_cayman_islands",
@@ -11116,7 +16486,9 @@
     "nation",
     "country",
     "banner",
-    "cayman_islands"
+    "cayman_islands",
+    "caymanian",
+    "island"
   ],
   "🇰🇿": [
     "flag_kazakhstan",
@@ -11125,7 +16497,9 @@
     "nation",
     "country",
     "banner",
-    "kazakhstan"
+    "kazakhstan",
+    "kazakh",
+    "kazakhstani"
   ],
   "🇱🇦": [
     "flag_laos",
@@ -11136,7 +16510,8 @@
     "nation",
     "country",
     "banner",
-    "laos"
+    "laos",
+    "laotian"
   ],
   "🇱🇧": [
     "flag_lebanon",
@@ -11145,7 +16520,8 @@
     "nation",
     "country",
     "banner",
-    "lebanon"
+    "lebanon",
+    "lebanese"
   ],
   "🇱🇨": [
     "flag_st_lucia",
@@ -11155,7 +16531,8 @@
     "nation",
     "country",
     "banner",
-    "st_lucia"
+    "st_lucia",
+    "st."
   ],
   "🇱🇮": [
     "flag_liechtenstein",
@@ -11164,7 +16541,8 @@
     "nation",
     "country",
     "banner",
-    "liechtenstein"
+    "liechtenstein",
+    "liechtensteiner"
   ],
   "🇱🇰": [
     "flag_sri_lanka",
@@ -11174,7 +16552,8 @@
     "nation",
     "country",
     "banner",
-    "sri_lanka"
+    "sri_lanka",
+    "lankan"
   ],
   "🇱🇷": [
     "flag_liberia",
@@ -11183,7 +16562,8 @@
     "nation",
     "country",
     "banner",
-    "liberia"
+    "liberia",
+    "liberian"
   ],
   "🇱🇸": [
     "flag_lesotho",
@@ -11192,7 +16572,8 @@
     "nation",
     "country",
     "banner",
-    "lesotho"
+    "lesotho",
+    "basotho"
   ],
   "🇱🇹": [
     "flag_lithuania",
@@ -11201,7 +16582,8 @@
     "nation",
     "country",
     "banner",
-    "lithuania"
+    "lithuania",
+    "lithuanian"
   ],
   "🇱🇺": [
     "flag_luxembourg",
@@ -11210,7 +16592,8 @@
     "nation",
     "country",
     "banner",
-    "luxembourg"
+    "luxembourg",
+    "luxembourger"
   ],
   "🇱🇻": [
     "flag_latvia",
@@ -11219,7 +16602,8 @@
     "nation",
     "country",
     "banner",
-    "latvia"
+    "latvia",
+    "latvian"
   ],
   "🇱🇾": [
     "flag_libya",
@@ -11228,7 +16612,8 @@
     "nation",
     "country",
     "banner",
-    "libya"
+    "libya",
+    "libyan"
   ],
   "🇲🇦": [
     "flag_morocco",
@@ -11237,7 +16622,8 @@
     "nation",
     "country",
     "banner",
-    "morocco"
+    "morocco",
+    "moroccan"
   ],
   "🇲🇨": [
     "flag_monaco",
@@ -11246,7 +16632,8 @@
     "nation",
     "country",
     "banner",
-    "monaco"
+    "monaco",
+    "monégasque"
   ],
   "🇲🇩": [
     "flag_moldova",
@@ -11255,7 +16642,8 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "moldovan"
   ],
   "🇲🇪": [
     "flag_montenegro",
@@ -11264,10 +16652,12 @@
     "nation",
     "country",
     "banner",
-    "montenegro"
+    "montenegro",
+    "montenegrin"
   ],
   "🇲🇫": [
-    "flag_st_martin"
+    "flag_st_martin",
+    "st."
   ],
   "🇲🇬": [
     "flag_madagascar",
@@ -11276,7 +16666,8 @@
     "nation",
     "country",
     "banner",
-    "madagascar"
+    "madagascar",
+    "madagascan"
   ],
   "🇲🇭": [
     "flag_marshall_islands",
@@ -11286,7 +16677,9 @@
     "nation",
     "country",
     "banner",
-    "marshall_islands"
+    "marshall_islands",
+    "island",
+    "marshallese"
   ],
   "🇲🇰": [
     "flag_north_macedonia",
@@ -11295,7 +16688,8 @@
     "nation",
     "country",
     "banner",
-    "north_macedonia"
+    "north_macedonia",
+    "macedonian"
   ],
   "🇲🇱": [
     "flag_mali",
@@ -11304,7 +16698,8 @@
     "nation",
     "country",
     "banner",
-    "mali"
+    "mali",
+    "malian"
   ],
   "🇲🇲": [
     "flag_myanmar",
@@ -11313,7 +16708,11 @@
     "nation",
     "country",
     "banner",
-    "myanmar"
+    "myanmar",
+    "burma",
+    "burmese",
+    "for",
+    "myanmarese flag"
   ],
   "🇲🇳": [
     "flag_mongolia",
@@ -11322,7 +16721,8 @@
     "nation",
     "country",
     "banner",
-    "mongolia"
+    "mongolia",
+    "mongolian"
   ],
   "🇲🇴": [
     "flag_macao_sar_china",
@@ -11331,7 +16731,9 @@
     "nation",
     "country",
     "banner",
-    "macao_sar_china"
+    "macao_sar_china",
+    "macanese flag",
+    "macau"
   ],
   "🇲🇵": [
     "flag_northern_mariana_islands",
@@ -11342,7 +16744,10 @@
     "nation",
     "country",
     "banner",
-    "northern_mariana_islands"
+    "northern_mariana_islands",
+    "island",
+    "micronesian",
+    "north"
   ],
   "🇲🇶": [
     "flag_martinique",
@@ -11351,7 +16756,10 @@
     "nation",
     "country",
     "banner",
-    "martinique"
+    "martinique",
+    "martiniquais flag",
+    "of martinique",
+    "snake"
   ],
   "🇲🇷": [
     "flag_mauritania",
@@ -11360,7 +16768,8 @@
     "nation",
     "country",
     "banner",
-    "mauritania"
+    "mauritania",
+    "mauritanian"
   ],
   "🇲🇸": [
     "flag_montserrat",
@@ -11369,7 +16778,8 @@
     "nation",
     "country",
     "banner",
-    "montserrat"
+    "montserrat",
+    "montserratian"
   ],
   "🇲🇹": [
     "flag_malta",
@@ -11378,7 +16788,8 @@
     "nation",
     "country",
     "banner",
-    "malta"
+    "malta",
+    "maltese"
   ],
   "🇲🇺": [
     "flag_mauritius",
@@ -11387,7 +16798,8 @@
     "nation",
     "country",
     "banner",
-    "mauritius"
+    "mauritius",
+    "mauritian"
   ],
   "🇲🇻": [
     "flag_maldives",
@@ -11396,7 +16808,8 @@
     "nation",
     "country",
     "banner",
-    "maldives"
+    "maldives",
+    "maldivian"
   ],
   "🇲🇼": [
     "flag_malawi",
@@ -11405,7 +16818,8 @@
     "nation",
     "country",
     "banner",
-    "malawi"
+    "malawi",
+    "malawian flag"
   ],
   "🇲🇽": [
     "flag_mexico",
@@ -11414,7 +16828,8 @@
     "nation",
     "country",
     "banner",
-    "mexico"
+    "mexico",
+    "mexican"
   ],
   "🇲🇾": [
     "flag_malaysia",
@@ -11423,7 +16838,8 @@
     "nation",
     "country",
     "banner",
-    "malaysia"
+    "malaysia",
+    "malaysian"
   ],
   "🇲🇿": [
     "flag_mozambique",
@@ -11432,7 +16848,8 @@
     "nation",
     "country",
     "banner",
-    "mozambique"
+    "mozambique",
+    "mozambican"
   ],
   "🇳🇦": [
     "flag_namibia",
@@ -11441,7 +16858,8 @@
     "nation",
     "country",
     "banner",
-    "namibia"
+    "namibia",
+    "namibian"
   ],
   "🇳🇨": [
     "flag_new_caledonia",
@@ -11451,7 +16869,8 @@
     "nation",
     "country",
     "banner",
-    "new_caledonia"
+    "new_caledonia",
+    "caledonian"
   ],
   "🇳🇪": [
     "flag_niger",
@@ -11460,7 +16879,8 @@
     "nation",
     "country",
     "banner",
-    "niger"
+    "niger",
+    "nigerien flag"
   ],
   "🇳🇫": [
     "flag_norfolk_island",
@@ -11478,7 +16898,8 @@
     "nation",
     "country",
     "banner",
-    "nigeria"
+    "nigeria",
+    "nigerian"
   ],
   "🇳🇮": [
     "flag_nicaragua",
@@ -11487,7 +16908,8 @@
     "nation",
     "country",
     "banner",
-    "nicaragua"
+    "nicaragua",
+    "nicaraguan"
   ],
   "🇳🇱": [
     "flag_netherlands",
@@ -11496,7 +16918,8 @@
     "nation",
     "country",
     "banner",
-    "netherlands"
+    "netherlands",
+    "dutch"
   ],
   "🇳🇴": [
     "flag_norway",
@@ -11505,7 +16928,12 @@
     "nation",
     "country",
     "banner",
-    "norway"
+    "norway",
+    "bouvet",
+    "jan",
+    "mayen",
+    "norwegian",
+    "svalbard"
   ],
   "🇳🇵": [
     "flag_nepal",
@@ -11514,7 +16942,8 @@
     "nation",
     "country",
     "banner",
-    "nepal"
+    "nepal",
+    "nepalese"
   ],
   "🇳🇷": [
     "flag_nauru",
@@ -11523,7 +16952,8 @@
     "nation",
     "country",
     "banner",
-    "nauru"
+    "nauru",
+    "nauruan"
   ],
   "🇳🇺": [
     "flag_niue",
@@ -11532,7 +16962,8 @@
     "nation",
     "country",
     "banner",
-    "niue"
+    "niue",
+    "niuean"
   ],
   "🇳🇿": [
     "flag_new_zealand",
@@ -11542,7 +16973,8 @@
     "nation",
     "country",
     "banner",
-    "new_zealand"
+    "new_zealand",
+    "kiwi"
   ],
   "🇴🇲": [
     "flag_oman",
@@ -11551,7 +16983,8 @@
     "nation",
     "country",
     "banner",
-    "oman"
+    "oman",
+    "omani"
   ],
   "🇵🇦": [
     "flag_panama",
@@ -11560,7 +16993,8 @@
     "nation",
     "country",
     "banner",
-    "panama"
+    "panama",
+    "panamanian"
   ],
   "🇵🇪": [
     "flag_peru",
@@ -11569,7 +17003,8 @@
     "nation",
     "country",
     "banner",
-    "peru"
+    "peru",
+    "peruvian"
   ],
   "🇵🇫": [
     "flag_french_polynesia",
@@ -11579,7 +17014,8 @@
     "nation",
     "country",
     "banner",
-    "french_polynesia"
+    "french_polynesia",
+    "polynesian"
   ],
   "🇵🇬": [
     "flag_papua_new_guinea",
@@ -11590,7 +17026,9 @@
     "nation",
     "country",
     "banner",
-    "papua_new_guinea"
+    "papua_new_guinea",
+    "guinean",
+    "png"
   ],
   "🇵🇭": [
     "flag_philippines",
@@ -11608,7 +17046,8 @@
     "nation",
     "country",
     "banner",
-    "pakistan"
+    "pakistan",
+    "pakistani"
   ],
   "🇵🇱": [
     "flag_poland",
@@ -11617,7 +17056,8 @@
     "nation",
     "country",
     "banner",
-    "poland"
+    "poland",
+    "polish"
   ],
   "🇵🇲": [
     "flag_st_pierre_miquelon",
@@ -11628,7 +17068,8 @@
     "nation",
     "country",
     "banner",
-    "st_pierre_miquelon"
+    "st_pierre_miquelon",
+    "st."
   ],
   "🇵🇳": [
     "flag_pitcairn_islands",
@@ -11637,7 +17078,8 @@
     "nation",
     "country",
     "banner",
-    "pitcairn_islands"
+    "pitcairn_islands",
+    "island"
   ],
   "🇵🇷": [
     "flag_puerto_rico",
@@ -11647,7 +17089,8 @@
     "nation",
     "country",
     "banner",
-    "puerto_rico"
+    "puerto_rico",
+    "rican"
   ],
   "🇵🇸": [
     "flag_palestinian_territories",
@@ -11667,7 +17110,8 @@
     "nation",
     "country",
     "banner",
-    "portugal"
+    "portugal",
+    "portugese"
   ],
   "🇵🇼": [
     "flag_palau",
@@ -11676,7 +17120,8 @@
     "nation",
     "country",
     "banner",
-    "palau"
+    "palau",
+    "palauan"
   ],
   "🇵🇾": [
     "flag_paraguay",
@@ -11685,7 +17130,8 @@
     "nation",
     "country",
     "banner",
-    "paraguay"
+    "paraguay",
+    "paraguayan"
   ],
   "🇶🇦": [
     "flag_qatar",
@@ -11694,7 +17140,8 @@
     "nation",
     "country",
     "banner",
-    "qatar"
+    "qatar",
+    "qatari"
   ],
   "🇷🇪": [
     "flag_reunion",
@@ -11703,7 +17150,8 @@
     "nation",
     "country",
     "banner",
-    "reunion"
+    "reunion",
+    "réunionnais"
   ],
   "🇷🇴": [
     "flag_romania",
@@ -11712,7 +17160,8 @@
     "nation",
     "country",
     "banner",
-    "romania"
+    "romania",
+    "romanian"
   ],
   "🇷🇸": [
     "flag_serbia",
@@ -11721,7 +17170,8 @@
     "nation",
     "country",
     "banner",
-    "serbia"
+    "serbia",
+    "serbian flag"
   ],
   "🇷🇺": [
     "flag_russia",
@@ -11731,7 +17181,12 @@
     "nation",
     "country",
     "banner",
-    "russia"
+    "russia",
+    "indicator",
+    "letters",
+    "regional",
+    "ru",
+    "symbol"
   ],
   "🇷🇼": [
     "flag_rwanda",
@@ -11740,7 +17195,8 @@
     "nation",
     "country",
     "banner",
-    "rwanda"
+    "rwanda",
+    "rwandan"
   ],
   "🇸🇦": [
     "flag_saudi_arabia",
@@ -11748,7 +17204,8 @@
     "nation",
     "country",
     "banner",
-    "saudi_arabia"
+    "saudi_arabia",
+    "arabian flag"
   ],
   "🇸🇧": [
     "flag_solomon_islands",
@@ -11758,7 +17215,9 @@
     "nation",
     "country",
     "banner",
-    "solomon_islands"
+    "solomon_islands",
+    "island",
+    "islander flag"
   ],
   "🇸🇨": [
     "flag_seychelles",
@@ -11767,7 +17226,8 @@
     "nation",
     "country",
     "banner",
-    "seychelles"
+    "seychelles",
+    "seychellois flag"
   ],
   "🇸🇩": [
     "flag_sudan",
@@ -11776,7 +17236,8 @@
     "nation",
     "country",
     "banner",
-    "sudan"
+    "sudan",
+    "sudanese"
   ],
   "🇸🇪": [
     "flag_sweden",
@@ -11785,7 +17246,8 @@
     "nation",
     "country",
     "banner",
-    "sweden"
+    "sweden",
+    "swedish"
   ],
   "🇸🇬": [
     "flag_singapore",
@@ -11794,7 +17256,8 @@
     "nation",
     "country",
     "banner",
-    "singapore"
+    "singapore",
+    "singaporean"
   ],
   "🇸🇭": [
     "flag_st_helena",
@@ -11807,7 +17270,8 @@
     "nation",
     "country",
     "banner",
-    "st_helena"
+    "st_helena",
+    "st."
   ],
   "🇸🇮": [
     "flag_slovenia",
@@ -11816,7 +17280,8 @@
     "nation",
     "country",
     "banner",
-    "slovenia"
+    "slovenia",
+    "slovenian"
   ],
   "🇸🇯": [
     "flag_svalbard_jan_mayen"
@@ -11828,7 +17293,9 @@
     "nation",
     "country",
     "banner",
-    "slovakia"
+    "slovakia",
+    "slovakian",
+    "slovak flag"
   ],
   "🇸🇱": [
     "flag_sierra_leone",
@@ -11838,7 +17305,8 @@
     "nation",
     "country",
     "banner",
-    "sierra_leone"
+    "sierra_leone",
+    "leonean"
   ],
   "🇸🇲": [
     "flag_san_marino",
@@ -11848,7 +17316,8 @@
     "nation",
     "country",
     "banner",
-    "san_marino"
+    "san_marino",
+    "sammarinese"
   ],
   "🇸🇳": [
     "flag_senegal",
@@ -11857,7 +17326,8 @@
     "nation",
     "country",
     "banner",
-    "senegal"
+    "senegal",
+    "sengalese"
   ],
   "🇸🇴": [
     "flag_somalia",
@@ -11866,7 +17336,8 @@
     "nation",
     "country",
     "banner",
-    "somalia"
+    "somalia",
+    "somalian flag"
   ],
   "🇸🇷": [
     "flag_suriname",
@@ -11875,7 +17346,8 @@
     "nation",
     "country",
     "banner",
-    "suriname"
+    "suriname",
+    "surinamer"
   ],
   "🇸🇸": [
     "flag_south_sudan",
@@ -11885,7 +17357,8 @@
     "nation",
     "country",
     "banner",
-    "south_sudan"
+    "south_sudan",
+    "sudanese flag"
   ],
   "🇸🇹": [
     "flag_sao_tome_principe",
@@ -11896,7 +17369,10 @@
     "nation",
     "country",
     "banner",
-    "sao_tome_principe"
+    "sao_tome_principe",
+    "príncipe",
+    "são",
+    "tomé"
   ],
   "🇸🇻": [
     "flag_el_salvador",
@@ -11906,7 +17382,8 @@
     "nation",
     "country",
     "banner",
-    "el_salvador"
+    "el_salvador",
+    "salvadoran"
   ],
   "🇸🇽": [
     "flag_sint_maarten",
@@ -11937,7 +17414,8 @@
     "nation",
     "country",
     "banner",
-    "eswatini"
+    "eswatini",
+    "swaziland"
   ],
   "🇹🇦": [
     "flag_tristan_da_cunha"
@@ -11951,7 +17429,8 @@
     "nation",
     "country",
     "banner",
-    "turks_caicos_islands"
+    "turks_caicos_islands",
+    "island"
   ],
   "🇹🇩": [
     "flag_chad",
@@ -11960,7 +17439,8 @@
     "nation",
     "country",
     "banner",
-    "chad"
+    "chad",
+    "chadian"
   ],
   "🇹🇫": [
     "flag_french_southern_territories",
@@ -11971,7 +17451,9 @@
     "nation",
     "country",
     "banner",
-    "french_southern_territories"
+    "french_southern_territories",
+    "antarctic",
+    "lands"
   ],
   "🇹🇬": [
     "flag_togo",
@@ -11980,7 +17462,8 @@
     "nation",
     "country",
     "banner",
-    "togo"
+    "togo",
+    "togolese"
   ],
   "🇹🇭": [
     "flag_thailand",
@@ -11989,7 +17472,8 @@
     "nation",
     "country",
     "banner",
-    "thailand"
+    "thailand",
+    "thai"
   ],
   "🇹🇯": [
     "flag_tajikistan",
@@ -11998,7 +17482,8 @@
     "nation",
     "country",
     "banner",
-    "tajikistan"
+    "tajikistan",
+    "tajik"
   ],
   "🇹🇰": [
     "flag_tokelau",
@@ -12007,7 +17492,8 @@
     "nation",
     "country",
     "banner",
-    "tokelau"
+    "tokelau",
+    "tokelauan"
   ],
   "🇹🇱": [
     "flag_timor_leste",
@@ -12017,7 +17503,10 @@
     "nation",
     "country",
     "banner",
-    "timor_leste"
+    "timor_leste",
+    "east",
+    "leste flag",
+    "timorese"
   ],
   "🇹🇲": [
     "flag_turkmenistan",
@@ -12025,7 +17514,8 @@
     "nation",
     "country",
     "banner",
-    "turkmenistan"
+    "turkmenistan",
+    "turkmen"
   ],
   "🇹🇳": [
     "flag_tunisia",
@@ -12034,7 +17524,8 @@
     "nation",
     "country",
     "banner",
-    "tunisia"
+    "tunisia",
+    "tunisian"
   ],
   "🇹🇴": [
     "flag_tonga",
@@ -12043,7 +17534,8 @@
     "nation",
     "country",
     "banner",
-    "tonga"
+    "tonga",
+    "tongan flag"
   ],
   "🇹🇷": [
     "flag_turkey",
@@ -12051,7 +17543,10 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "tr",
+    "turkish flag",
+    "türkiye"
   ],
   "🇹🇹": [
     "flag_trinidad_tobago",
@@ -12069,7 +17564,8 @@
     "nation",
     "country",
     "banner",
-    "tuvalu"
+    "tuvalu",
+    "tuvaluan"
   ],
   "🇹🇼": [
     "flag_taiwan",
@@ -12078,7 +17574,9 @@
     "nation",
     "country",
     "banner",
-    "taiwan"
+    "taiwan",
+    "china",
+    "taiwanese"
   ],
   "🇹🇿": [
     "flag_tanzania",
@@ -12088,7 +17586,8 @@
     "flag",
     "nation",
     "country",
-    "banner"
+    "banner",
+    "tanzanian"
   ],
   "🇺🇦": [
     "flag_ukraine",
@@ -12097,7 +17596,8 @@
     "nation",
     "country",
     "banner",
-    "ukraine"
+    "ukraine",
+    "ukrainian"
   ],
   "🇺🇬": [
     "flag_uganda",
@@ -12106,10 +17606,13 @@
     "nation",
     "country",
     "banner",
-    "uganda"
+    "uganda",
+    "ugandan flag"
   ],
   "🇺🇲": [
-    "flag_u_s_outlying_islands"
+    "flag_u_s_outlying_islands",
+    "u.s.",
+    "us"
   ],
   "🇺🇳": [
     "flag_united_nations",
@@ -12126,7 +17629,16 @@
     "nation",
     "country",
     "banner",
-    "united_states"
+    "united_states",
+    "american",
+    "indicator",
+    "islands",
+    "letters",
+    "outlying",
+    "regional",
+    "symbol",
+    "us",
+    "usa"
   ],
   "🇺🇾": [
     "flag_uruguay",
@@ -12135,7 +17647,8 @@
     "nation",
     "country",
     "banner",
-    "uruguay"
+    "uruguay",
+    "uruguayan"
   ],
   "🇺🇿": [
     "flag_uzbekistan",
@@ -12144,7 +17657,9 @@
     "nation",
     "country",
     "banner",
-    "uzbekistan"
+    "uzbekistan",
+    "uzbek",
+    "uzbekistani"
   ],
   "🇻🇦": [
     "flag_vatican_city",
@@ -12154,7 +17669,8 @@
     "nation",
     "country",
     "banner",
-    "vatican_city"
+    "vatican_city",
+    "vanticanien"
   ],
   "🇻🇨": [
     "flag_st_vincent_grenadines",
@@ -12165,7 +17681,8 @@
     "nation",
     "country",
     "banner",
-    "st_vincent_grenadines"
+    "st_vincent_grenadines",
+    "st."
   ],
   "🇻🇪": [
     "flag_venezuela",
@@ -12176,7 +17693,8 @@
     "nation",
     "country",
     "banner",
-    "venezuela"
+    "venezuela",
+    "venezuelan"
   ],
   "🇻🇬": [
     "flag_british_virgin_islands",
@@ -12188,7 +17706,9 @@
     "nation",
     "country",
     "banner",
-    "british_virgin_islands"
+    "british_virgin_islands",
+    "island",
+    "islander"
   ],
   "🇻🇮": [
     "flag_u_s_virgin_islands",
@@ -12199,7 +17719,14 @@
     "nation",
     "country",
     "banner",
-    "u_s_virgin_islands"
+    "u_s_virgin_islands",
+    "america",
+    "island",
+    "islander",
+    "states",
+    "u.s.",
+    "united",
+    "usa"
   ],
   "🇻🇳": [
     "flag_vietnam",
@@ -12209,7 +17736,8 @@
     "nation",
     "country",
     "banner",
-    "vietnam"
+    "vietnam",
+    "vietnamese"
   ],
   "🇻🇺": [
     "flag_vanuatu",
@@ -12218,7 +17746,9 @@
     "nation",
     "country",
     "banner",
-    "vanuatu"
+    "vanuatu",
+    "ni",
+    "vanuatu flag"
   ],
   "🇼🇫": [
     "flag_wallis_futuna",
@@ -12237,7 +17767,8 @@
     "nation",
     "country",
     "banner",
-    "samoa"
+    "samoa",
+    "samoan flag"
   ],
   "🇽🇰": [
     "flag_kosovo",
@@ -12246,7 +17777,8 @@
     "nation",
     "country",
     "banner",
-    "kosovo"
+    "kosovo",
+    "kosovar"
   ],
   "🇾🇪": [
     "flag_yemen",
@@ -12255,7 +17787,8 @@
     "nation",
     "country",
     "banner",
-    "yemen"
+    "yemen",
+    "yemeni flag"
   ],
   "🇾🇹": [
     "flag_mayotte",
@@ -12274,7 +17807,8 @@
     "nation",
     "country",
     "banner",
-    "south_africa"
+    "south_africa",
+    "african flag"
   ],
   "🇿🇲": [
     "flag_zambia",
@@ -12283,7 +17817,8 @@
     "nation",
     "country",
     "banner",
-    "zambia"
+    "zambia",
+    "zambian"
   ],
   "🇿🇼": [
     "flag_zimbabwe",
@@ -12292,362 +17827,642 @@
     "nation",
     "country",
     "banner",
-    "zimbabwe"
+    "zimbabwe",
+    "zim",
+    "zimbabwean flag"
   ],
   "🏴󠁧󠁢󠁥󠁮󠁧󠁿": [
     "flag_england",
     "flag",
-    "english"
+    "english",
+    "cross",
+    "george's",
+    "st"
   ],
   "🏴󠁧󠁢󠁳󠁣󠁴󠁿": [
     "flag_scotland",
     "flag",
-    "scottish"
+    "scottish",
+    "andrew's",
+    "cross",
+    "saltire",
+    "st"
   ],
   "🏴󠁧󠁢󠁷󠁬󠁳󠁿": [
     "flag_wales",
     "flag",
-    "welsh"
+    "welsh",
+    "baner",
+    "cymru",
+    "ddraig",
+    "dragon",
+    "goch",
+    "red",
+    "y"
   ],
   "🥲": [
     "smiling face with tear",
     "sad",
     "cry",
-    "pretend"
+    "pretend",
+    "grateful",
+    "happy",
+    "proud",
+    "relieved",
+    "smile",
+    "touched"
   ],
   "🥸": [
     "disguised face",
     "pretent",
     "brows",
     "glasses",
-    "moustache"
+    "moustache",
+    "disguise",
+    "incognito",
+    "nose"
   ],
   "🤌": [
     "pinched fingers",
     "size",
     "tiny",
-    "small"
+    "small",
+    "che",
+    "finger",
+    "gesture",
+    "hand",
+    "interrogation",
+    "ma",
+    "purse",
+    "sarcastic",
+    "vuoi"
   ],
   "🫀": [
     "anatomical heart",
     "health",
-    "heartbeat"
+    "heartbeat",
+    "cardiology",
+    "organ",
+    "pulse"
   ],
   "🫁": [
     "lungs",
-    "breathe"
+    "breathe",
+    "breath",
+    "exhalation",
+    "inhalation",
+    "organ",
+    "respiration"
   ],
   "🥷": [
     "ninja",
     "ninjutsu",
     "skills",
-    "japanese"
+    "japanese",
+    "fighter",
+    "hidden",
+    "stealth"
   ],
   "🤵‍♂️": [
     "man in tuxedo",
     "formal",
-    "fashion"
+    "fashion",
+    "groom",
+    "male",
+    "men",
+    "person",
+    "suit",
+    "wedding"
   ],
   "🤵‍♀️": [
     "woman in tuxedo",
     "formal",
-    "fashion"
+    "fashion",
+    "female",
+    "wedding",
+    "women"
   ],
   "👰‍♂️": [
     "man with veil",
     "wedding",
-    "marriage"
+    "marriage",
+    "bride",
+    "male",
+    "men"
   ],
   "👰‍♀️": [
     "woman with veil",
     "wedding",
-    "marriage"
+    "marriage",
+    "bride",
+    "female",
+    "women"
   ],
   "👩‍🍼": [
     "woman feeding baby",
     "birth",
-    "food"
+    "food",
+    "bottle",
+    "child",
+    "female",
+    "infant",
+    "milk",
+    "nursing",
+    "women"
   ],
   "👨‍🍼": [
     "man feeding baby",
     "birth",
-    "food"
+    "food",
+    "bottle",
+    "child",
+    "infant",
+    "male",
+    "men",
+    "milk",
+    "nursing"
   ],
   "🧑‍🍼": [
     "person feeding baby",
     "birth",
-    "food"
+    "food",
+    "bottle",
+    "child",
+    "infant",
+    "milk",
+    "nursing"
   ],
   "🧑‍🎄": [
     "mx claus",
-    "christmas"
+    "christmas",
+    "activity",
+    "celebration",
+    "mx.",
+    "santa"
   ],
   "🫂": [
     "people hugging",
-    "care"
+    "care",
+    "goodbye",
+    "hello",
+    "hug",
+    "thanks"
   ],
   "🐈‍⬛": [
     "black cat",
     "superstition",
-    "luck"
+    "luck",
+    "halloween",
+    "pet",
+    "unlucky"
   ],
   "🦬": [
     "bison",
-    "ox"
+    "ox",
+    "buffalo",
+    "herd",
+    "wisent"
   ],
   "🦣": [
     "mammoth",
     "elephant",
-    "tusks"
+    "tusks",
+    "extinct",
+    "extinction",
+    "large",
+    "tusk",
+    "woolly"
   ],
   "🦫": [
     "beaver",
     "animal",
-    "rodent"
+    "rodent",
+    "dam"
   ],
   "🐻‍❄️": [
     "polar bear",
     "animal",
-    "arctic"
+    "arctic",
+    "face",
+    "white"
   ],
   "🦤": [
     "dodo",
     "animal",
-    "bird"
+    "bird",
+    "extinct",
+    "extinction",
+    "large",
+    "mauritius",
+    "obsolete"
   ],
   "🪶": [
     "feather",
     "bird",
-    "fly"
+    "fly",
+    "flight",
+    "light",
+    "plumage"
   ],
   "🦭": [
     "seal",
     "animal",
     "creature",
-    "sea"
+    "sea",
+    "lion"
   ],
   "🪲": [
     "beetle",
-    "insect"
+    "insect",
+    "bug"
   ],
   "🪳": [
     "cockroach",
     "insect",
-    "pests"
+    "pests",
+    "pest",
+    "roach"
   ],
   "🪰": [
     "fly",
-    "insect"
+    "insect",
+    "disease",
+    "maggot",
+    "pest",
+    "rotting"
   ],
   "🪱": [
     "worm",
-    "animal"
+    "animal",
+    "annelid",
+    "earthworm",
+    "parasite"
   ],
   "🪴": [
     "potted plant",
     "greenery",
-    "house"
+    "house",
+    "boring",
+    "grow",
+    "houseplant",
+    "nurturing",
+    "useless"
   ],
   "🫐": [
     "blueberries",
-    "fruit"
+    "fruit",
+    "berry",
+    "bilberry",
+    "blue",
+    "blueberry"
   ],
   "🫒": [
     "olive",
-    "fruit"
+    "fruit",
+    "food",
+    "olives"
   ],
   "🫑": [
     "bell pepper",
     "fruit",
-    "plant"
+    "plant",
+    "capsicum",
+    "vegetable"
   ],
   "🫓": [
     "flatbread",
     "flour",
     "food",
-    "bakery"
+    "bakery",
+    "arepa",
+    "bread",
+    "flat",
+    "lavash",
+    "naan",
+    "pita"
   ],
   "🫔": [
     "tamale",
     "food",
-    "masa"
+    "masa",
+    "mexican",
+    "tamal",
+    "wrapped"
   ],
   "🫕": [
     "fondue",
     "cheese",
     "pot",
-    "food"
+    "food",
+    "chocolate",
+    "melted",
+    "swiss"
   ],
   "🫖": [
     "teapot",
     "drink",
-    "hot"
+    "hot",
+    "kettle",
+    "pot",
+    "tea"
   ],
   "🧋": [
     "bubble tea",
     "taiwan",
     "boba",
     "milk tea",
-    "straw"
+    "straw",
+    "momi",
+    "pearl",
+    "tapioca"
   ],
   "🪨": [
     "rock",
-    "stone"
+    "stone",
+    "boulder",
+    "construction",
+    "heavy",
+    "solid"
   ],
   "🪵": [
     "wood",
     "nature",
     "timber",
-    "trunk"
+    "trunk",
+    "construction",
+    "log",
+    "lumber"
   ],
   "🛖": [
     "hut",
     "house",
-    "structure"
+    "structure",
+    "roundhouse",
+    "yurt"
   ],
   "🛻": [
     "pickup truck",
     "car",
-    "transportation"
+    "transportation",
+    "vehicle"
   ],
   "🛼": [
     "roller skate",
     "footwear",
-    "sports"
+    "sports",
+    "derby",
+    "inline"
   ],
   "🪄": [
     "magic wand",
     "supernature",
-    "power"
+    "power",
+    "witch",
+    "wizard"
   ],
   "🪅": [
     "pinata",
     "mexico",
     "candy",
-    "celebration"
+    "celebration",
+    "party",
+    "piñata"
   ],
   "🪆": [
     "nesting dolls",
     "matryoshka",
-    "toy"
+    "toy",
+    "doll",
+    "russia",
+    "russian"
   ],
   "🪡": [
     "sewing needle",
-    "stitches"
+    "stitches",
+    "embroidery",
+    "sutures",
+    "tailoring"
   ],
   "🪢": [
     "knot",
     "rope",
-    "scout"
+    "scout",
+    "tangled",
+    "tie",
+    "twine",
+    "twist"
   ],
   "🩴": [
     "thong sandal",
     "footwear",
-    "summer"
+    "summer",
+    "beach",
+    "flip",
+    "flops",
+    "jandals",
+    "sandals",
+    "thongs",
+    "zōri"
   ],
   "🪖": [
     "military helmet",
     "army",
-    "protection"
+    "protection",
+    "soldier",
+    "warrior"
   ],
   "🪗": [
     "accordion",
-    "music"
+    "music",
+    "accordian",
+    "box",
+    "concertina",
+    "squeeze"
   ],
   "🪘": [
     "long drum",
-    "music"
+    "music",
+    "beat",
+    "conga",
+    "djembe",
+    "rhythm"
   ],
   "🪙": [
     "coin",
     "money",
-    "currency"
+    "currency",
+    "gold",
+    "metal",
+    "silver",
+    "treasure"
   ],
   "🪃": [
     "boomerang",
-    "weapon"
+    "weapon",
+    "australia",
+    "rebound",
+    "repercussion"
   ],
   "🪚": [
     "carpentry saw",
     "cut",
-    "chop"
+    "chop",
+    "carpenter",
+    "hand",
+    "lumber",
+    "tool"
   ],
   "🪛": [
     "screwdriver",
-    "tools"
+    "tools",
+    "screw",
+    "tool"
   ],
   "🪝": [
     "hook",
-    "tools"
+    "tools",
+    "catch",
+    "crook",
+    "curve",
+    "ensnare",
+    "fishing",
+    "point",
+    "selling",
+    "tool"
   ],
   "🪜": [
     "ladder",
-    "tools"
+    "tools",
+    "climb",
+    "rung",
+    "step",
+    "tool"
   ],
   "🛗": [
     "elevator",
-    "lift"
+    "lift",
+    "accessibility",
+    "hoist"
   ],
   "🪞": [
     "mirror",
-    "reflection"
+    "reflection",
+    "reflector",
+    "speculum"
   ],
   "🪟": [
     "window",
-    "scenery"
+    "scenery",
+    "air",
+    "frame",
+    "fresh",
+    "glass",
+    "opening",
+    "transparent",
+    "view"
   ],
   "🪠": [
     "plunger",
-    "toilet"
+    "toilet",
+    "cup",
+    "force",
+    "plumber",
+    "suction"
   ],
   "🪤": [
     "mouse trap",
-    "cheese"
+    "cheese",
+    "bait",
+    "mousetrap",
+    "rodent",
+    "snare"
   ],
   "🪣": [
     "bucket",
     "water",
-    "container"
+    "container",
+    "cask",
+    "pail",
+    "vat"
   ],
   "🪥": [
     "toothbrush",
     "hygiene",
-    "dental"
+    "dental",
+    "bathroom",
+    "brush",
+    "clean",
+    "teeth"
   ],
   "🪦": [
     "headstone",
     "death",
     "rip",
-    "grave"
+    "grave",
+    "cemetery",
+    "graveyard",
+    "halloween",
+    "tombstone"
   ],
   "🪧": [
     "placard",
-    "announcement"
+    "announcement",
+    "demonstration",
+    "lawn",
+    "picket",
+    "post",
+    "protest",
+    "sign"
   ],
   "⚧️": [
     "transgender symbol",
     "transgender",
-    "lgbtq"
+    "lgbtq",
+    "female",
+    "lgbt",
+    "male",
+    "pride",
+    "sign",
+    "stroke"
   ],
   "🏳️‍⚧️": [
     "transgender flag",
     "transgender",
     "flag",
     "pride",
-    "lgbtq"
+    "lgbtq",
+    "blue",
+    "lgbt",
+    "light",
+    "pink",
+    "trans",
+    "white"
   ],
   "😶‍🌫️": [
     "face in clouds",
     "shower",
     "steam",
-    "dream"
+    "dream",
+    "absentminded",
+    "brain",
+    "fog",
+    "forgetful",
+    "haze",
+    "head",
+    "impractical",
+    "unrealistic"
   ],
   "😮‍💨": [
     "face exhaling",
     "relieve",
     "relief",
     "tired",
-    "sigh"
+    "sigh",
+    "exhale",
+    "gasp",
+    "groan",
+    "whisper",
+    "whistle"
   ],
   "😵‍💫": [
     "face with spiral eyes",
@@ -12655,103 +18470,170 @@
     "ill",
     "confused",
     "nauseous",
-    "nausea"
+    "nausea",
+    "dizzy",
+    "hypnotized",
+    "trouble",
+    "whoa"
   ],
   "❤️‍🔥": [
     "heart on fire",
     "passionate",
-    "enthusiastic"
+    "enthusiastic",
+    "burn",
+    "love",
+    "lust",
+    "sacred"
   ],
   "❤️‍🩹": [
     "mending heart",
     "broken heart",
     "bandage",
-    "wounded"
+    "wounded",
+    "bandaged",
+    "healing",
+    "healthier",
+    "improving",
+    "recovering",
+    "recuperating",
+    "unbroken",
+    "well"
   ],
   "🧔‍♂️": [
     "man beard",
-    "facial hair"
+    "facial hair",
+    "bearded",
+    "bewhiskered",
+    "male",
+    "men"
   ],
   "🧔‍♀️": [
     "woman beard",
-    "facial hair"
+    "facial hair",
+    "bearded",
+    "bewhiskered",
+    "female",
+    "women"
   ],
   "🫠": [
     "melting face",
     "hot",
-    "heat"
+    "heat",
+    "disappear",
+    "dissolve",
+    "dread",
+    "liquid",
+    "melt",
+    "sarcasm"
   ],
   "🫢": [
     "face with open eyes and hand over mouth",
     "silence",
     "secret",
     "shock",
-    "surprise"
+    "surprise",
+    "amazement",
+    "awe",
+    "disbelief",
+    "embarrass",
+    "gasp",
+    "scared"
   ],
   "🫣": [
     "face with peeking eye",
     "scared",
     "frightening",
     "embarrassing",
-    "shy"
+    "shy",
+    "captivated",
+    "peep",
+    "stare"
   ],
   "🫡": [
     "saluting face",
     "respect",
-    "salute"
+    "salute",
+    "ok",
+    "sunny",
+    "troops",
+    "yes"
   ],
   "🫥": [
     "dotted line face",
     "invisible",
     "lonely",
     "isolation",
-    "depression"
+    "depression",
+    "depressed",
+    "disappear",
+    "hide",
+    "introvert"
   ],
   "🫤": [
     "face with diagonal mouth",
     "skeptic",
     "confuse",
     "frustrated",
-    "indifferent"
+    "indifferent",
+    "confused",
+    "disappointed",
+    "meh",
+    "skeptical",
+    "unsure"
   ],
   "🥹": [
     "face holding back tears",
     "touched",
     "gratitude",
-    "cry"
+    "cry",
+    "angry",
+    "proud",
+    "resist",
+    "sad"
   ],
   "🫱": [
     "rightwards hand",
     "palm",
-    "offer"
+    "offer",
+    "right",
+    "rightward"
   ],
   "🫲": [
     "leftwards hand",
     "palm",
-    "offer"
+    "offer",
+    "left",
+    "leftward"
   ],
   "🫳": [
     "palm down hand",
     "palm",
-    "drop"
+    "drop",
+    "dismiss",
+    "shoo"
   ],
   "🫴": [
     "palm up hand",
     "lift",
     "offer",
-    "demand"
+    "demand",
+    "beckon",
+    "catch",
+    "come"
   ],
   "🫰": [
     "hand with index finger and thumb crossed",
     "heart",
     "love",
     "money",
-    "expensive"
+    "expensive",
+    "snap"
   ],
   "🫵": [
     "index pointing at the viewer",
     "you",
-    "recruit"
+    "recruit",
+    "point"
   ],
   "🫶": [
     "heart hands",
@@ -12764,27 +18646,43 @@
     "flirt",
     "sexy",
     "pain",
-    "worry"
+    "worry",
+    "anxious",
+    "fear",
+    "flirting",
+    "nervous",
+    "uncomfortable",
+    "worried"
   ],
   "🫅": [
     "person with crown",
     "royalty",
-    "power"
+    "power",
+    "monarch",
+    "noble",
+    "regal"
   ],
   "🫃": [
     "pregnant man",
     "baby",
-    "belly"
+    "belly",
+    "bloated",
+    "full"
   ],
   "🫄": [
     "pregnant person",
     "baby",
-    "belly"
+    "belly",
+    "bloated",
+    "full"
   ],
   "🧌": [
     "troll",
     "mystical",
-    "monster"
+    "monster",
+    "fairy",
+    "fantasy",
+    "tale"
   ],
   "🪸": [
     "coral",
@@ -12796,85 +18694,138 @@
     "lotus",
     "flower",
     "calm",
-    "meditation"
+    "meditation",
+    "buddhism",
+    "hinduism",
+    "india",
+    "purity",
+    "vietnam"
   ],
   "🪹": [
     "empty nest",
-    "bird"
+    "bird",
+    "nesting"
   ],
   "🪺": [
     "nest with eggs",
-    "bird"
+    "bird",
+    "nesting"
   ],
   "🫘": [
     "beans",
-    "food"
+    "food",
+    "kidney",
+    "legume"
   ],
   "🫗": [
     "pouring liquid",
     "cup",
-    "water"
+    "water",
+    "drink",
+    "empty",
+    "glass",
+    "spill"
   ],
   "🫙": [
     "jar",
     "container",
-    "sauce"
+    "sauce",
+    "condiment",
+    "empty",
+    "store"
   ],
   "🛝": [
     "playground slide",
     "fun",
-    "park"
+    "park",
+    "amusement",
+    "play"
   ],
   "🛞": [
     "wheel",
     "car",
-    "transport"
+    "transport",
+    "circle",
+    "tire",
+    "turn"
   ],
   "🛟": [
     "ring buoy",
     "life saver",
-    "life preserver"
+    "life preserver",
+    "float",
+    "rescue",
+    "safety"
   ],
   "🪬": [
     "hamsa",
     "religion",
-    "protection"
+    "protection",
+    "amulet",
+    "fatima",
+    "hand",
+    "mary",
+    "miriam"
   ],
   "🪩": [
     "mirror ball",
     "disco",
     "dance",
-    "party"
+    "party",
+    "glitter"
   ],
   "🪫": [
     "low battery",
     "drained",
-    "dead"
+    "dead",
+    "electronic",
+    "energy",
+    "no",
+    "red"
   ],
   "🩼": [
     "crutch",
     "accessibility",
-    "assist"
+    "assist",
+    "aid",
+    "cane",
+    "disability",
+    "hurt",
+    "mobility",
+    "stick"
   ],
   "🩻": [
     "x-ray",
     "skeleton",
-    "medicine"
+    "medicine",
+    "bones",
+    "doctor",
+    "medical",
+    "ray",
+    "x"
   ],
   "🫧": [
     "bubbles",
     "soap",
     "fun",
     "carbonation",
-    "sparkling"
+    "sparkling",
+    "burp",
+    "clean",
+    "underwater"
   ],
   "🪪": [
     "identification card",
-    "document"
+    "document",
+    "credentials",
+    "id",
+    "license",
+    "security"
   ],
   "🟰": [
     "heavy equals sign",
-    "math"
+    "math",
+    "equality"
   ],
   "🫨": [
     "shaking face",
@@ -12926,7 +18877,8 @@
     "wing",
     "angel",
     "birds",
-    "flying"
+    "flying",
+    "fly"
   ],
   "🐦‍⬛": [
     "black bird",
@@ -12936,7 +18888,8 @@
     "goose",
     "silly",
     "jemima",
-    "goosebumps"
+    "goosebumps",
+    "honk"
   ],
   "🪼": [
     "jellyfish",
@@ -12963,7 +18916,8 @@
   "🪭": [
     "folding hand fan",
     "flamenco",
-    "hot"
+    "hot",
+    "sensu"
   ],
   "🪮": [
     "hair pick",
@@ -12974,14 +18928,16 @@
     "maracas",
     "music",
     "instrument",
-    "percussion"
+    "percussion",
+    "shaker"
   ],
   "🪈": [
     "flute",
     "bamboo",
     "music",
     "instrument",
-    "pied piper"
+    "pied piper",
+    "recorder"
   ],
   "🪯": [
     "khanda",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,22 @@
       "version": "3.0.11",
       "license": "MIT",
       "devDependencies": {
+        "change-case": "^5.4.3",
+        "emoji-platform-data": "^0.1.0",
         "prettier": "^1.18.2",
         "promptly": "^3.2.0",
         "tape": "^5.1.1",
         "unicode-emoji-json": "0.5.0",
         "xml2json": "^0.12.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/array-filter": {
@@ -69,11 +80,26 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "node_modules/deep-equal": {
       "version": "2.0.5",
@@ -127,6 +153,39 @@
       "bin": {
         "ignored": "bin/ignored"
       }
+    },
+    "node_modules/emoji-platform-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-platform-data/-/emoji-platform-data-0.1.0.tgz",
+      "integrity": "sha512-UxUQBoDundmCy0cuBhlH3zjGrJXq6w4086yFPSFkgwHgVzDlSE2MHgWMMy4gUOpr1+xpiDEBQhp13yjCxlY8RQ==",
+      "dev": true,
+      "dependencies": {
+        "emojipedia": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/emojipedia": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/emojipedia/-/emojipedia-0.3.0.tgz",
+      "integrity": "sha512-bQ6D92mcENmXiuZJrq0SMsHJzjrpXSZQYfQhYHf/qC1IBx1InourtVcnpapmpMaP9PcZQ09NCZW6DmYGbYTD4A==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^5.4.3",
+        "graphql-request": "^6.1.0",
+        "p-throttle": "^6.1.0",
+        "unicode-emoji-json": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/emojipedia/node_modules/unicode-emoji-json": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.4.0.tgz",
+      "integrity": "sha512-lVNOwh2AnmbwqtSrEVjAWKQoVzWgyWmXVqPuPkPfKb0tnA0+uYN/4ILCTdy9IRj/+3drAVhmjwjNJQr2dhCwnA==",
+      "dev": true
     },
     "node_modules/es-abstract": {
       "version": "1.17.7",
@@ -239,6 +298,29 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.2.tgz",
+      "integrity": "sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
       }
     },
     "node_modules/has": {
@@ -534,9 +616,30 @@
       "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.18.tgz",
       "integrity": "sha512-9dIrDxXePa9HSn+hhlAg1wXkvqOjxefEbMclGxk2cEnq/Y3U7Qo5HNNqeo3fQ4bVmLhcdt3YN1TZy7WMZy4MHw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.13.2"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-inspect": {
@@ -589,6 +692,18 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/p-throttle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.1.0.tgz",
+      "integrity": "sha512-eQMdGTxk2+047La67wefUtt0tEHh7D+C8Jl7QXoFCuIiNYeQ9zWs2AZiJdIAs72rSXZ06t11me2bgalRNdy3SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-is-absolute": {
@@ -797,11 +912,33 @@
       "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
       "dev": true
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "node_modules/unicode-emoji-json": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.5.0.tgz",
       "integrity": "sha512-MFNnM6XBt6K1gjHT/XG4dWoE4DzqzOdNt/433qG651eD1ce1bxNKHClttOL0dwlJfWKxTKYBfXoq5m36FS2WmA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
@@ -891,6 +1028,13 @@
     }
   },
   "dependencies": {
+    "@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "requires": {}
+    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
@@ -941,11 +1085,26 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "deep-equal": {
       "version": "2.0.5",
@@ -992,6 +1151,35 @@
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "emoji-platform-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-platform-data/-/emoji-platform-data-0.1.0.tgz",
+      "integrity": "sha512-UxUQBoDundmCy0cuBhlH3zjGrJXq6w4086yFPSFkgwHgVzDlSE2MHgWMMy4gUOpr1+xpiDEBQhp13yjCxlY8RQ==",
+      "dev": true,
+      "requires": {
+        "emojipedia": "^0.3.0"
+      }
+    },
+    "emojipedia": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/emojipedia/-/emojipedia-0.3.0.tgz",
+      "integrity": "sha512-bQ6D92mcENmXiuZJrq0SMsHJzjrpXSZQYfQhYHf/qC1IBx1InourtVcnpapmpMaP9PcZQ09NCZW6DmYGbYTD4A==",
+      "dev": true,
+      "requires": {
+        "change-case": "^5.4.3",
+        "graphql-request": "^6.1.0",
+        "p-throttle": "^6.1.0",
+        "unicode-emoji-json": "^0.4.0"
+      },
+      "dependencies": {
+        "unicode-emoji-json": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.4.0.tgz",
+          "integrity": "sha512-lVNOwh2AnmbwqtSrEVjAWKQoVzWgyWmXVqPuPkPfKb0tnA0+uYN/4ILCTdy9IRj/+3drAVhmjwjNJQr2dhCwnA==",
+          "dev": true
+        }
       }
     },
     "es-abstract": {
@@ -1096,6 +1284,23 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graphql": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.2.tgz",
+      "integrity": "sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg==",
+      "dev": true,
+      "peer": true
+    },
+    "graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
       }
     },
     "has": {
@@ -1346,6 +1551,15 @@
         "nan": "^2.13.2"
       }
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
@@ -1388,6 +1602,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "p-throttle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.1.0.tgz",
+      "integrity": "sha512-eQMdGTxk2+047La67wefUtt0tEHh7D+C8Jl7QXoFCuIiNYeQ9zWs2AZiJdIAs72rSXZ06t11me2bgalRNdy3SQ==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1572,11 +1792,33 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "unicode-emoji-json": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.5.0.tgz",
       "integrity": "sha512-MFNnM6XBt6K1gjHT/XG4dWoE4DzqzOdNt/433qG651eD1ce1bxNKHClttOL0dwlJfWKxTKYBfXoq5m36FS2WmA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which-boxed-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dist"
   ],
   "scripts": {
+    "augment": "node scripts/augment.js",
     "test": "node scripts/test.js",
     "upgrade": "node scripts/upgrade.js",
     "i18n": "node scripts/i18n.js",
@@ -29,6 +30,8 @@
   },
   "homepage": "https://github.com/muan/emojilib#readme",
   "devDependencies": {
+    "change-case": "^5.4.3",
+    "emoji-platform-data": "^0.1.0",
     "prettier": "^1.18.2",
     "promptly": "^3.2.0",
     "tape": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "augment": "node scripts/augment.js",
+    "augment-en": "node scripts/augment-en.js",
     "test": "node scripts/test.js",
     "upgrade": "node scripts/upgrade.js",
     "i18n": "node scripts/i18n.js",

--- a/scripts/augment-en.js
+++ b/scripts/augment-en.js
@@ -1,15 +1,9 @@
 const fs = require('fs')
-const lang = process.argv[2]
-if (!lang) {
-  const files = fs.readdirSync('dist')
-  const langs = files.map(tag => tag.match(/-(.+)\./)[1])
-  console.log(`Please provide a language tag: ${langs.join(', ')}`)
-} else {
-  start()
-}
+  
+start()
 
 async function start() {
-  const path = `dist/emoji-${lang}.json`
+  const path = `dist/emoji-en-US.json`
   const allEmojiData = require(`../${path}`)
   const missing = await generateAugmentations(allEmojiData)
   let addedCounts = {}

--- a/scripts/augment.js
+++ b/scripts/augment.js
@@ -1,0 +1,198 @@
+const fs = require('fs')
+const lang = process.argv[2]
+if (!lang) {
+  const files = fs.readdirSync('dist')
+  const langs = files.map(tag => tag.match(/-(.+)\./)[1])
+  console.log(`Please provide a language tag: ${langs.join(', ')}`)
+} else {
+  start()
+}
+
+async function start() {
+  const path = `dist/emoji-${lang}.json`
+  const allEmojiData = require(`../${path}`)
+  const missing = await generateAugmentations(allEmojiData)
+  let addedCounts = {}
+
+  for (const emoji in allEmojiData) {
+    const existing = allEmojiData[emoji]
+    const existingLikeWords = existing.join('_').split(/[ _]/)
+    const existingLowerCase = existing.map(keyword => keyword.toLowerCase())
+    const missingKeywords = missing[emoji]?.filter(
+      keyword =>
+        /[A-z]/.test(keyword) &&
+        !keyword.includes('_') &&
+        !existingLikeWords.includes(keyword) &&
+        !existingLowerCase.includes(keyword)
+    )
+
+    if (missingKeywords?.length) {
+      allEmojiData[emoji] = [...existing, ...missingKeywords]
+      addedCounts[emoji] = missingKeywords.length
+    }
+  }
+
+  fs.writeFileSync(`./${path}`, JSON.stringify(allEmojiData, null, 2))
+  const addedTo = Object.keys(addedCounts).length
+  const addedTotal = Object.values(addedCounts).reduce((a, b) => a + b, 0)
+  console.log('Augmented', addedTo, 'emoji with a total of', addedTotal, 'keyword(s)')
+}
+
+async function generateAugmentations(existingData) {
+  const emojipedia = await import('emojipedia/data')
+  const {byTitle} = await import('emoji-platform-data')
+  const changeCase = await import('change-case')
+
+  const ignoredValues = new Set(['a', 'and', 'at', 'in', 'is', 'it', 'of', 'on', 'the', 'to', 'with'])
+
+  function toPartialKeywords(candidateKeywords, fullKeywords = candidateKeywords) {
+    return candidateKeywords
+      ? toUniqueSortedArray(
+          candidateKeywords
+            .flatMap(text => text.replaceAll(/[:,]/g, '').split(/[ _]/g))
+            .filter(keyword => !fullKeywords.includes(keyword))
+        )
+      : []
+  }
+
+  function toUniqueSortedArray(values) {
+    return Array.from(new Set(values))
+      .filter(value => !ignoredValues.has(value))
+      .sort()
+  }
+
+  function toNormalizedText(text = '') {
+    return text
+      .toLowerCase()
+      .replaceAll(/[ ,)(]/g, '_')
+      .replaceAll(':', '')
+      .replaceAll('-', '_')
+      .replaceAll(/__/g, '_')
+      .replaceAll(/^_/g, '')
+      .replaceAll(/_$/g, '')
+  }
+
+  function toNormalizedTitle(text) {
+    return changeCase.pascalCase(text).replaceAll(' ', '')
+  }
+
+  function generateFullIdentityKeywords(inEmojilib, platforms) {
+    const inEmojipedia = getKeywordsForEmojipediaEntry(platforms.emojipedia).map(toNormalizedText)
+    const inFluemoji = platforms.fluemoji && [platforms.fluemoji.cldr, platforms.fluemoji.tts].map(toNormalizedText)
+    const inGemoji = platforms.gemoji?.names
+    const inTwemoji = platforms.twemoji && [platforms.twemoji.description].map(toNormalizedText)
+    const inAny = [inFluemoji, inGemoji, inTwemoji, inEmojipedia]
+      .flat()
+      .map(text => text && toNormalizedText(text))
+      .filter(x => !!x)
+
+    return {
+      inAny,
+      inEmojilib,
+      inEmojipedia,
+      inFluemoji,
+      inGemoji,
+      inTwemoji
+    }
+  }
+
+  function generatePartialIdentityKeywords(keywordsEmojilib, fullIdentity) {
+    const inAny = toPartialKeywords(fullIdentity.inAny)
+    const inEmojilib = toPartialKeywords(keywordsEmojilib)
+    const inEmojipedia = toPartialKeywords(fullIdentity.inEmojipedia)
+    const inFluemoji = toPartialKeywords(fullIdentity.inFluemoji)
+    const inGemoji = toPartialKeywords(fullIdentity.inGemoji)
+    const inTwemoji = toPartialKeywords(fullIdentity.inTwemoji)
+
+    return {
+      inAny,
+      inEmojilib,
+      inEmojipedia,
+      inFluemoji,
+      inGemoji,
+      inTwemoji
+    }
+  }
+
+  function getKeywordsForEmojipediaEntry(entry) {
+    return [entry.appleName, entry.currentCldrName, entry.title, ...(entry.alsoKnownAs ?? [])].map(toNormalizedText)
+  }
+
+  function generateRelationKeywords(fullIdentity, partialIdentity, platforms) {
+    const partialIdentityKeywords = [...fullIdentity.inAny, ...partialIdentity.inAny]
+    const inFluemoji = toPartialKeywords(platforms.fluemoji?.keywords, partialIdentityKeywords)
+    const inGemoji = toPartialKeywords(
+      platforms.gemoji && [platforms.gemoji.description, ...platforms.gemoji.tags],
+      partialIdentityKeywords
+    )
+    const inTwemoji = toPartialKeywords(
+      platforms.twemoji && 'keywords' in platforms.twemoji ? platforms.twemoji.keywords : undefined,
+      partialIdentityKeywords
+    )
+
+    const inAny = toUniqueSortedArray([...inFluemoji, ...inGemoji, ...inTwemoji])
+
+    return {inAny, inFluemoji, inGemoji, inTwemoji}
+  }
+
+  function generateAllEmojiKeywords(emojis) {
+    return emojis.map(emoji => {
+      const keywordsEmojilib =
+        existingData[emoji.code] ??
+        Object.values(existingData).find(
+          keywords =>
+            Array.isArray(keywords) && keywords[0].replaceAll(/[\W_]/g, '') === emoji.slug.replaceAll(/[\W_]/g, '')
+        )
+
+      const platforms =
+        (emoji.currentCldrName && byTitle[toNormalizedTitle(emoji.currentCldrName)]) ??
+        byTitle[toNormalizedTitle(emoji.title)] ??
+        Object.values(byTitle).find(platformData => platformData.emojipedia?.title === emoji.title)
+
+      const fullIdentity = generateFullIdentityKeywords(keywordsEmojilib, platforms)
+      const partialIdentity = generatePartialIdentityKeywords(keywordsEmojilib, fullIdentity)
+      const relationIdentity = generateRelationKeywords(fullIdentity, partialIdentity, platforms)
+
+      return {
+        emoji,
+        fullIdentity,
+        partialIdentity,
+        relationIdentity
+      }
+    })
+  }
+
+  function generateMissingKeywords(allKeywords) {
+    return allKeywords.map(keywords => {
+      const existing = keywords.fullIdentity.inEmojilib
+
+      const proposed = toUniqueSortedArray(
+        [
+          keywords.fullIdentity.inEmojipedia,
+          keywords.fullIdentity.inFluemoji,
+          keywords.fullIdentity.inGemoji,
+          keywords.fullIdentity.inTwemoji,
+          keywords.partialIdentity.inEmojipedia,
+          keywords.partialIdentity.inFluemoji,
+          keywords.partialIdentity.inGemoji,
+          keywords.partialIdentity.inTwemoji,
+          keywords.relationIdentity.inFluemoji,
+          keywords.relationIdentity.inGemoji,
+          keywords.relationIdentity.inTwemoji
+        ]
+          .flat()
+          .map(toNormalizedText)
+          .filter(Boolean)
+      )
+
+      const added = proposed.filter(keyword => !existing.includes(keyword))
+      return [keywords.emoji.code, added]
+    })
+  }
+
+  const emojis = Object.values(emojipedia)
+  const allEmojiKeywords = await generateAllEmojiKeywords(emojis)
+  const missingKeywords = await generateMissingKeywords(allEmojiKeywords)
+
+  return Object.fromEntries(missingKeywords)
+}


### PR DESCRIPTION
Does not fix #194, but somewhat sidesteps the issue by adding in a _lot_ of keywords.

This is mostly the same strategy as https://github.com/muan/emojilib/issues/194#issuecomment-2009621140. `scripts/augment-en.js` pulls in all keywords and names from the Emojipedia/Unicode, GitHub, Fluent UI, and Twitter platforms via [`emoji-platform-data`](https://github.com/JoshuaKGoldberg/emoji-platform-data). It filters out duplicate and unnecessary keywords, then pushes any new ones to `dist/emoji-*.json`.

Note that this PR adds a couple more filters, to keep the change a little smaller:

* Keywords that already appear in the emoji's title (e.g. `"health"` as a part of `"health_worker"`)
* Keywords that include `_` (e.g. `"big_grin"` in 😆)
* Keywords that don't have any letters (e.g. `"><"` in 😆)

In total, this augments 1728 emoji with a total of 5956 keywords. 

~Leaving this in draft for now as I haven't gotten approval for this strategy 😄~ un-drafted, with the same note. I won't be upset at all if it's just blanket denied. But it was a ton of fun to get to this PR! 