### PR TITLE
removed trailing commas in emoji-en-US.json

### DIFF
--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -1233,7 +1233,7 @@
     "fantasy",
     "monster",
     "tale",
-    "external",
+    "external"
   ],
   "👾": [
     "alien_monster",
@@ -13940,7 +13940,7 @@
     "logo",
     "recycle",
     "universal",
-    "reuse",
+    "reuse"
   ],
   "⚜️": [
     "fleur_de_lis",


### PR DESCRIPTION
JSON specification does not allow a trailing comma
this causes errors when parsing JSON with tools like jq
This small commit fixes the parsing errors