### PR TITLE
Add 'masked' variants to villain entries

### DIFF
--- a/dist/emoji-en-US.json
+++ b/dist/emoji-en-US.json
@@ -3800,7 +3800,8 @@
     "fantasy",
     "superpower",
     "superpowers",
-    "villain"
+    "villain",
+    "masked"
   ],
   "🦹‍♂️": [
     "man_supervillain",
@@ -3814,7 +3815,8 @@
     "fantasy",
     "men",
     "superpower",
-    "villain"
+    "villain",
+    "man_masked"
   ],
   "🦹‍♀️": [
     "woman_supervillain",
@@ -3828,7 +3830,8 @@
     "fantasy",
     "superpower",
     "villain",
-    "women"
+    "women",
+    "woman_masked"
   ],
   "🧙": [
     "mage",


### PR DESCRIPTION
Current `mask` query returns some results, but not people who wear a mask to conceal themselves. In the lack of robber/thief emoji, this could do.
https://emoji.muan.co/#mask