### PR TITLE
remove foot aliases on unrelated emojis

### DIFF
--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -523,15 +523,9 @@
     "face",
     "grimace",
     "teeth",
-    "#1 best",
     "awkward",
     "eek",
-    "foot",
-    "friend",
-    "mouth",
-    "mutual",
-    "nervous",
-    "snapchat"
+    "nervous"
   ],
   "🤥": [
     "lying_face",
@@ -3545,7 +3539,6 @@
     "guard",
     "protect",
     "british",
-    "foot",
     "guardsman"
   ],
   "💂‍♂️": [


### PR DESCRIPTION
Not sure why 😬 or 💂 need "foot" as an alias