### PR TITLE
Move "shrek" keyword from moose to troll and ogre

### DIFF
--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -1185,7 +1185,8 @@
     "fairy",
     "fantasy",
     "oni",
-    "tale"
+    "tale",
+    "shrek"
   ],
   "👺": [
     "goblin",
@@ -18742,7 +18743,8 @@
     "monster",
     "fairy",
     "fantasy",
-    "tale"
+    "tale",
+    "shrek"
   ],
   "🪸": [
     "coral",
@@ -18922,7 +18924,6 @@
   ],
   "🫎": [
     "moose",
-    "shrek",
     "canada",
     "sweden",
     "sven",


### PR DESCRIPTION
The troll is probably what people are looking for most often, because it is green like shrek. Ogre also seems reasonable, as shrek is an ogre. Moose does not. Shrek is not a moose and there are no moose in the shrek movies.